### PR TITLE
Solve UnboundLocalError in launch_browser()

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2023,7 +2023,7 @@ class ServerApp(JupyterApp):
         if not browser:
             return
 
-        assembled_url, _ = self._prepare_browser_open()
+        assembled_url, __ = self._prepare_browser_open()
 
         b = lambda: browser.open(assembled_url, new=self.webbrowser_open_new)
         threading.Thread(target=b).start()


### PR DESCRIPTION
Python's scoping rules cause the log statement to fail because `_` was being redefined in `launch_browser()`.

The issue was introduced in [this commit](https://github.com/jupyter-server/jupyter_server/commit/1bbcbcb359601f6b0a9e1afd16720df09920aa64#annotation_1006253621) and flagged by CI.

I can confirm that this bug causes JupyterLab to crash when it cannot find a web browser.