### PR TITLE
use setuptools find_packages, exclude tests, docs and examples from dist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import pathlib
-from setuptools import setup
+from setuptools import (
+    find_packages,
+    setup,
+)
 from setupbase import (
-    get_version, find_packages
+    get_version,
 )
 
 here = pathlib.Path('.')
@@ -17,7 +20,7 @@ setup_args = dict(
     long_description = README,
     long_description_content_type='text/markdown',
     version          = VERSION,
-    packages         = find_packages('.'),
+    packages         = find_packages('.', exclude=['tests*', 'docs*', 'examples*']),
     include_package_data = True,
     author           = 'Jupyter Development Team',
     author_email     = 'jupyter@googlegroups.com',

--- a/setupbase.py
+++ b/setupbase.py
@@ -95,19 +95,6 @@ def ensure_python(specs):
     raise ValueError('Python version %s unsupported' % part)
 
 
-def find_packages(top):
-    """
-    Find all of the packages.
-    """
-    import warnings
-    warnings.warn(
-        'Deprecated, please use setuptools.find_packages',
-        category=DeprecationWarning
-    )
-    from setuptools import find_packages as fp
-    return fp(top)
-
-
 def update_package_data(distribution):
     """update build_py options to get package_data changes"""
     build_py = distribution.get_command_obj('build_py')


### PR DESCRIPTION
This:
- removes the confusing, deprecated `find_packages` from `setupbase.py`
- imports and uses the _real_ `setuptools.find_packages` to `exclude` things that _might_ be python-module-like

In `site-packages/`, `tests/`, `docs/`, etc. are dumping grounds of all the packages that either _don't_ use this flag. In this state, it's not even worth distributing them, as there's basically zero chance they'll work. Putting them in-tree, on the other hand, is very nice, as downstreams can ensure that their packages work, which helps catch issues sooner, but that's for another day...