### PR TITLE
[Gateway] Track only this server's kernels

### DIFF
--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -55,9 +55,9 @@ class MainKernelHandler(APIHandler):
 class KernelHandler(APIHandler):
 
     @web.authenticated
-    def get(self, kernel_id):
+    async def get(self, kernel_id):
         km = self.kernel_manager
-        model = km.kernel_model(kernel_id)
+        model = await ensure_async(km.kernel_model(kernel_id))
         self.finish(json.dumps(model, default=date_default))
 
     @web.authenticated


### PR DESCRIPTION
While working on Enterprise Gateway, I found that if a gateway server is hosting kernels from multiple lab servers (via either jupyter_server or notebook), all kernels managed by the gateway server could be shut down when terminating _one_ of the lab servers.  This change ensures that kernel-based operations of a given lab/notebook server only operate against its own kernels.

Also:
- Updated log statements to f-strings in the working file.
- Found the KernelHandlers `get` method hadn't transitioned to `async def` so I made that change.