### PR TITLE
recursive-include to grab spec.yaml and favicons

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include CHANGELOG.md
 include setupbase.py
 
 # include everything in package_data
-include jupyter_server/**/*
+recursive-include jupyter_server *
 
 # Documentation
 graft docs
@@ -26,3 +26,5 @@ global-exclude *.pyc
 global-exclude *.pyo
 global-exclude .git
 global-exclude .ipynb_checkpoints
+global-exclude .pytest_cache
+global-exclude .coverage


### PR DESCRIPTION
This backports d925e670e0a904a8b75d2412056b951e924bc2c7 to pick up favicons and other files in the package distribution.