### PR TITLE
Use async kernel manager by default

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -9,7 +9,7 @@ from tornado import web
 from tornado.escape import json_encode, json_decode, url_escape
 from tornado.httpclient import HTTPClient, AsyncHTTPClient, HTTPError
 
-from ..services.kernels.kernelmanager import MappingKernelManager
+from ..services.kernels.kernelmanager import AsyncMappingKernelManager
 from ..services.sessions.sessionmanager import SessionManager
 
 from jupyter_client.kernelspec import KernelSpecManager
@@ -329,7 +329,7 @@ async def gateway_request(endpoint, **kwargs):
     return response
 
 
-class GatewayKernelManager(MappingKernelManager):
+class GatewayKernelManager(AsyncMappingKernelManager):
     """Kernel manager that supports remote kernels hosted by Jupyter Kernel or Enterprise Gateway."""
 
     # We'll maintain our own set of kernel ids

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1174,7 +1174,8 @@ class ServerApp(JupyterApp):
         self.root_dir = change['new']
 
     kernel_manager_class = Type(
-        default_value=MappingKernelManager,
+        default_value=AsyncMappingKernelManager,
+        klass=MappingKernelManager,
         config=True,
         help=_('The kernel manager class to use.')
     )


### PR DESCRIPTION
Seems time we switched to using the async kernel management framework by default.  This has already been adopted by NBclient (Papermill), Voila, and Enterprise Gateway.