### PR TITLE
Fix upgrade packaging dependencies build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         architecture: 'x64'
     - name: Upgrade packaging dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools wheel --user
     - name: Get pip cache dir
       id: pip-cache
       run: |


### PR DESCRIPTION
The "Upgrade Packaging Dependencies" step in `workflows/main.yml` failed  due to 
```
ERROR: Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pip-uninstall-z_gzya01\\pip.exe'
Consider using the `--user` option or check the permissions.
```
The fix is to include the `--user` option. 