### PR TITLE
Fix: await possible async dir_exists method

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -180,7 +180,7 @@ class ContentsHandler(APIHandler):
         if file_exists:
             raise web.HTTPError(400, "Cannot POST to files, use PUT instead.")
 
-        dir_exists = cm.dir_exists(path)
+        dir_exists = await ensure_async(cm.dir_exists(path))
         if not dir_exists:
             raise web.HTTPError(404, "No such directory: %s" % path)
 


### PR DESCRIPTION
When a custom contents manager is a sub class of `AsyncContentsManager`, and the `dir_exists` method is asynchronous, `dir_exists` is never await during file creation in the specified path. 

**Steps to reproduce error**
1. Run the server with a custom async contents manager that has an asynchronous `dir_exists` method. 
2. Create a notebook

```
RuntimeWarning: coroutine 'AsyncCustomContentsManager.dir_exists' was never awaited
```

