### PR TITLE
Rename translation function alias

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -222,7 +222,7 @@ class ExtensionApp(JupyterApp):
         return url_path_join(self.serverapp.base_url, static_url)
 
     static_paths = List(Unicode(),
-        help=_i18n("""paths to search for serving static files.
+        help="""paths to search for serving static files.
 
         This allows adding javascript/css to be available from the notebook server machine,
         or overriding individual files in the IPython
@@ -230,7 +230,7 @@ class ExtensionApp(JupyterApp):
     ).tag(config=True)
 
     template_paths = List(Unicode(),
-        help="""Paths to search for serving jinja templates.
+        help=_i18n("""Paths to search for serving jinja templates.
 
         Can be used to override templates from notebook.templates.""")
     ).tag(config=True)

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -230,7 +230,7 @@ class ExtensionApp(JupyterApp):
     ).tag(config=True)
 
     template_paths = List(Unicode(),
-        help=_i18n("""Paths to search for serving jinja templates.
+        help="""Paths to search for serving jinja templates.
 
         Can be used to override templates from notebook.templates.""")
     ).tag(config=True)
@@ -247,7 +247,7 @@ class ExtensionApp(JupyterApp):
         """The default config file name."""
         if not self.name:
             return ''
-        return 'jupyter_{}_config'.format(self.name.replace('-','_'))
+        return 'jupyter_{}_config'.format(self.name.replace('-', '_'))
 
     def initialize_settings(self):
         """Override this method to add handling of settings."""

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -19,7 +19,7 @@ from tornado.web import RedirectHandler
 from jupyter_core.application import JupyterApp, NoStart
 
 from jupyter_server.serverapp import ServerApp
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 from jupyter_server.utils import url_path_join
 from .handler import ExtensionHandlerMixin
 
@@ -87,7 +87,7 @@ class ExtensionAppJinjaMixin(HasTraits):
     """Use Jinja templates for HTML templates on top of an ExtensionApp."""
 
     jinja2_options = Dict(
-        help=_("""Options to pass to the jinja2 environment for this
+        help=_i18n("""Options to pass to the jinja2 environment for this
         """)
     ).tag(config=True)
 
@@ -222,7 +222,7 @@ class ExtensionApp(JupyterApp):
         return url_path_join(self.serverapp.base_url, static_url)
 
     static_paths = List(Unicode(),
-        help="""paths to search for serving static files.
+        help=_i18n("""paths to search for serving static files.
 
         This allows adding javascript/css to be available from the notebook server machine,
         or overriding individual files in the IPython
@@ -230,17 +230,17 @@ class ExtensionApp(JupyterApp):
     ).tag(config=True)
 
     template_paths = List(Unicode(),
-        help=_("""Paths to search for serving jinja templates.
+        help=_i18n("""Paths to search for serving jinja templates.
 
         Can be used to override templates from notebook.templates.""")
     ).tag(config=True)
 
     settings = Dict(
-        help=_("""Settings that will passed to the server.""")
+        help=_i18n("""Settings that will passed to the server.""")
     ).tag(config=True)
 
     handlers = List(
-        help=_("""Handlers appended to the server.""")
+        help=_i18n("""Handlers appended to the server.""")
     ).tag(config=True)
 
     def _config_file_name_default(self):

--- a/jupyter_server/i18n/README.md
+++ b/jupyter_server/i18n/README.md
@@ -116,7 +116,7 @@ communicate this back to Jinja2.  So far, I haven't yet figured out how to do th
 of languages in the UI ( never a good thing ).
 
 2. We will need to decide if console messages should be translatable, and enable them if desired.
-3. The keyboard shorcut editor was implemented after the i18n work was completed, so that portion
+3. The keyboard shortcut editor was implemented after the i18n work was completed, so that portion
 does not have translation support at this time.
 4. Babel's documentation has instructions on how to integrate messages extraction
 into your *setup.py* so that eventually we can just do:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -44,7 +44,7 @@ except ImportError:
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_core.paths import secure_write
-from jupyter_server.transutils import trans, _
+from jupyter_server.transutils import trans, _i18n
 from jupyter_server.utils import run_sync
 
 # the minimum viable tornado version: needs to be kept in sync with setup.py
@@ -55,7 +55,7 @@ try:
     assert tornado.version_info >= MIN_TORNADO
 except (ImportError, AttributeError, AssertionError) as e:  # pragma: no cover
     raise ImportError(
-        _("The Jupyter Server requires tornado >=%s.%s.%s") % MIN_TORNADO
+        _i18n("The Jupyter Server requires tornado >=%s.%s.%s") % MIN_TORNADO
     ) from e
 
 from tornado import httpserver
@@ -480,21 +480,21 @@ class JupyterServerStopApp(JupyterApp):
 
 class JupyterServerListApp(JupyterApp):
     version = __version__
-    description=_("List currently running notebook servers.")
+    description=_i18n("List currently running notebook servers.")
 
     flags = dict(
         jsonlist=({'JupyterServerListApp': {'jsonlist': True}},
-              _("Produce machine-readable JSON list output.")),
+              _i18n("Produce machine-readable JSON list output.")),
         json=({'JupyterServerListApp': {'json': True}},
-              _("Produce machine-readable JSON object on each line of output.")),
+              _i18n("Produce machine-readable JSON object on each line of output.")),
     )
 
     jsonlist = Bool(False, config=True,
-          help=_("If True, the output will be a JSON list of objects, one per "
+          help=_i18n("If True, the output will be a JSON list of objects, one per "
                  "active notebook server, each with the details from the "
                  "relevant server info file."))
     json = Bool(False, config=True,
-          help=_("If True, each line of output will be a JSON object with the "
+          help=_i18n("If True, each line of output will be a JSON object with the "
                   "details from the server info file. For a JSON list output, "
                   "see the JupyterServerListApp.jsonlist configuration value"))
 
@@ -519,23 +519,23 @@ class JupyterServerListApp(JupyterApp):
 
 flags = dict(base_flags)
 
-flags['allow-root']=(
+flags['allow-root'] = (
     {'ServerApp' : {'allow_root' : True}},
-    _("Allow the server to be run from root user.")
+    _i18n("Allow the server to be run from root user.")
 )
 flags["no-browser"] = (
     {
         "ServerApp": {"open_browser": False},
         "ExtensionApp": {"open_browser": False}
     },
-    _("Prevent the opening of the default url in the browser."),
+    _i18n("Prevent the opening of the default url in the browser."),
 )
 flags["debug"] = (
     {
         'ServerApp': {'log_level': 'DEBUG'},
         'ExtensionApp': {'log_level': 'DEBUG'}
     },
-    _("Set debug level for the extension and underlying server applications.")
+    _i18n("Set debug level for the extension and underlying server applications.")
 )
 flags['autoreload'] = (
     {'ServerApp': {'autoreload': True}},
@@ -576,7 +576,7 @@ class ServerApp(JupyterApp):
 
     name = 'jupyter-server'
     version = __version__
-    description = _("""The Jupyter Server.
+    description = _i18n("""The Jupyter Server.
 
     This launches a Tornado-based Jupyter Server.""")
     examples = _examples
@@ -659,23 +659,23 @@ class ServerApp(JupyterApp):
     )
 
     allow_credentials = Bool(False, config=True,
-        help=_("Set the Access-Control-Allow-Credentials: true header")
+        help=_i18n("Set the Access-Control-Allow-Credentials: true header")
     )
 
     allow_root = Bool(False, config=True,
-        help=_("Whether to allow the user to run the server as root.")
+        help=_i18n("Whether to allow the user to run the server as root.")
     )
 
     autoreload = Bool(False, config=True,
-        help= ("Reload the webapp when changes are made to any Python src files.")
+        help=_i18n("Reload the webapp when changes are made to any Python src files.")
     )
 
     default_url = Unicode('/', config=True,
-        help=_("The default URL to redirect to from `/`")
+        help=_i18n("The default URL to redirect to from `/`")
     )
 
     ip = Unicode('localhost', config=True,
-        help=_("The IP address the Jupyter server will listen on.")
+        help=_i18n("The IP address the Jupyter server will listen on.")
     )
 
     @default('ip')
@@ -688,7 +688,7 @@ class ServerApp(JupyterApp):
         try:
             s.bind(('localhost', 0))
         except socket.error as e:
-            self.log.warning(_("Cannot bind to localhost, using 127.0.0.1 as default ip\n%s"), e)
+            self.log.warning(_i18n("Cannot bind to localhost, using 127.0.0.1 as default ip\n%s"), e)
             return '127.0.0.1'
         else:
             s.close()
@@ -702,7 +702,7 @@ class ServerApp(JupyterApp):
         return value
 
     custom_display_url = Unicode(u'', config=True,
-        help=_("""Override URL shown to users.
+        help=_i18n("""Override URL shown to users.
 
         Replace actual URL, including protocol, address, port and base URL,
         with the given value when displaying URL to the users. Do not change
@@ -715,27 +715,27 @@ class ServerApp(JupyterApp):
     )
 
     port = Integer(8888, config=True,
-        help=_("The port the Jupyter server will listen on.")
+        help=_i18n("The port the Jupyter server will listen on.")
     )
 
     port_retries = Integer(50, config=True,
-        help=_("The number of additional ports to try if the specified port is not available.")
+        help=_i18n("The number of additional ports to try if the specified port is not available.")
     )
 
     certfile = Unicode(u'', config=True,
-        help=_("""The full path to an SSL/TLS certificate file.""")
+        help=_i18n("""The full path to an SSL/TLS certificate file.""")
     )
 
     keyfile = Unicode(u'', config=True,
-        help=_("""The full path to a private key file for usage with SSL/TLS.""")
+        help=_i18n("""The full path to a private key file for usage with SSL/TLS.""")
     )
 
     client_ca = Unicode(u'', config=True,
-        help=_("""The full path to a certificate authority certificate for SSL/TLS client authentication.""")
+        help=_i18n("""The full path to a certificate authority certificate for SSL/TLS client authentication.""")
     )
 
     cookie_secret_file = Unicode(config=True,
-        help=_("""The file where the cookie secret is stored.""")
+        help=_i18n("""The file where the cookie secret is stored.""")
     )
 
     @default('cookie_secret_file')
@@ -766,16 +766,16 @@ class ServerApp(JupyterApp):
 
     def _write_cookie_secret_file(self, secret):
         """write my secret to my secret_file"""
-        self.log.info(_("Writing notebook server cookie secret to %s"), self.cookie_secret_file)
+        self.log.info(_i18n("Writing notebook server cookie secret to %s"), self.cookie_secret_file)
         try:
             with secure_write(self.cookie_secret_file, True) as f:
                 f.write(secret)
         except OSError as e:
-            self.log.error(_("Failed to write cookie secret to %s: %s"),
+            self.log.error(_i18n("Failed to write cookie secret to %s: %s"),
                            self.cookie_secret_file, e)
 
     token = Unicode('<generated>',
-        help=_("""Token used for authenticating first-time connections to the server.
+        help=_i18n("""Token used for authenticating first-time connections to the server.
 
         When no password is enabled,
         the default is to generate a new, random token.
@@ -985,7 +985,7 @@ class ServerApp(JupyterApp):
                       """)
 
     webbrowser_open_new = Integer(2, config=True,
-        help=_("""Specify where to open the server on startup. This is the
+        help=_i18n("""Specify where to open the server on startup. This is the
         `new` argument passed to the standard library method `webbrowser.open`.
         The behaviour is not guaranteed, but depends on browser support. Valid
         values are:
@@ -998,11 +998,11 @@ class ServerApp(JupyterApp):
         """))
 
     tornado_settings = Dict(config=True,
-            help=_("Supply overrides for the tornado.web.Application that the "
+            help=_i18n("Supply overrides for the tornado.web.Application that the "
                  "Jupyter server uses."))
 
     websocket_compression_options = Any(None, config=True,
-        help=_("""
+        help=_i18n("""
         Set the tornado compression options for websocket connections.
 
         This value will be returned from :meth:`WebSocketHandler.get_compression_options`.
@@ -1013,28 +1013,28 @@ class ServerApp(JupyterApp):
         """)
     )
     terminado_settings = Dict(config=True,
-            help=_('Supply overrides for terminado. Currently only supports "shell_command".'))
+            help=_i18n('Supply overrides for terminado. Currently only supports "shell_command".'))
 
     cookie_options = Dict(config=True,
-        help=_("Extra keyword arguments to pass to `set_secure_cookie`."
+        help=_i18n("Extra keyword arguments to pass to `set_secure_cookie`."
              " See tornado's set_secure_cookie docs for details.")
     )
     get_secure_cookie_kwargs = Dict(config=True,
-        help=_("Extra keyword arguments to pass to `get_secure_cookie`."
+        help=_i18n("Extra keyword arguments to pass to `get_secure_cookie`."
              " See tornado's get_secure_cookie docs for details.")
     )
     ssl_options = Dict(
             allow_none=True,
             config=True,
-            help=_("""Supply SSL options for the tornado HTTPServer.
+            help=_i18n("""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details."""))
 
     jinja_environment_options = Dict(config=True,
-            help=_("Supply extra arguments that will be passed to Jinja environment."))
+            help=_i18n("Supply extra arguments that will be passed to Jinja environment."))
 
     jinja_template_vars = Dict(
         config=True,
-        help=_("Extra variables to supply to jinja templates when rendering."),
+        help=_i18n("Extra variables to supply to jinja templates when rendering."),
     )
 
     base_url = Unicode('/', config=True,
@@ -1066,7 +1066,7 @@ class ServerApp(JupyterApp):
         return self.extra_static_paths + [DEFAULT_STATIC_FILES_PATH]
 
     static_custom_path = List(Unicode(),
-        help=_("""Path to search for custom.js, css""")
+        help=_i18n("""Path to search for custom.js, css""")
     )
 
     @default('static_custom_path')
@@ -1078,7 +1078,7 @@ class ServerApp(JupyterApp):
         ]
 
     extra_template_paths = List(Unicode(), config=True,
-        help=_("""Extra paths to search for serving jinja templates.
+        help=_i18n("""Extra paths to search for serving jinja templates.
 
         Can be used to override templates from jupyter_server.templates.""")
     )
@@ -1089,7 +1089,7 @@ class ServerApp(JupyterApp):
         return self.extra_template_paths + DEFAULT_TEMPLATE_PATH_LIST
 
     extra_services = List(Unicode(), config=True,
-        help=_("""handlers that should be loaded at higher priority than the default services""")
+        help=_i18n("""handlers that should be loaded at higher priority than the default services""")
     )
 
     websocket_url = Unicode("", config=True,
@@ -1114,7 +1114,7 @@ class ServerApp(JupyterApp):
             'notebook.services.contents.manager.ContentsManager'
         ],
         config=True,
-        help=_('The content manager class to use.')
+        help=_i18n('The content manager class to use.')
     )
 
     # Throws a deprecation warning to notebook based contents managers.
@@ -1138,26 +1138,26 @@ class ServerApp(JupyterApp):
 
     @observe('notebook_dir')
     def _update_notebook_dir(self, change):
-        self.log.warning(_("notebook_dir is deprecated, use root_dir"))
+        self.log.warning(_i18n("notebook_dir is deprecated, use root_dir"))
         self.root_dir = change['new']
 
     kernel_manager_class = Type(
         default_value=AsyncMappingKernelManager,
         klass=MappingKernelManager,
         config=True,
-        help=_('The kernel manager class to use.')
+        help=_i18n('The kernel manager class to use.')
     )
 
     session_manager_class = Type(
         default_value=SessionManager,
         config=True,
-        help=_('The session manager class to use.')
+        help=_i18n('The session manager class to use.')
     )
 
     config_manager_class = Type(
         default_value=ConfigManager,
         config = True,
-        help=_('The config manager class to use')
+        help=_i18n('The config manager class to use')
     )
 
     kernel_spec_manager = Instance(KernelSpecManager, allow_none=True)
@@ -1178,18 +1178,18 @@ class ServerApp(JupyterApp):
         default_value=LoginHandler,
         klass=web.RequestHandler,
         config=True,
-        help=_('The login handler class to use.'),
+        help=_i18n('The login handler class to use.'),
     )
 
     logout_handler_class = Type(
         default_value=LogoutHandler,
         klass=web.RequestHandler,
         config=True,
-        help=_('The logout handler class to use.'),
+        help=_i18n('The logout handler class to use.'),
     )
 
     trust_xheaders = Bool(False, config=True,
-        help=(_("Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headers"
+        help=(_i18n("Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-For headers"
               "sent by the upstream reverse proxy. Necessary if the proxy handles SSL"))
     )
 
@@ -1215,7 +1215,7 @@ class ServerApp(JupyterApp):
         return os.path.join(self.runtime_dir, basename)
 
     pylab = Unicode('disabled', config=True,
-        help=_("""
+        help=_i18n("""
         DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
         """)
     )
@@ -1227,15 +1227,15 @@ class ServerApp(JupyterApp):
             backend = ' %s' % change['new']
         else:
             backend = ''
-        self.log.error(_("Support for specifying --pylab on the command line has been removed."))
+        self.log.error(_i18n("Support for specifying --pylab on the command line has been removed."))
         self.log.error(
-            _("Please use `%pylab{0}` or `%matplotlib{0}` in the notebook itself.").format(backend)
+            _i18n("Please use `%pylab{0}` or `%matplotlib{0}` in the notebook itself.").format(backend)
         )
         self.exit(1)
 
     notebook_dir = Unicode(
         config=True,
-        help=_("DEPRECATED, use root_dir.")
+        help=_i18n("DEPRECATED, use root_dir.")
     )
 
     @observe('notebook_dir')
@@ -1243,12 +1243,12 @@ class ServerApp(JupyterApp):
         if self._root_dir_set:
             # only use deprecated config if new config is not set
             return
-        self.log.warning(_("notebook_dir is deprecated, use root_dir"))
+        self.log.warning(_i18n("notebook_dir is deprecated, use root_dir"))
         self.root_dir = change['new']
 
     root_dir = Unicode(
         config=True,
-        help=_("The directory to use for notebooks and kernels.")
+        help=_i18n("The directory to use for notebooks and kernels.")
     )
     _root_dir_set = False
 
@@ -1282,11 +1282,11 @@ class ServerApp(JupyterApp):
 
     @observe('server_extensions')
     def _update_server_extensions(self, change):
-        self.log.warning(_("server_extensions is deprecated, use jpserver_extensions"))
+        self.log.warning(_i18n("server_extensions is deprecated, use jpserver_extensions"))
         self.server_extensions = change['new']
 
     jpserver_extensions = Dict({}, config=True,
-        help=(_("Dict of Python modules to load as notebook server extensions."
+        help=(_i18n("Dict of Python modules to load as notebook server extensions."
               "Entry values can be used to enable and disable the loading of"
               "the extensions. The extensions will be loaded in alphabetical "
               "order."))
@@ -1295,18 +1295,18 @@ class ServerApp(JupyterApp):
     reraise_server_extension_failures = Bool(
         False,
         config=True,
-        help=_("Reraise exceptions encountered loading server extensions?"),
+        help=_i18n("Reraise exceptions encountered loading server extensions?"),
     )
 
-    iopub_msg_rate_limit = Float(1000, config=True, help=_("""(msgs/sec)
+    iopub_msg_rate_limit = Float(1000, config=True, help=_i18n("""(msgs/sec)
         Maximum rate at which messages can be sent on iopub before they are
         limited."""))
 
-    iopub_data_rate_limit = Float(1000000, config=True, help=_("""(bytes/sec)
+    iopub_data_rate_limit = Float(1000000, config=True, help=_i18n("""(bytes/sec)
         Maximum rate at which stream output can be sent on iopub before they are
         limited."""))
 
-    rate_limit_window = Float(3, config=True, help=_("""(sec) Time window used to
+    rate_limit_window = Float(3, config=True, help=_i18n("""(sec) Time window used to
         check the message and data rate limits."""))
 
     shutdown_no_activity_timeout = Integer(0, config=True,
@@ -1320,7 +1320,7 @@ class ServerApp(JupyterApp):
     )
 
     terminals_enabled = Bool(True, config=True,
-         help=_("""Set to False to disable terminals.
+         help=_i18n("""Set to False to disable terminals.
 
          This does *not* make the server more secure by itself.
          Anything the user can in a terminal, they can also do in a notebook.
@@ -1357,7 +1357,7 @@ class ServerApp(JupyterApp):
             f = os.path.abspath(arg0)
             self.argv.remove(arg0)
             if not os.path.exists(f):
-                self.log.critical(_("No such file or directory: %s"), f)
+                self.log.critical(_i18n("No such file or directory: %s"), f)
                 self.exit(1)
 
             # Use config here, to ensure that it takes higher priority than
@@ -1436,9 +1436,9 @@ class ServerApp(JupyterApp):
             self.default_url = url_path_join(self.base_url, self.default_url)
 
         if self.password_required and (not self.password):
-            self.log.critical(_("Jupyter servers are configured to only be run with a password."))
-            self.log.critical(_("Hint: run the following command to set a password"))
-            self.log.critical(_("\t$ python -m jupyter_server.auth password"))
+            self.log.critical(_i18n("Jupyter servers are configured to only be run with a password."))
+            self.log.critical(_i18n("Hint: run the following command to set a password"))
+            self.log.critical(_i18n("\t$ python -m jupyter_server.auth password"))
             sys.exit(1)
 
         self.web_app = ServerWebApplication(
@@ -1549,7 +1549,7 @@ class ServerApp(JupyterApp):
             initialize(self.web_app, self.root_dir, self.connection_url, self.terminado_settings)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
-            self.log.warning(_("Terminals not available (error was %s)"), e)
+            self.log.warning(_i18n("Terminals not available (error was %s)"), e)
 
     def init_signal(self):
         if not sys.platform.startswith('win') and sys.stdin and sys.stdin.isatty():
@@ -1585,24 +1585,24 @@ class ServerApp(JupyterApp):
         This doesn't work on Windows.
         """
         info = self.log.info
-        info(_('interrupted'))
+        info(_i18n('interrupted'))
         print(self.running_server_info())
-        yes = _('y')
-        no = _('n')
-        sys.stdout.write(_("Shutdown this Jupyter server (%s/[%s])? ") % (yes, no))
+        yes = _i18n('y')
+        no = _i18n('n')
+        sys.stdout.write(_i18n("Shutdown this Jupyter server (%s/[%s])? ") % (yes, no))
         sys.stdout.flush()
         r,w,x = select.select([sys.stdin], [], [], 5)
         if r:
             line = sys.stdin.readline()
             if line.lower().startswith(yes) and no not in line.lower():
-                self.log.critical(_("Shutdown confirmed"))
+                self.log.critical(_i18n("Shutdown confirmed"))
                 # schedule stop on the main thread,
                 # since this might be called from a signal handler
                 self.io_loop.add_callback_from_signal(self.io_loop.stop)
                 return
         else:
-            print(_("No answer for 5s:"), end=' ')
-        print(_("resuming operation..."))
+            print(_i18n("No answer for 5s:"), end=' ')
+        print(_i18n("resuming operation..."))
         # no answer, or answer is no:
         # set it back to original SIGINT handler
         # use IOLoop.add_callback because signal.signal must be called
@@ -1610,7 +1610,7 @@ class ServerApp(JupyterApp):
         self.io_loop.add_callback_from_signal(self._restore_sigint_handler)
 
     def _signal_stop(self, sig, frame):
-        self.log.critical(_("received signal %s, stopping"), sig)
+        self.log.critical(_i18n("received signal %s, stopping"), sig)
         self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
     def _signal_info(self, sig, frame):
@@ -1752,10 +1752,10 @@ class ServerApp(JupyterApp):
                 self.http_server.listen(port, self.ip)
             except socket.error as e:
                 if e.errno == errno.EADDRINUSE:
-                    self.log.info(_('The port %i is already in use, trying another port.') % port)
+                    self.log.info(_i18n('The port %i is already in use, trying another port.') % port)
                     continue
                 elif e.errno in (errno.EACCES, getattr(errno, 'WSAEACCES', errno.EACCES)):
-                    self.log.warning(_("Permission to listen on port %i denied") % port)
+                    self.log.warning(_i18n("Permission to listen on port %i denied") % port)
                     continue
                 else:
                     raise
@@ -1764,7 +1764,7 @@ class ServerApp(JupyterApp):
                 success = True
                 break
         if not success:
-            self.log.critical(_('ERROR: the Jupyter server could not be started because '
+            self.log.critical(_i18n('ERROR: the Jupyter server could not be started because '
                               'no available port could be found.'))
             self.exit(1)
 
@@ -1855,10 +1855,10 @@ class ServerApp(JupyterApp):
             info += kernel_msg % n_kernels
             info += "\n"
         # Format the info so that the URL fits on a single line in 80 char display
-        info += _("Jupyter Server {version} is running at:\n{url}".
+        info += _i18n("Jupyter Server {version} is running at:\n{url}".
                   format(version=ServerApp.version, url=self.display_url))
         if self.gateway_config.gateway_enabled:
-            info += _("\nKernels will be managed by the Gateway server running at:\n%s") % self.gateway_config.url
+            info += _i18n("\nKernels will be managed by the Gateway server running at:\n%s") % self.gateway_config.url
         return info
 
     def server_info(self):
@@ -1881,7 +1881,7 @@ class ServerApp(JupyterApp):
             with secure_write(self.info_file) as f:
                 json.dump(self.server_info(), f, indent=2, sort_keys=True)
         except OSError as e:
-            self.log.error(_("Failed to write server-info to %s: %s"),
+            self.log.error(_i18n("Failed to write server-info to %s: %s"),
                            self.info_file, e)
 
     def remove_server_info_file(self):
@@ -2017,13 +2017,13 @@ class ServerApp(JupyterApp):
         try:
             browser = webbrowser.get(self.browser or None)
         except webbrowser.Error as e:
-            self.log.warning(_('No web browser found: %s.') % e)
+            self.log.warning(_i18n('No web browser found: %s.') % e)
             browser = None
 
         if not browser:
             return
 
-        assembled_url, __ = self._prepare_browser_open()
+        assembled_url, _ = self._prepare_browser_open()
 
         b = lambda: browser.open(assembled_url, new=self.webbrowser_open_new)
         threading.Thread(target=b).start()
@@ -2038,15 +2038,15 @@ class ServerApp(JupyterApp):
             except AttributeError:
                 uid = -1 # anything nonzero here, since we can't check UID assume non-root
             if uid == 0:
-                self.log.critical(_("Running as root is not recommended. Use --allow-root to bypass."))
+                self.log.critical(_i18n("Running as root is not recommended. Use --allow-root to bypass."))
                 self.exit(1)
 
         info = self.log.info
         for line in self.running_server_info(kernel_count=False).split("\n"):
             info(line)
-        info(_("Use Control-C to stop this server and shut down all kernels (twice to skip confirmation)."))
+        info(_i18n("Use Control-C to stop this server and shut down all kernels (twice to skip confirmation)."))
         if 'dev' in jupyter_server.__version__:
-            info(_("Welcome to Project Jupyter! Explore the various tools available"
+            info(_i18n("Welcome to Project Jupyter! Explore the various tools available"
                  " and their corresponding documentation. If you are interested"
                  " in contributing to the platform, please visit the community"
                  "resources section at https://jupyter.org/community.html."))
@@ -2088,7 +2088,7 @@ class ServerApp(JupyterApp):
         try:
             self.io_loop.start()
         except KeyboardInterrupt:
-            self.log.info(_("Interrupted..."))
+            self.log.info(_i18n("Interrupted..."))
         finally:
             self._cleanup()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -145,7 +145,6 @@ JUPYTER_SERVICE_HANDLERS = dict(
     view=['jupyter_server.view.handlers']
 )
 
-
 #-----------------------------------------------------------------------------
 # Helper functions
 #-----------------------------------------------------------------------------
@@ -161,12 +160,10 @@ def random_ports(port, n):
     for i in range(n-5):
         yield max(1, port + random.randint(-2*n, 2*n))
 
-
 def load_handlers(name):
     """Load the (URL pattern, handler) tuples for each component."""
     mod = __import__(name, fromlist=['default_handlers'])
     return mod.default_handlers
-
 
 #-----------------------------------------------------------------------------
 # The Tornado web application
@@ -239,9 +236,9 @@ class ServerWebApplication(web.Application):
             template_path=template_path,
             static_path=jupyter_app.static_file_path,
             static_custom_path=jupyter_app.static_custom_path,
-            static_handler_class=FileFindHandler,
-            static_url_prefix=url_path_join(base_url, '/static/'),
-            static_handler_args={
+            static_handler_class = FileFindHandler,
+            static_url_prefix = url_path_join(base_url, '/static/'),
+            static_handler_args = {
                 # don't cache custom.js
                 'no_cache_paths': [url_path_join(base_url, 'static', 'custom')],
             },
@@ -343,8 +340,8 @@ class ServerWebApplication(web.Application):
             # set the URL that will be redirected from `/`
             handlers.append(
                 (r'/?', RedirectWithParams, {
-                    'url': settings['default_url'],
-                    'permanent': False,  # want 302, not 301
+                    'url' : settings['default_url'],
+                    'permanent': False, # want 302, not 301
                 })
             )
         else:
@@ -398,7 +395,7 @@ class JupyterPasswordApp(JupyterApp):
     def start(self):
         from .auth.security import set_password
         set_password(config_file=self.config_file)
-        self.log.info(_i18n("Wrote hashed password to %s" % self.config_file))
+        self.log.info("Wrote hashed password to %s" % self.config_file)
 
 
 def shutdown_server(server_info, timeout=5, log=None):
@@ -450,15 +447,15 @@ def shutdown_server(server_info, timeout=5, log=None):
 class JupyterServerStopApp(JupyterApp):
 
     version = __version__
-    description = _i18n("Stop currently running Jupyter server for a given port")
+    description = "Stop currently running Jupyter server for a given port"
 
     port = Integer(8888, config=True,
-                   help=_i18n("Port of the server to be killed. Default 8888"))
+        help="Port of the server to be killed. Default 8888")
 
     def parse_command_line(self, argv=None):
         super(JupyterServerStopApp, self).parse_command_line(argv)
         if self.extra_args:
-            self.port = int(self.extra_args[0])
+            self.port=int(self.extra_args[0])
 
     def shutdown_server(self, server):
         return shutdown_server(server, log=self.log)
@@ -483,7 +480,7 @@ class JupyterServerStopApp(JupyterApp):
 
 class JupyterServerListApp(JupyterApp):
     version = __version__
-    description = _i18n("List currently running notebook servers.")
+    description=_i18n("List currently running notebook servers.")
 
     flags = dict(
         jsonlist=({'JupyterServerListApp': {'jsonlist': True}},
@@ -493,7 +490,7 @@ class JupyterServerListApp(JupyterApp):
     )
 
     jsonlist = Bool(False, config=True,
-            help=_i18n("If True, the output will be a JSON list of objects, one per "
+          help=_i18n("If True, the output will be a JSON list of objects, one per "
                  "active notebook server, each with the details from the "
                  "relevant server info file."))
     json = Bool(False, config=True,
@@ -515,7 +512,6 @@ class JupyterServerListApp(JupyterApp):
                 if serverinfo.get('token'):
                     url = url + '?token=%s' % serverinfo['token']
                 print(url, "::", serverinfo['root_dir'])
-
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -543,11 +539,11 @@ flags["debug"] = (
 )
 flags['autoreload'] = (
     {'ServerApp': {'autoreload': True}},
-    _i18n("""Autoreload the webapp
+    """Autoreload the webapp
     Enable reloading of the tornado webapp and all imported Python packages
     when any changes are made to any Python src files in server or
     extensions.
-    """)
+    """
 )
 
 
@@ -571,7 +567,6 @@ aliases.update({
     'pylab': 'ServerApp.pylab',
     'gateway-url': 'GatewayClient.url',
 })
-
 
 #-----------------------------------------------------------------------------
 # ServerApp
@@ -633,25 +628,25 @@ class ServerApp(JupyterApp):
 
     # file to be opened in the Jupyter server
     file_to_run = Unicode('',
-        help=_i18n("Open the named file when the application is launched.")
+        help="Open the named file when the application is launched."
     ).tag(config=True)
 
     file_url_prefix = Unicode('notebooks',
-        help=_i18n("The URL prefix where files are opened directly.")
+        help="The URL prefix where files are opened directly."
     ).tag(config=True)
 
     # Network related information
     allow_origin = Unicode('', config=True,
-        help=_i18n("""Set the Access-Control-Allow-Origin header
+        help="""Set the Access-Control-Allow-Origin header
 
         Use '*' to allow any origin to access your server.
 
         Takes precedence over allow_origin_pat.
-        """)
+        """
     )
 
     allow_origin_pat = Unicode('', config=True,
-        help=_i18n("""Use a regular expression for the Access-Control-Allow-Origin header
+        help="""Use a regular expression for the Access-Control-Allow-Origin header
 
         Requests from an origin matching the expression will get replies with:
 
@@ -660,7 +655,7 @@ class ServerApp(JupyterApp):
         where `origin` is the origin of the request.
 
         Ignored if allow_origin is set.
-        """)
+        """
     )
 
     allow_credentials = Bool(False, config=True,
@@ -748,13 +743,13 @@ class ServerApp(JupyterApp):
         return os.path.join(self.runtime_dir, 'jupyter_cookie_secret')
 
     cookie_secret = Bytes(b'', config=True,
-        help=_i18n("""The random bytes used to secure cookies.
+        help="""The random bytes used to secure cookies.
         By default this is a new random number every time you start the server.
         Set it to a value in a config file to enable logins to persist across server sessions.
 
         Note: Cookie secrets should be kept private, do not share config files with
         cookie_secret stored in plaintext (you can read the value from a file).
-        """)
+        """
     )
 
     @default('cookie_secret')
@@ -805,13 +800,12 @@ class ServerApp(JupyterApp):
             return binascii.hexlify(os.urandom(24)).decode('ascii')
 
     min_open_files_limit = Integer(config=True,
-        help=_i18n("""
+        help="""
         Gets or sets a lower bound on the open file handles process resource
         limit. This may need to be increased if you run into an
         OSError: [Errno 24] Too many open files.
         This is not applicable when running on Windows.
         """)
-    )
 
     @default('min_open_files_limit')
     def _default_min_open_files_limit(self):
@@ -830,21 +824,21 @@ class ServerApp(JupyterApp):
         return soft
 
     max_body_size = Integer(512 * 1024 * 1024, config=True,
-        help=_i18n("""
+        help="""
         Sets the maximum allowed size of the client request body, specified in
         the Content-Length request header field. If the size in a request
         exceeds the configured value, a malformed HTTP message is returned to
         the client.
 
         Note: max_body_size is applied even in streaming mode.
-        """)
+        """
     )
 
     max_buffer_size = Integer(512 * 1024 * 1024, config=True,
-        help=_i18n("""
+        help="""
         Gets or sets the maximum amount of memory, in bytes, that is allocated
         for use by the buffer manager.
-        """)
+        """
     )
 
     @observe('token')
@@ -852,41 +846,41 @@ class ServerApp(JupyterApp):
         self._token_generated = False
 
     password = Unicode(u'', config=True,
-                      help=_i18n("""Hashed password to use for web authentication.
+                      help="""Hashed password to use for web authentication.
 
                       To generate, type in a python/IPython shell:
 
                         from jupyter_server.auth import passwd; passwd()
 
                       The string should be of the form type:salt:hashed-password.
-                      """)
+                      """
     )
 
     password_required = Bool(False, config=True,
-                      help=_i18n("""Forces users to use a password for the Jupyter server.
+                      help="""Forces users to use a password for the Jupyter server.
                       This is useful in a multi user environment, for instance when
                       everybody in the LAN can access each other's machine through ssh.
 
                       In such a case, serving on localhost is not secure since
                       any user can connect to the Jupyter server via ssh.
 
-                      """)
+                      """
     )
 
     allow_password_change = Bool(True, config=True,
-                    help=_i18n("""Allow password to be changed at login for the Jupyter server.
+                    help="""Allow password to be changed at login for the Jupyter server.
 
                     While loggin in with a token, the Jupyter server UI will give the opportunity to
                     the user to enter a new password at the same time that will replace
                     the token login mechanism.
 
                     This can be set to false to prevent changing password from the UI/API.
-                    """)
+                    """
     )
 
 
     disable_check_xsrf = Bool(False, config=True,
-        help=_i18n("""Disable cross-site-request-forgery protection
+        help="""Disable cross-site-request-forgery protection
 
         Jupyter notebook 4.3.1 introduces protection from cross-site request forgeries,
         requiring API requests to either:
@@ -898,11 +892,11 @@ class ServerApp(JupyterApp):
         completely without authentication.
         These services can disable all authentication and security checks,
         with the full knowledge of what that implies.
-        """)
+        """
     )
 
     allow_remote_access = Bool(config=True,
-       help=_i18n("""Allow requests where the Host header doesn't point to a local server
+       help="""Allow requests where the Host header doesn't point to a local server
 
        By default, requests get a 403 forbidden response if the 'Host' header
        shows that the browser thinks it's on a non-local domain.
@@ -915,7 +909,6 @@ class ServerApp(JupyterApp):
        Local IP addresses (such as 127.0.0.1 and ::1) are allowed as local,
        along with hostnames configured in local_hostnames.
        """)
-    )
 
     @default('allow_remote_access')
     def _default_allow_remote(self):
@@ -952,7 +945,7 @@ class ServerApp(JupyterApp):
             return not addr.is_loopback
 
     use_redirect_file = Bool(True, config=True,
-        help=_i18n("""Disable launching browser by redirect file
+        help="""Disable launching browser by redirect file
      For versions of notebook > 5.7.2, a security feature measure was added that
      prevented the authentication token used to launch the browser from being visible.
      This feature makes it difficult for other users on a multi-user system from
@@ -964,34 +957,32 @@ class ServerApp(JupyterApp):
 
      Disabling this setting to False will disable this behavior, allowing the browser
      to launch by using a URL and visible token (as before).
-     """)
+     """
     )
 
     local_hostnames = List(Unicode(), ['localhost'], config=True,
-       help=_i18n("""Hostnames to allow as local when allow_remote_access is False.
+       help="""Hostnames to allow as local when allow_remote_access is False.
 
        Local IP addresses (such as 127.0.0.1 and ::1) are automatically accepted
        as local as well.
-       """)
+       """
     )
 
     open_browser = Bool(False, config=True,
-                        help=_i18n("""Whether to open in a browser after starting.
+                        help="""Whether to open in a browser after starting.
                         The specific browser used is platform dependent and
                         determined by the python standard library `webbrowser`
                         module, unless it is overridden using the --browser
                         (ServerApp.browser) configuration option.
                         """)
-    )
 
     browser = Unicode(u'', config=True,
-                      help=_i18n("""Specify what command to use to invoke a web
+                      help="""Specify what command to use to invoke a web
                       browser when starting the server. If not specified, the
                       default browser will be determined by the `webbrowser`
                       standard library module, which allows setting of the
                       BROWSER environment variable to override it.
                       """)
-    )
 
     webbrowser_open_new = Integer(2, config=True,
         help=_i18n("""Specify where to open the server on startup. This is the
@@ -1047,11 +1038,11 @@ class ServerApp(JupyterApp):
     )
 
     base_url = Unicode('/', config=True,
-                       help=_i18n('''The base URL for the Jupyter server.
+                       help='''The base URL for the Jupyter server.
 
                        Leading and trailing slashes can be omitted,
                        and will automatically be added.
-                       '''))
+                       ''')
 
     @validate('base_url')
     def _update_base_url(self, proposal):
@@ -1063,10 +1054,10 @@ class ServerApp(JupyterApp):
         return value
 
     extra_static_paths = List(Unicode(), config=True,
-        help=_i18n("""Extra paths to search for serving static files.
+        help="""Extra paths to search for serving static files.
 
         This allows adding javascript/css to be available from the Jupyter server machine,
-        or overriding individual files in the IPython""")
+        or overriding individual files in the IPython"""
     )
 
     @property
@@ -1102,15 +1093,15 @@ class ServerApp(JupyterApp):
     )
 
     websocket_url = Unicode("", config=True,
-        help=_i18n("""The base URL for websockets,
+        help="""The base URL for websockets,
         if it differs from the HTTP server (hint: it almost certainly doesn't).
 
         Should be in the form of an HTTP origin: ws[s]://hostname[:port]
-        """)
+        """
     )
 
     quit_button = Bool(True, config=True,
-        help=_i18n("""If True, display controls to shut down the Jupyter server, such as menu items or buttons.""")
+        help="""If True, display controls to shut down the Jupyter server, such as menu items or buttons."""
     )
 
     # REMOVE in VERSION 2.0
@@ -1174,13 +1165,13 @@ class ServerApp(JupyterApp):
     kernel_spec_manager_class = Type(
         default_value=KernelSpecManager,
         config=True,
-        help=_i18n("""
+        help="""
         The kernel spec manager class to use. Should be a subclass
         of `jupyter_client.kernelspec.KernelSpecManager`.
 
         The Api of KernelSpecManager is provisional and might change
         without warning between this version of Jupyter and the next stable one.
-        """)
+        """
     )
 
     login_handler_class = Type(
@@ -1282,7 +1273,7 @@ class ServerApp(JupyterApp):
             # If we receive a non-absolute path, make it absolute.
             value = os.path.abspath(value)
         if not os.path.isdir(value):
-            raise TraitError(_i18n("No such directory: '%r'") % value)
+            raise TraitError(trans.gettext("No such directory: '%r'") % value)
         return value
 
     @observe('root_dir')
@@ -1319,7 +1310,7 @@ class ServerApp(JupyterApp):
         check the message and data rate limits."""))
 
     shutdown_no_activity_timeout = Integer(0, config=True,
-        help=_i18n("Shut down the server after N seconds with no kernels or "
+        help=("Shut down the server after N seconds with no kernels or "
               "terminals running and no activity. "
               "This can be used together with culling idle kernels "
               "(MappingKernelManager.cull_idle_timeout) to "
@@ -1340,9 +1331,9 @@ class ServerApp(JupyterApp):
 
     authenticate_prometheus = Bool(
         True,
-        help=_i18n("""
+        help=""""
         Require authentication to access prometheus metrics.
-        """),
+        """,
         config=True
     )
 
@@ -1485,9 +1476,7 @@ class ServerApp(JupyterApp):
     def init_resources(self):
         """initialize system resources"""
         if resource is None:
-            self.log.debug(
-                _i18n('Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)')
-            )
+            self.log.debug('Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)')
             return
 
         old_soft, old_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -1497,7 +1486,7 @@ class ServerApp(JupyterApp):
             if hard < soft:
                 hard = soft
             self.log.debug(
-                _i18n('Raising open file limit: soft {}->{}; hard {}->{}'.format(old_soft, soft, old_hard, hard))
+                'Raising open file limit: soft {}->{}; hard {}->{}'.format(old_soft, soft, old_hard, hard)
             )
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
@@ -1782,11 +1771,11 @@ class ServerApp(JupyterApp):
     @staticmethod
     def _init_asyncio_patch():
         """no longer needed with tornado 6.1"""
-        warnings.warn(_i18n(
+        warnings.warn(
             """ServerApp._init_asyncio_patch called, and is longer needed for """
             """tornado 6.1+, and will be removed in a future release.""",
             DeprecationWarning
-        ))
+        )
 
     @catch_config_error
     def initialize(self, argv=None, find_extensions=True, new_httpserver=True, starter_extension=None):
@@ -2149,8 +2138,6 @@ def list_running_servers(runtime_dir=None):
                     os.unlink(os.path.join(runtime_dir, file_name))
                 except OSError:
                     pass  # TODO: This should warn or log or something
-
-
 #-----------------------------------------------------------------------------
 # Main entry point
 #-----------------------------------------------------------------------------

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1714,17 +1714,17 @@ class ServerApp(JupyterApp):
 
         seconds_since_active = \
             (utcnow() - self.web_app.last_activity()).total_seconds()
-        self.log.debug(_i18n("No activity for %d seconds.",
-                       seconds_since_active))
+        self.log.debug("No activity for %d seconds.",
+                       seconds_since_active)
         if seconds_since_active > self.shutdown_no_activity_timeout:
-            self.log.info(_i18n("No kernels or terminals for %d seconds; shutting down.",
-                          seconds_since_active))
+            self.log.info("No kernels or terminals for %d seconds; shutting down.",
+                          seconds_since_active)
             self.stop()
 
     def init_shutdown_no_activity(self):
         if self.shutdown_no_activity_timeout > 0:
-            self.log.info(_i18n("Will shut down after %d seconds with no kernels or terminals.",
-                          self.shutdown_no_activity_timeout))
+            self.log.info("Will shut down after %d seconds with no kernels or terminals.",
+                          self.shutdown_no_activity_timeout)
             pc = ioloop.PeriodicCallback(self.shutdown_no_activity, 60000)
             pc.start()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -145,6 +145,7 @@ JUPYTER_SERVICE_HANDLERS = dict(
     view=['jupyter_server.view.handlers']
 )
 
+
 #-----------------------------------------------------------------------------
 # Helper functions
 #-----------------------------------------------------------------------------
@@ -160,10 +161,12 @@ def random_ports(port, n):
     for i in range(n-5):
         yield max(1, port + random.randint(-2*n, 2*n))
 
+
 def load_handlers(name):
     """Load the (URL pattern, handler) tuples for each component."""
     mod = __import__(name, fromlist=['default_handlers'])
     return mod.default_handlers
+
 
 #-----------------------------------------------------------------------------
 # The Tornado web application
@@ -236,9 +239,9 @@ class ServerWebApplication(web.Application):
             template_path=template_path,
             static_path=jupyter_app.static_file_path,
             static_custom_path=jupyter_app.static_custom_path,
-            static_handler_class = FileFindHandler,
-            static_url_prefix = url_path_join(base_url, '/static/'),
-            static_handler_args = {
+            static_handler_class=FileFindHandler,
+            static_url_prefix=url_path_join(base_url, '/static/'),
+            static_handler_args={
                 # don't cache custom.js
                 'no_cache_paths': [url_path_join(base_url, 'static', 'custom')],
             },
@@ -340,8 +343,8 @@ class ServerWebApplication(web.Application):
             # set the URL that will be redirected from `/`
             handlers.append(
                 (r'/?', RedirectWithParams, {
-                    'url' : settings['default_url'],
-                    'permanent': False, # want 302, not 301
+                    'url': settings['default_url'],
+                    'permanent': False,  # want 302, not 301
                 })
             )
         else:
@@ -395,7 +398,7 @@ class JupyterPasswordApp(JupyterApp):
     def start(self):
         from .auth.security import set_password
         set_password(config_file=self.config_file)
-        self.log.info("Wrote hashed password to %s" % self.config_file)
+        self.log.info(_i18n("Wrote hashed password to %s" % self.config_file))
 
 
 def shutdown_server(server_info, timeout=5, log=None):
@@ -447,15 +450,15 @@ def shutdown_server(server_info, timeout=5, log=None):
 class JupyterServerStopApp(JupyterApp):
 
     version = __version__
-    description = "Stop currently running Jupyter server for a given port"
+    description = _i18n("Stop currently running Jupyter server for a given port")
 
     port = Integer(8888, config=True,
-        help="Port of the server to be killed. Default 8888")
+                   help=_i18n("Port of the server to be killed. Default 8888"))
 
     def parse_command_line(self, argv=None):
         super(JupyterServerStopApp, self).parse_command_line(argv)
         if self.extra_args:
-            self.port=int(self.extra_args[0])
+            self.port = int(self.extra_args[0])
 
     def shutdown_server(self, server):
         return shutdown_server(server, log=self.log)
@@ -480,7 +483,7 @@ class JupyterServerStopApp(JupyterApp):
 
 class JupyterServerListApp(JupyterApp):
     version = __version__
-    description=_i18n("List currently running notebook servers.")
+    description = _i18n("List currently running notebook servers.")
 
     flags = dict(
         jsonlist=({'JupyterServerListApp': {'jsonlist': True}},
@@ -490,7 +493,7 @@ class JupyterServerListApp(JupyterApp):
     )
 
     jsonlist = Bool(False, config=True,
-          help=_i18n("If True, the output will be a JSON list of objects, one per "
+            help=_i18n("If True, the output will be a JSON list of objects, one per "
                  "active notebook server, each with the details from the "
                  "relevant server info file."))
     json = Bool(False, config=True,
@@ -512,6 +515,7 @@ class JupyterServerListApp(JupyterApp):
                 if serverinfo.get('token'):
                     url = url + '?token=%s' % serverinfo['token']
                 print(url, "::", serverinfo['root_dir'])
+
 
 #-----------------------------------------------------------------------------
 # Aliases and Flags
@@ -539,11 +543,11 @@ flags["debug"] = (
 )
 flags['autoreload'] = (
     {'ServerApp': {'autoreload': True}},
-    """Autoreload the webapp
+    _i18n("""Autoreload the webapp
     Enable reloading of the tornado webapp and all imported Python packages
     when any changes are made to any Python src files in server or
     extensions.
-    """
+    """)
 )
 
 
@@ -567,6 +571,7 @@ aliases.update({
     'pylab': 'ServerApp.pylab',
     'gateway-url': 'GatewayClient.url',
 })
+
 
 #-----------------------------------------------------------------------------
 # ServerApp
@@ -628,25 +633,25 @@ class ServerApp(JupyterApp):
 
     # file to be opened in the Jupyter server
     file_to_run = Unicode('',
-        help="Open the named file when the application is launched."
+        help=_i18n("Open the named file when the application is launched.")
     ).tag(config=True)
 
     file_url_prefix = Unicode('notebooks',
-        help="The URL prefix where files are opened directly."
+        help=_i18n("The URL prefix where files are opened directly.")
     ).tag(config=True)
 
     # Network related information
     allow_origin = Unicode('', config=True,
-        help="""Set the Access-Control-Allow-Origin header
+        help=_i18n("""Set the Access-Control-Allow-Origin header
 
         Use '*' to allow any origin to access your server.
 
         Takes precedence over allow_origin_pat.
-        """
+        """)
     )
 
     allow_origin_pat = Unicode('', config=True,
-        help="""Use a regular expression for the Access-Control-Allow-Origin header
+        help=_i18n("""Use a regular expression for the Access-Control-Allow-Origin header
 
         Requests from an origin matching the expression will get replies with:
 
@@ -655,7 +660,7 @@ class ServerApp(JupyterApp):
         where `origin` is the origin of the request.
 
         Ignored if allow_origin is set.
-        """
+        """)
     )
 
     allow_credentials = Bool(False, config=True,
@@ -743,13 +748,13 @@ class ServerApp(JupyterApp):
         return os.path.join(self.runtime_dir, 'jupyter_cookie_secret')
 
     cookie_secret = Bytes(b'', config=True,
-        help="""The random bytes used to secure cookies.
+        help=_i18n("""The random bytes used to secure cookies.
         By default this is a new random number every time you start the server.
         Set it to a value in a config file to enable logins to persist across server sessions.
 
         Note: Cookie secrets should be kept private, do not share config files with
         cookie_secret stored in plaintext (you can read the value from a file).
-        """
+        """)
     )
 
     @default('cookie_secret')
@@ -800,12 +805,13 @@ class ServerApp(JupyterApp):
             return binascii.hexlify(os.urandom(24)).decode('ascii')
 
     min_open_files_limit = Integer(config=True,
-        help="""
+        help=_i18n("""
         Gets or sets a lower bound on the open file handles process resource
         limit. This may need to be increased if you run into an
         OSError: [Errno 24] Too many open files.
         This is not applicable when running on Windows.
         """)
+    )
 
     @default('min_open_files_limit')
     def _default_min_open_files_limit(self):
@@ -824,21 +830,21 @@ class ServerApp(JupyterApp):
         return soft
 
     max_body_size = Integer(512 * 1024 * 1024, config=True,
-        help="""
+        help=_i18n("""
         Sets the maximum allowed size of the client request body, specified in
         the Content-Length request header field. If the size in a request
         exceeds the configured value, a malformed HTTP message is returned to
         the client.
 
         Note: max_body_size is applied even in streaming mode.
-        """
+        """)
     )
 
     max_buffer_size = Integer(512 * 1024 * 1024, config=True,
-        help="""
+        help=_i18n("""
         Gets or sets the maximum amount of memory, in bytes, that is allocated
         for use by the buffer manager.
-        """
+        """)
     )
 
     @observe('token')
@@ -846,41 +852,41 @@ class ServerApp(JupyterApp):
         self._token_generated = False
 
     password = Unicode(u'', config=True,
-                      help="""Hashed password to use for web authentication.
+                      help=_i18n("""Hashed password to use for web authentication.
 
                       To generate, type in a python/IPython shell:
 
                         from jupyter_server.auth import passwd; passwd()
 
                       The string should be of the form type:salt:hashed-password.
-                      """
+                      """)
     )
 
     password_required = Bool(False, config=True,
-                      help="""Forces users to use a password for the Jupyter server.
+                      help=_i18n("""Forces users to use a password for the Jupyter server.
                       This is useful in a multi user environment, for instance when
                       everybody in the LAN can access each other's machine through ssh.
 
                       In such a case, serving on localhost is not secure since
                       any user can connect to the Jupyter server via ssh.
 
-                      """
+                      """)
     )
 
     allow_password_change = Bool(True, config=True,
-                    help="""Allow password to be changed at login for the Jupyter server.
+                    help=_i18n("""Allow password to be changed at login for the Jupyter server.
 
                     While loggin in with a token, the Jupyter server UI will give the opportunity to
                     the user to enter a new password at the same time that will replace
                     the token login mechanism.
 
                     This can be set to false to prevent changing password from the UI/API.
-                    """
+                    """)
     )
 
 
     disable_check_xsrf = Bool(False, config=True,
-        help="""Disable cross-site-request-forgery protection
+        help=_i18n("""Disable cross-site-request-forgery protection
 
         Jupyter notebook 4.3.1 introduces protection from cross-site request forgeries,
         requiring API requests to either:
@@ -892,11 +898,11 @@ class ServerApp(JupyterApp):
         completely without authentication.
         These services can disable all authentication and security checks,
         with the full knowledge of what that implies.
-        """
+        """)
     )
 
     allow_remote_access = Bool(config=True,
-       help="""Allow requests where the Host header doesn't point to a local server
+       help=_i18n("""Allow requests where the Host header doesn't point to a local server
 
        By default, requests get a 403 forbidden response if the 'Host' header
        shows that the browser thinks it's on a non-local domain.
@@ -909,6 +915,7 @@ class ServerApp(JupyterApp):
        Local IP addresses (such as 127.0.0.1 and ::1) are allowed as local,
        along with hostnames configured in local_hostnames.
        """)
+    )
 
     @default('allow_remote_access')
     def _default_allow_remote(self):
@@ -945,7 +952,7 @@ class ServerApp(JupyterApp):
             return not addr.is_loopback
 
     use_redirect_file = Bool(True, config=True,
-        help="""Disable launching browser by redirect file
+        help=_i18n("""Disable launching browser by redirect file
      For versions of notebook > 5.7.2, a security feature measure was added that
      prevented the authentication token used to launch the browser from being visible.
      This feature makes it difficult for other users on a multi-user system from
@@ -957,32 +964,34 @@ class ServerApp(JupyterApp):
 
      Disabling this setting to False will disable this behavior, allowing the browser
      to launch by using a URL and visible token (as before).
-     """
+     """)
     )
 
     local_hostnames = List(Unicode(), ['localhost'], config=True,
-       help="""Hostnames to allow as local when allow_remote_access is False.
+       help=_i18n("""Hostnames to allow as local when allow_remote_access is False.
 
        Local IP addresses (such as 127.0.0.1 and ::1) are automatically accepted
        as local as well.
-       """
+       """)
     )
 
     open_browser = Bool(False, config=True,
-                        help="""Whether to open in a browser after starting.
+                        help=_i18n("""Whether to open in a browser after starting.
                         The specific browser used is platform dependent and
                         determined by the python standard library `webbrowser`
                         module, unless it is overridden using the --browser
                         (ServerApp.browser) configuration option.
                         """)
+    )
 
     browser = Unicode(u'', config=True,
-                      help="""Specify what command to use to invoke a web
+                      help=_i18n("""Specify what command to use to invoke a web
                       browser when starting the server. If not specified, the
                       default browser will be determined by the `webbrowser`
                       standard library module, which allows setting of the
                       BROWSER environment variable to override it.
                       """)
+    )
 
     webbrowser_open_new = Integer(2, config=True,
         help=_i18n("""Specify where to open the server on startup. This is the
@@ -1038,11 +1047,11 @@ class ServerApp(JupyterApp):
     )
 
     base_url = Unicode('/', config=True,
-                       help='''The base URL for the Jupyter server.
+                       help=_i18n('''The base URL for the Jupyter server.
 
                        Leading and trailing slashes can be omitted,
                        and will automatically be added.
-                       ''')
+                       '''))
 
     @validate('base_url')
     def _update_base_url(self, proposal):
@@ -1054,10 +1063,10 @@ class ServerApp(JupyterApp):
         return value
 
     extra_static_paths = List(Unicode(), config=True,
-        help="""Extra paths to search for serving static files.
+        help=_i18n("""Extra paths to search for serving static files.
 
         This allows adding javascript/css to be available from the Jupyter server machine,
-        or overriding individual files in the IPython"""
+        or overriding individual files in the IPython""")
     )
 
     @property
@@ -1093,15 +1102,15 @@ class ServerApp(JupyterApp):
     )
 
     websocket_url = Unicode("", config=True,
-        help="""The base URL for websockets,
+        help=_i18n("""The base URL for websockets,
         if it differs from the HTTP server (hint: it almost certainly doesn't).
 
         Should be in the form of an HTTP origin: ws[s]://hostname[:port]
-        """
+        """)
     )
 
     quit_button = Bool(True, config=True,
-        help="""If True, display controls to shut down the Jupyter server, such as menu items or buttons."""
+        help=_i18n("""If True, display controls to shut down the Jupyter server, such as menu items or buttons.""")
     )
 
     # REMOVE in VERSION 2.0
@@ -1165,13 +1174,13 @@ class ServerApp(JupyterApp):
     kernel_spec_manager_class = Type(
         default_value=KernelSpecManager,
         config=True,
-        help="""
+        help=_i18n("""
         The kernel spec manager class to use. Should be a subclass
         of `jupyter_client.kernelspec.KernelSpecManager`.
 
         The Api of KernelSpecManager is provisional and might change
         without warning between this version of Jupyter and the next stable one.
-        """
+        """)
     )
 
     login_handler_class = Type(
@@ -1273,7 +1282,7 @@ class ServerApp(JupyterApp):
             # If we receive a non-absolute path, make it absolute.
             value = os.path.abspath(value)
         if not os.path.isdir(value):
-            raise TraitError(trans.gettext("No such directory: '%r'") % value)
+            raise TraitError(_i18n("No such directory: '%r'") % value)
         return value
 
     @observe('root_dir')
@@ -1310,7 +1319,7 @@ class ServerApp(JupyterApp):
         check the message and data rate limits."""))
 
     shutdown_no_activity_timeout = Integer(0, config=True,
-        help=("Shut down the server after N seconds with no kernels or "
+        help=_i18n("Shut down the server after N seconds with no kernels or "
               "terminals running and no activity. "
               "This can be used together with culling idle kernels "
               "(MappingKernelManager.cull_idle_timeout) to "
@@ -1331,9 +1340,9 @@ class ServerApp(JupyterApp):
 
     authenticate_prometheus = Bool(
         True,
-        help=""""
+        help=_i18n("""
         Require authentication to access prometheus metrics.
-        """,
+        """),
         config=True
     )
 
@@ -1476,7 +1485,9 @@ class ServerApp(JupyterApp):
     def init_resources(self):
         """initialize system resources"""
         if resource is None:
-            self.log.debug('Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)')
+            self.log.debug(
+                _i18n('Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)')
+            )
             return
 
         old_soft, old_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -1486,7 +1497,7 @@ class ServerApp(JupyterApp):
             if hard < soft:
                 hard = soft
             self.log.debug(
-                'Raising open file limit: soft {}->{}; hard {}->{}'.format(old_soft, soft, old_hard, hard)
+                _i18n('Raising open file limit: soft {}->{}; hard {}->{}'.format(old_soft, soft, old_hard, hard))
             )
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
@@ -1703,17 +1714,17 @@ class ServerApp(JupyterApp):
 
         seconds_since_active = \
             (utcnow() - self.web_app.last_activity()).total_seconds()
-        self.log.debug("No activity for %d seconds.",
-                       seconds_since_active)
+        self.log.debug(_i18n("No activity for %d seconds.",
+                       seconds_since_active))
         if seconds_since_active > self.shutdown_no_activity_timeout:
-            self.log.info("No kernels or terminals for %d seconds; shutting down.",
-                          seconds_since_active)
+            self.log.info(_i18n("No kernels or terminals for %d seconds; shutting down.",
+                          seconds_since_active))
             self.stop()
 
     def init_shutdown_no_activity(self):
         if self.shutdown_no_activity_timeout > 0:
-            self.log.info("Will shut down after %d seconds with no kernels or terminals.",
-                          self.shutdown_no_activity_timeout)
+            self.log.info(_i18n("Will shut down after %d seconds with no kernels or terminals.",
+                          self.shutdown_no_activity_timeout))
             pc = ioloop.PeriodicCallback(self.shutdown_no_activity, 60000)
             pc.start()
 
@@ -1771,11 +1782,11 @@ class ServerApp(JupyterApp):
     @staticmethod
     def _init_asyncio_patch():
         """no longer needed with tornado 6.1"""
-        warnings.warn(
+        warnings.warn(_i18n(
             """ServerApp._init_asyncio_patch called, and is longer needed for """
             """tornado 6.1+, and will be removed in a future release.""",
             DeprecationWarning
-        )
+        ))
 
     @catch_config_error
     def initialize(self, argv=None, find_extensions=True, new_httpserver=True, starter_extension=None):
@@ -2138,6 +2149,8 @@ def list_running_servers(runtime_dir=None):
                     os.unlink(os.path.join(runtime_dir, file_name))
                 except OSError:
                     pass  # TODO: This should warn or log or something
+
+
 #-----------------------------------------------------------------------------
 # Main entry point
 #-----------------------------------------------------------------------------

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -27,7 +27,7 @@ from ipython_genutils.py3compat import getcwd, string_types
 from jupyter_core.paths import exists, is_hidden, is_file_hidden
 from jupyter_server import _tz as tz
 from jupyter_server.base.handlers import AuthenticatedFileHandler
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 
 try:
     from os.path import samefile
@@ -531,7 +531,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                                 (old_path, e)) from e
 
     def info_string(self):
-        return _("Serving notebooks from local directory: %s") % self.root_dir
+        return _i18n("Serving notebooks from local directory: %s") % self.root_dir
 
     def get_kernel_path(self, path, model=None):
         """Return the initial API path of  a kernel associated with a given notebook"""

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -30,7 +30,7 @@ from traitlets import (
     default,
 )
 from ipython_genutils.py3compat import string_types
-from jupyter_server.transutils import _
+from jupyter_server.transutils import _i18n
 from jupyter_server.utils import ensure_async
 
 
@@ -71,7 +71,7 @@ class ContentsManager(LoggingConfigurable):
         Glob patterns to hide in file and directory listings.
     """)
 
-    untitled_notebook = Unicode(_("Untitled"), config=True,
+    untitled_notebook = Unicode(_i18n("Untitled"), config=True,
         help="The base name used when creating untitled notebooks."
     )
 

--- a/jupyter_server/transutils.py
+++ b/jupyter_server/transutils.py
@@ -4,10 +4,18 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
+import warnings
 import gettext
+
+
+def _trans_gettext_deprecation_helper(*args, **kwargs):
+    warn_msg = "The alias `_()` will be deprecated. Use `_i18n()` instead."
+    warnings.warn(warn_msg, FutureWarning)
+    return trans.gettext(*args, **kwargs)
 
 
 # Set up message catalog access
 base_dir = os.path.realpath(os.path.join(__file__, '..', '..'))
 trans = gettext.translation('notebook', localedir=os.path.join(base_dir, 'notebook/i18n'), fallback=True)
+_ = _trans_gettext_deprecation_helper
 _i18n = trans.gettext

--- a/jupyter_server/transutils.py
+++ b/jupyter_server/transutils.py
@@ -10,4 +10,4 @@ import gettext
 # Set up message catalog access
 base_dir = os.path.realpath(os.path.join(__file__, '..', '..'))
 trans = gettext.translation('notebook', localedir=os.path.join(base_dir, 'notebook/i18n'), fallback=True)
-_ = trans.gettext
+_i18n = trans.gettext


### PR DESCRIPTION
Corresponds to https://github.com/jupyter-server/jupyter_server/issues/424

In this project, `_` is used as an alias for `trans.gettext` although `_` is commonly used as a placeholder for ignored variables or loop variables in Python.
In this PR, I'm trying to rename `_` to `_i18n` as discussed in #424, it would be clearer and more useful to avoid conflicts between these two uses.

P.S.
This is the first time for me to make a contribution, so I would appreciate it if you could kindly point out any inadequacies/advice 😉 

### TODO
- [ ] update `CONTRIBUTING.rst` since [the link](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html) is outdated.
- [x] ~~there are bunch of strings which are not given to `_i18n` in [serverapp.py](https://github.com/jupyter-server/jupyter_server/blob/master/jupyter_server/serverapp.py)~~