### PR TITLE
Enable CodeQL runs on all pushed branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,7 +14,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]


### PR DESCRIPTION
Enable CodeQL on pushed branches so pull request authors have a chance to address flagged issues prior to creating their pull request.