### PR TITLE
Correct logging message position

### DIFF
--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -54,16 +54,17 @@ def get_metadata(package_name, logger=None):
     # _jupyter_server_extension_paths. We will remove in
     # a later release of Jupyter Server.
     try:
-        return module, module._jupyter_server_extension_paths()
-    except AttributeError:
+        extension_points = module._jupyter_server_extension_paths()
         if logger:
-            logger.debug(
+            logger.warning(
                 "A `_jupyter_server_extension_points` function was not "
                 "found in {name}. Instead, a `_jupyter_server_extension_paths` "
                 "function was found and will be used for now. This function "
                 "name will be deprecated in future releases "
                 "of Jupyter Server.".format(name=package_name)
             )
+        return module, extension_points
+    except AttributeError:
         pass
 
     # Dynamically create metadata if the package doesn't


### PR DESCRIPTION
Reading that piece of code - I think the log message is at the wrong place.

I also change it to a warning as extension authors should be aware that they should update the method name. Otherwise they would be kept in the dark like I was before today.