### PR TITLE
Port Notebook PRs 5565 and 5588 - terminal shell heuristics

### DIFF
--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -22,8 +22,13 @@ def initialize(webapp, root_dir, connection_url, settings):
     shell = settings.get('shell_command',
         [os.environ.get('SHELL') or default_shell]
     )
-    # Enable login mode - to automatically source the /etc/profile script
-    if os.name != 'nt':
+    # Enable login mode - to automatically source the /etc/profile
+    # script, but only for non-nested shells; for nested shells, it's
+    # superfluous and may even be harmful (e.g. on macOS, where login
+    # shells invoke /usr/libexec/path_helper to add entries from
+    # /etc/paths{,.d} to the PATH, reordering it in the process and
+    # potentially overriding virtualenvs and other PATH modifications)
+    if os.name != 'nt' and int(os.environ.get("SHLVL", 0)) < 1:
         shell.append('-l')
     terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(
         shell_command=shell,

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import terminado
 from ..utils import check_version
@@ -19,16 +20,18 @@ def initialize(webapp, root_dir, connection_url, settings):
         default_shell = 'powershell.exe'
     else:
         default_shell = which('sh')
-    shell = settings.get('shell_command',
+    shell_override = settings.get('shell_command')
+    shell = (
         [os.environ.get('SHELL') or default_shell]
+        if shell_override is None
+        else shell_override
     )
-    # Enable login mode - to automatically source the /etc/profile
-    # script, but only for non-nested shells; for nested shells, it's
-    # superfluous and may even be harmful (e.g. on macOS, where login
-    # shells invoke /usr/libexec/path_helper to add entries from
-    # /etc/paths{,.d} to the PATH, reordering it in the process and
-    # potentially overriding virtualenvs and other PATH modifications)
-    if os.name != 'nt' and int(os.environ.get("SHLVL", 0)) < 1:
+    # When the notebook server is not running in a terminal (e.g. when
+    # it's launched by a JupyterHub spawner), it's likely that the user
+    # environment hasn't been fully set up. In that case, run a login
+    # shell to automatically source /etc/profile and the like, unless
+    # the user has specifically set a preferred shell command.
+    if os.name != 'nt' and shell_override is None and not sys.stdout.isatty():
         shell.append('-l')
     terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(
         shell_command=shell,


### PR DESCRIPTION
This PR brings the commits associated with Notebook PRs https://github.com/jupyter/notebook/pull/5565 and https://github.com/jupyter/notebook/pull/5588.  Originally, we just recorded the need to port 5565, but 5588 was the final outcome.

We can then look at addressing #342 following this update.