### PR TITLE
Add possibility to make websocket token auth optional. Add config.

### DIFF
--- a/docs/source/other/full-config.rst
+++ b/docs/source/other/full-config.rst
@@ -549,6 +549,10 @@ ServerApp.token : Unicode
 
     Setting to an empty string disables authentication altogether, which is NOT RECOMMENDED.
 
+ServerApp.enable_wss_token_auth: Bool
+    Default: ``False``
+
+    Enable token auth for websocket connection
 
 ServerApp.tornado_settings : Dict
     Default: ``{}``

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1001,6 +1001,9 @@ class ServerApp(JupyterApp):
             help=_("Supply overrides for the tornado.web.Application that the "
                  "Jupyter server uses."))
 
+    websocket_enable_token_auth = Bool(config=True,
+                                       help="Enable token auth for websocket connections")
+    
     websocket_compression_options = Any(None, config=True,
         help=_("""
         Set the tornado compression options for websocket connections.


### PR DESCRIPTION
Add server config to set websocket config enable in case you need
related pull request - https://github.com/jupyterlab/jupyterlab/pull/9853
Related to issue https://github.com/jupyterlab/jupyterlab/issues/9070