### PR TITLE
More complex handling of open_browser from extension applications

### DIFF
--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -45,11 +45,11 @@ jobs:
     - name: Run the tests
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |
-        pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
+        pytest -vv jupyter_server --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
     - name: Run the tests on pypy
       if: ${{ matrix.python-version == 'pypy3' }}
       run: |
-        pytest -vv
+        pytest -vv jupyter_server
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -45,11 +45,11 @@ jobs:
     - name: Run the tests
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |
-        pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
+        pytest -vv jupyter_server --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
     - name: Run the tests on pypy
       if: ${{ matrix.python-version == 'pypy3' }}
       run: |
-        pytest -vv
+        pytest -vv jupyter_server
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .

--- a/.github/workflows/python-windows.yml
+++ b/.github/workflows/python-windows.yml
@@ -49,7 +49,7 @@ jobs:
         # the file descriptions opened by the asyncio IOLoop.
         # This leads to a nasty, flaky race condition that we haven't
         # been able to solve.
-        pytest -vv -s
+        pytest -vv jupyter_server -s
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Launch with:
 To test an installed `jupyter_server`, run the following:
 
     $ pip install jupyter_server[test]
-    $ pytest --pyargs jupyter_server
+    $ pytest jupyter_server
 
 ## Contributing
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -154,7 +154,6 @@ class ExtensionApp(JupyterApp):
     # the default value to False if they don't offer a browser
     # based frontend.
     open_browser = Bool(
-        True,
         help="""Whether to open in a browser after starting.
         The specific browser used is platform dependent and
         determined by the python standard library `webbrowser`
@@ -162,6 +161,10 @@ class ExtensionApp(JupyterApp):
         (ServerApp.browser) configuration option.
         """
     ).tag(config=True)
+
+    @default('open_browser')
+    def _default_open_browser(self):
+        return self.serverapp.config["ServerApp"].get("open_browser", True)
 
     # The extension name used to name the jupyter config
     # file, jupyter_{name}_config.

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -426,3 +426,9 @@ def jp_create_notebook(jp_root_dir):
         nbtext = nbformat.writes(nb, version=4)
         nbpath.write_text(nbtext)
     return inner
+
+
+@pytest.fixture(autouse=True)
+def jp_server_cleanup():
+    yield
+    ServerApp.clear_instance()

--- a/jupyter_server/tests/extension/conftest.py
+++ b/jupyter_server/tests/extension/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from .mockextensions.app import MockExtensionApp
 
 
 mock_html = """
@@ -42,3 +43,9 @@ def config_file(jp_config_dir):
     f = jp_config_dir.joinpath("jupyter_mockextension_config.py")
     f.write_text("c.MockExtensionApp.mock_trait ='config from file'")
     return f
+
+
+@pytest.fixture(autouse=True)
+def jp_mockextension_cleanup():
+    yield
+    MockExtensionApp.clear_instance()

--- a/jupyter_server/tests/extension/mockextensions/app.py
+++ b/jupyter_server/tests/extension/mockextensions/app.py
@@ -47,6 +47,10 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
     mock_trait = Unicode('mock trait', config=True)
     loaded = False
 
+    @staticmethod
+    def get_extension_package():
+        return "jupyter_server.tests.extension.mockextensions"
+
     def initialize_handlers(self):
         self.handlers.append(('/mock', MockExtensionHandler))
         self.handlers.append(('/mock_template', MockExtensionTemplateHandler))

--- a/jupyter_server/tests/extension/test_app.py
+++ b/jupyter_server/tests/extension/test_app.py
@@ -1,5 +1,7 @@
 import pytest
+from traitlets.config import Config
 from jupyter_server.serverapp import ServerApp
+from .mockextensions.app import MockExtensionApp
 
 
 @pytest.fixture
@@ -67,3 +69,23 @@ def test_extensionapp_load_config_file(
     assert mock_extension.config_file_name == 'jupyter_mockextension_config'
     # Assert that the trait is updated by config file
     assert mock_extension.mock_trait == 'config from file'
+
+
+OPEN_BROWSER_COMBINATIONS = (
+    (True, {}),
+    (True, {'ServerApp': {'open_browser': True}}),
+    (False, {'ServerApp': {'open_browser': False}}),
+    (True, {'MockExtensionApp': {'open_browser': True}}),
+    (False, {'MockExtensionApp': {'open_browser': False}}),
+    (True, {'ServerApp': {'open_browser': True}, 'MockExtensionApp': {'open_browser': True}}),
+    (False, {'ServerApp': {'open_browser': True}, 'MockExtensionApp': {'open_browser': False}}),
+    (True, {'ServerApp': {'open_browser': False}, 'MockExtensionApp': {'open_browser': True}}),
+    (False, {'ServerApp': {'open_browser': False}, 'MockExtensionApp': {'open_browser': False}}),
+)
+
+@pytest.mark.parametrize(
+    'expected_value, config', OPEN_BROWSER_COMBINATIONS
+)
+def test_browser_open(monkeypatch, jp_environ, config, expected_value):
+    serverapp = MockExtensionApp.initialize_server(config=Config(config))
+    assert serverapp.open_browser == expected_value

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 # Exclude the example tests.
 norecursedirs = examples/*
-# Work around for https://github.com/pytest-dev/pytest/issues/4039
-addopts = --pyargs jupyter_server


### PR DESCRIPTION
This changes the default value open_browser in extension applications slightly.

Before this was set to `True` *always*. That means, even if `ServerApp.open_browser=False`, a browser was still opened. Now, the extension first checks if the server's `open_browser` trait was configured. If so, it uses this configured value; otherwise, it defaults to `True`.

In the case where *both* the starting extension application and the underlying server application receive a configuration value for `open_browser`, the extension application wins as you'd expect.

This PR also drops the `--pyargs` config from `pytest.ini` because it prevents you from running individual tests (always runs the whole test suite). Instead, it is advised to run `pytest <path to tests>`. Updated the README and GA workflows to reflect this change.