### PR TITLE
Update manager.py: more descriptive warnings when extensions fail to load

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -306,7 +306,7 @@ class ExtensionManager(LoggingConfigurable):
                 extension.load_all_points(serverapp)
                 self.log.info("{name} | extension was successfully loaded.".format(name=name))
             except Exception as e:
-                self.log.warning(e)
+                self.log.warning("{name} | extension failed loading with message: {error}".format(name=name,error=str(e)))
 
     def link_all_extensions(self, serverapp):
         """Link all enabled extensions


### PR DESCRIPTION
Warning message are descriptive when an extension fails to load. To provide an example, before this tiny fix, I got the warning message when starting jupyter-lab:
```[W 2021-01-29 16:36:12.766 ServerApp] 'nbextensions_path'```
while now I would get:
```[W 2021-01-29 16:55:35.576 ServerApp] jupyter_nbextensions_configurator | extension failed loading with message: 'nbextensions_path'```
clarifying that it is `jupyter_nbextensions_configurator` not loading. With this better description, this warning is no more surprising because I know that this extension is for the classic notebook only.

