### PR TITLE
Correction in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.5.0](https://github.com/jupyter-server/jupyter_server/tree/1.5.0) (2021-02-22)
+## [1.4.1](https://github.com/jupyter-server/jupyter_server/tree/1.4.1) (2021-02-22)
 
 [Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/1.4.0...bc252d33de2f647f98d048dc32888f0a83f005ac)
 


### PR DESCRIPTION
The latest release was 1.4.1, not 1.5.0. The latest entry in the changelog reports the wrong version.