### PR TITLE
Update the link to paths documentation

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -400,7 +400,7 @@ Putting it all together, authors can distribute their extension following this s
 
 .. links
 
-.. _`Jupyter's paths`: https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html
+.. _`Jupyter's paths`: https://jupyter.readthedocs.io/en/latest/use/jupyter-directories.html
 
 
 Migrating an extension to use Jupyter Server


### PR DESCRIPTION
The old one: https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html appears dead, but: https://jupyter.readthedocs.io/en/latest/use/jupyter-directories.html works fine.