### PR TITLE
Allow toggling auth for prometheus metrics

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -842,10 +842,12 @@ class RedirectWithParams(web.RequestHandler):
 
 class PrometheusMetricsHandler(JupyterHandler):
     """
-    Return prometheus metrics for this Jupyter server
+    Return prometheus metrics for this notebook server
     """
-    @web.authenticated
     def get(self):
+        if self.settings['authenticate_prometheus'] and not self.logged_in:
+            raise web.HTTPError(403)
+
         self.set_header('Content-Type', prometheus_client.CONTENT_TYPE_LATEST)
         self.write(prometheus_client.generate_latest(prometheus_client.REGISTRY))
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -246,6 +246,7 @@ class ServerWebApplication(web.Application):
             disable_check_xsrf=jupyter_app.disable_check_xsrf,
             allow_remote_access=jupyter_app.allow_remote_access,
             local_hostnames=jupyter_app.local_hostnames,
+            authenticate_prometheus=jupyter_app.authenticate_prometheus,
 
             # managers
             kernel_manager=kernel_manager,
@@ -1198,6 +1199,14 @@ class ServerApp(JupyterApp):
          Terminals may also be automatically disabled if the terminado package
          is not available.
          """))
+
+    authenticate_prometheus = Bool(
+        True,
+        help=""""
+        Require authentication to access prometheus metrics.
+        """,
+        config=True
+    )
 
     def parse_command_line(self, argv=None):
 


### PR DESCRIPTION
Equivalent to https://github.com/jupyterhub/jupyterhub/pull/2224.

Port of https://github.com/jupyter/notebook/pull/5870

Prometheus metrics can potentially leak information about
the user, so they should be kept behind auth by default.
However, for many JupyterHub deployments, they would need
to be scraped by a centralized Prometheus instance that can not
really authenticate separately to each user notebook without
a lot of work. Admins can use this setting to allow unauthenticated
access to the /metrics endpoint.