### PR TITLE
Port terminal culling from Notebook

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,4 +13,5 @@ dependencies:
   - sphinxcontrib_github_alt
   - sphinxcontrib-openapi
   - sphinxemoji
+  - terminado
   - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1547,7 +1547,7 @@ class ServerApp(JupyterApp):
 
         try:
             from .terminal import initialize
-            initialize(self.web_app, self.root_dir, self.connection_url, self.terminado_settings, self)
+            initialize(parent=self)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
             self.log.warning(_i18n("Terminals not available (error was %s)"), e)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -83,6 +83,7 @@ from .gateway.managers import GatewayKernelManager, GatewayKernelSpecManager, Ga
 from .auth.login import LoginHandler
 from .auth.logout import LogoutHandler
 from .base.handlers import FileFindHandler
+from .terminal import TerminalManager
 
 from traitlets.config import Config
 from traitlets.config.application import catch_config_error, boolean_flag
@@ -587,7 +588,7 @@ class ServerApp(JupyterApp):
     classes = [
             KernelManager, Session, MappingKernelManager, KernelSpecManager, AsyncMappingKernelManager,
             ContentsManager, FileContentsManager, AsyncContentsManager, AsyncFileContentsManager, NotebookNotary,
-            GatewayKernelManager, GatewayKernelSpecManager, GatewaySessionManager, GatewayClient
+            TerminalManager, GatewayKernelSpecManager, GatewaySessionManager, GatewayClient
         ]
 
     subcommands = dict(
@@ -1546,7 +1547,7 @@ class ServerApp(JupyterApp):
 
         try:
             from .terminal import initialize
-            initialize(self.web_app, self.root_dir, self.connection_url, self.terminado_settings)
+            initialize(self.web_app, self.root_dir, self.connection_url, self.terminado_settings, self)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
             self.log.warning(_i18n("Terminals not available (error was %s)"), e)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1564,7 +1564,7 @@ class ServerApp(JupyterApp):
 
         try:
             from .terminal import initialize
-            initialize(server_app=self)
+            initialize(self.web_app, self.root_dir, self.connection_url, self.terminado_settings)
             self.terminals_available = True
         except ImportError as e:
             self.log.warning(_i18n("Terminals not available (error was %s)"), e)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1547,7 +1547,7 @@ class ServerApp(JupyterApp):
 
         try:
             from .terminal import initialize
-            initialize(parent=self)
+            initialize(server_app=self)
             self.web_app.settings['terminals_available'] = True
         except ImportError as e:
             self.log.warning(_i18n("Terminals not available (error was %s)"), e)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1847,6 +1847,22 @@ class ServerApp(JupyterApp):
         self.log.info(kernel_msg % n_kernels)
         run_sync(self.kernel_manager.shutdown_all())
 
+    def cleanup_terminals(self):
+        """Shutdown all terminals.
+
+        The terminals will shutdown themselves when this process no longer exists,
+        but explicit shutdown allows the TerminalManager to cleanup.
+        """
+        try:
+            terminal_manager = self.web_app.settings['terminal_manager']
+        except KeyError:
+            return  # Terminals not enabled
+
+        n_terminals = len(terminal_manager.list())
+        terminal_msg = trans.ngettext('Shutting down %d terminal', 'Shutting down %d terminals', n_terminals)
+        self.log.info(terminal_msg % n_terminals)
+        run_sync(terminal_manager.terminate_all())
+
     def running_server_info(self, kernel_count=True):
         "Return the current working directory and the server url information"
         info = self.contents_manager.info_string() + "\n"
@@ -2077,6 +2093,7 @@ class ServerApp(JupyterApp):
         self.remove_server_info_file()
         self.remove_browser_open_files()
         self.cleanup_kernels()
+        self.cleanup_terminals()
 
     def start_ioloop(self):
         """Start the IO Loop."""

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -568,7 +568,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Terminal_ID'
+              $ref: '#/definitions/Terminal'
         403:
           description: Forbidden to access
         404:
@@ -582,7 +582,7 @@ paths:
         200:
           description: Succesfully created a new terminal
           schema:
-            $ref: '#/definitions/Terminal_ID'
+            $ref: '#/definitions/Terminal'
         403:
           description: Forbidden to access
         404:
@@ -599,7 +599,7 @@ paths:
         200:
           description: Terminal session with given id
           schema:
-            $ref: '#/definitions/Terminal_ID'
+            $ref: '#/definitions/Terminal'
         403:
           description: Forbidden to access
         404:
@@ -845,12 +845,18 @@ definitions:
         type: string
         description: Last modified timestamp
         format: dateTime
-  Terminal_ID:
-    description: A Terminal_ID object
+  Terminal:
+    description: A Terminal object
     type: object
     required:
       - name
     properties:
       name:
         type: string
-        description: name of terminal ID
+        description: name of terminal
+      last_activity:
+        type: string
+        description: |
+          ISO 8601 timestamp for the last-seen activity on this terminal.  Use
+          this to identify which terminals have been inactive since a given time.
+          Timestamps will be UTC, indicated 'Z' suffix.

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -8,14 +8,14 @@ if not check_version(terminado.__version__, '0.8.3'):
     raise ImportError("terminado >= 0.8.3 required, found %s" % terminado.__version__)
 
 from ipython_genutils.py3compat import which
-from terminado import NamedTermManager
 from tornado.log import app_log
 from jupyter_server.utils import url_path_join as ujoin
 from . import api_handlers
-from .handlers import TermSocket
+from .handlers import TerminalHandler, TermSocket
+from .terminalmanager import TerminalManager
 
 
-def initialize(webapp, root_dir, connection_url, settings):
+def initialize(webapp, root_dir, connection_url, settings, parent):
     if os.name == 'nt':
         default_shell = 'powershell.exe'
     else:
@@ -33,11 +33,12 @@ def initialize(webapp, root_dir, connection_url, settings):
     # the user has specifically set a preferred shell command.
     if os.name != 'nt' and shell_override is None and not sys.stdout.isatty():
         shell.append('-l')
-    terminal_manager = webapp.settings['terminal_manager'] = NamedTermManager(
+    terminal_manager = webapp.settings['terminal_manager'] = TerminalManager(
         shell_command=shell,
         extra_env={'JUPYTER_SERVER_ROOT': root_dir,
                    'JUPYTER_SERVER_URL': connection_url,
                    },
+        parent=parent,
     )
     terminal_manager.log = app_log
     base_url = webapp.settings['base_url']

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -10,7 +10,7 @@ if not check_version(terminado.__version__, '0.8.3'):
 from ipython_genutils.py3compat import which
 from jupyter_server.utils import url_path_join as ujoin
 from . import api_handlers
-from .handlers import TerminalHandler, TermSocket
+from .handlers import TermSocket
 from .terminalmanager import TerminalManager
 
 
@@ -42,7 +42,6 @@ def initialize(webapp, root_dir, connection_url, settings):
     terminal_manager.log = webapp.settings['serverapp'].log
     base_url = webapp.settings['base_url']
     handlers = [
-        (ujoin(base_url, r"/terminals/(\w+)"), TerminalHandler),
         (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
              {'term_manager': terminal_manager}),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -15,12 +15,12 @@ from .handlers import TerminalHandler, TermSocket
 from .terminalmanager import TerminalManager
 
 
-def initialize(parent):
+def initialize(server_app):
     if os.name == 'nt':
         default_shell = 'powershell.exe'
     else:
         default_shell = which('sh')
-    shell_override = parent.terminado_settings.get('shell_command')
+    shell_override = server_app.terminado_settings.get('shell_command')
     shell = (
         [os.environ.get('SHELL') or default_shell]
         if shell_override is None
@@ -33,19 +33,19 @@ def initialize(parent):
     # the user has specifically set a preferred shell command.
     if os.name != 'nt' and shell_override is None and not sys.stdout.isatty():
         shell.append('-l')
-    terminal_manager = parent.web_app.settings['terminal_manager'] = TerminalManager(
+    terminal_manager = server_app.web_app.settings['terminal_manager'] = TerminalManager(
         shell_command=shell,
-        extra_env={'JUPYTER_SERVER_ROOT': parent.root_dir,
-                   'JUPYTER_SERVER_URL': parent.connection_url,
+        extra_env={'JUPYTER_SERVER_ROOT': server_app.root_dir,
+                   'JUPYTER_SERVER_URL': server_app.connection_url,
                    },
-        parent=parent,
+        parent=server_app,
     )
-    terminal_manager.log = parent.log
-    base_url = parent.web_app.settings['base_url']
+    terminal_manager.log = server_app.log
+    base_url = server_app.web_app.settings['base_url']
     handlers = [
         (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
              {'term_manager': terminal_manager}),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),
         (ujoin(base_url, r"/api/terminals/(\w+)"), api_handlers.TerminalHandler),
     ]
-    parent.web_app.add_handlers(".*$", handlers)
+    server_app.web_app.add_handlers(".*$", handlers)

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -8,7 +8,6 @@ if not check_version(terminado.__version__, '0.8.3'):
     raise ImportError("terminado >= 0.8.3 required, found %s" % terminado.__version__)
 
 from ipython_genutils.py3compat import which
-from tornado.log import app_log
 from jupyter_server.utils import url_path_join as ujoin
 from . import api_handlers
 from .handlers import TerminalHandler, TermSocket

--- a/jupyter_server/terminal/api_handlers.py
+++ b/jupyter_server/terminal/api_handlers.py
@@ -1,7 +1,6 @@
 import json
 from tornado import web
 from ..base.handlers import APIHandler
-from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 
 
 
@@ -9,25 +8,16 @@ class TerminalRootHandler(APIHandler):
 
     @web.authenticated
     def get(self):
-        tm = self.terminal_manager
-        terms = [{'name': name} for name in tm.terminals]
-        self.finish(json.dumps(terms))
-
-        # Update the metric below to the length of the list 'terms'
-        TERMINAL_CURRENTLY_RUNNING_TOTAL.set(
-            len(terms)
-        )
+        models = self.terminal_manager.list()
+        self.finish(json.dumps(models))
 
     @web.authenticated
     def post(self):
         """POST /terminals creates a new terminal and redirects to it"""
         data = self.get_json_body() or {}
 
-        name, _ = self.terminal_manager.new_named_terminal(**data)
-        self.finish(json.dumps({'name': name}))
-
-        # Increase the metric by one because a new terminal was created
-        TERMINAL_CURRENTLY_RUNNING_TOTAL.inc()
+        model = self.terminal_manager.create(**data)
+        self.finish(json.dumps(model))
 
 
 class TerminalHandler(APIHandler):
@@ -35,23 +25,11 @@ class TerminalHandler(APIHandler):
 
     @web.authenticated
     def get(self, name):
-        tm = self.terminal_manager
-        if name in tm.terminals:
-            self.finish(json.dumps({'name': name}))
-        else:
-            raise web.HTTPError(404, "Terminal not found: %r" % name)
+        model = self.terminal_manager.get(name)
+        self.finish(json.dumps(model))
 
     @web.authenticated
     async def delete(self, name):
-        tm = self.terminal_manager
-        if name in tm.terminals:
-            await tm.terminate(name, force=True)
-            self.set_status(204)
-            self.finish()
-
-            # Decrease the metric below by one
-            # because a terminal has been shutdown
-            TERMINAL_CURRENTLY_RUNNING_TOTAL.dec()
-
-        else:
-            raise web.HTTPError(404, "Terminal not found: %r" % name)
+        await self.terminal_manager.terminate(name, force=True)
+        self.set_status(204)
+        self.finish()

--- a/jupyter_server/terminal/api_handlers.py
+++ b/jupyter_server/terminal/api_handlers.py
@@ -3,7 +3,6 @@ from tornado import web
 from ..base.handlers import APIHandler
 
 
-
 class TerminalRootHandler(APIHandler):
 
     @web.authenticated

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -11,14 +11,6 @@ from ..base.handlers import JupyterHandler
 from ..base.zmqhandlers import WebSocketMixin
 
 
-class TerminalHandler(JupyterHandler):
-    """Render the terminal interface."""
-    @web.authenticated
-    def get(self, term_name):
-        self.write(self.render_template('terminal.html',
-                   ws_path="terminals/websocket/%s" % term_name))
-
-
 class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
 
     def origin_check(self):

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -6,19 +6,18 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import warnings
+import terminado
 
 from datetime import timedelta
 from jupyter_server._tz import utcnow, isoformat
-from terminado import NamedTermManager
 from tornado import web
 from tornado.ioloop import IOLoop, PeriodicCallback
-from traitlets import Integer, validate
+from traitlets import Integer
 from traitlets.config import LoggingConfigurable
 from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 
 
-class TerminalManager(LoggingConfigurable, NamedTermManager):
+class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
     """  """
 
     _culler_callback = None

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -1,0 +1,140 @@
+"""A MultiTerminalManager for use in the notebook webserver
+- raises HTTPErrors
+- creates REST API models
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+from datetime import timedelta
+from notebook._tz import utcnow, isoformat
+from terminado import NamedTermManager
+from tornado import web
+from tornado.ioloop import IOLoop, PeriodicCallback
+from traitlets import Integer
+from traitlets.config import Configurable
+from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
+
+
+class TerminalManager(Configurable, NamedTermManager):
+    """  """
+
+    _culler_callback = None
+
+    _initialized_culler = False
+
+    cull_inactive_timeout = Integer(0, config=True,
+                                    help="""Timeout (in seconds) in which a terminal has been inactive and ready to be culled.
+        Values of 0 or lower disable culling."""
+                                    )
+
+    cull_interval_default = 300  # 5 minutes
+    cull_interval = Integer(cull_interval_default, config=True,
+        help="""The interval (in seconds) on which to check for terminals exceeding the inactive timeout value."""
+                            )
+
+    # -------------------------------------------------------------------------
+    # Methods for managing terminals
+    # -------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        super(TerminalManager, self).__init__(*args, **kwargs)
+
+    def create(self):
+        name, term = self.new_named_terminal()
+        # Monkey-patch last-activity, similar to kernels.  Should we need
+        # more functionality per terminal, we can look into possible sub-
+        # classing or containment then.
+        term.last_activity = utcnow()
+        model = self.terminal_model(name)
+        # Increase the metric by one because a new terminal was created
+        TERMINAL_CURRENTLY_RUNNING_TOTAL.inc()
+        # Ensure culler is initialized
+        self.initialize_culler()
+        return model
+
+    def get(self, name):
+        model = self.terminal_model(name)
+        return model
+
+    def list(self):
+        models = [self.terminal_model(name) for name in self.terminals]
+
+        # Update the metric below to the length of the list 'terms'
+        TERMINAL_CURRENTLY_RUNNING_TOTAL.set(
+            len(models)
+        )
+        return models
+
+    async def terminate(self, name, force=False):
+        self._check_terminal(name)
+        await super(TerminalManager, self).terminate(name, force=force)
+
+        # Decrease the metric below by one
+        # because a terminal has been shutdown
+        TERMINAL_CURRENTLY_RUNNING_TOTAL.dec()
+
+    def terminal_model(self, name):
+        """Return a JSON-safe dict representing a terminal.
+        For use in representing terminals in the JSON APIs.
+        """
+        self._check_terminal(name)
+        term = self.terminals[name]
+        model = {
+            "name": name,
+            "last_activity": isoformat(term.last_activity),
+        }
+        return model
+
+    def _check_terminal(self, name):
+        """Check a that terminal 'name' exists and raise 404 if not."""
+        if name not in self.terminals:
+            raise web.HTTPError(404, u'Terminal not found: %s' % name)
+
+    def initialize_culler(self):
+        """Start culler if 'cull_inactive_timeout' is greater than zero.
+        Regardless of that value, set flag that we've been here.
+        """
+        if not self._initialized_culler and self.cull_inactive_timeout > 0:
+            if self._culler_callback is None:
+                loop = IOLoop.current()
+                if self.cull_interval <= 0:  # handle case where user set invalid value
+                    self.log.warning("Invalid value for 'cull_interval' detected (%s) - using default value (%s).",
+                        self.cull_interval, self.cull_interval_default)
+                    self.cull_interval = self.cull_interval_default
+                self._culler_callback = PeriodicCallback(
+                    self.cull_terminals, 1000*self.cull_interval)
+                self.log.info("Culling terminals with inactivity > %s seconds at %s second intervals ...",
+                              self.cull_inactive_timeout, self.cull_interval)
+                self._culler_callback.start()
+
+        self._initialized_culler = True
+
+    async def cull_terminals(self):
+        self.log.debug("Polling every %s seconds for terminals inactive for > %s seconds...",
+                       self.cull_interval, self.cull_inactive_timeout)
+        # Create a separate list of terminals to avoid conflicting updates while iterating
+        for name in list(self.terminals):
+            try:
+                await self.cull_inactive_terminal(name)
+            except Exception as e:
+                self.log.exception("The following exception was encountered while checking the "
+                                   "activity of terminal {}: {}".format(name, e))
+
+    async def cull_inactive_terminal(self, name):
+        try:
+            term = self.terminals[name]
+        except KeyError:
+            return  # KeyErrors are somewhat expected since the terminal can be terminated as the culling check is made.
+
+        self.log.debug("name=%s, last_activity=%s", name, term.last_activity)
+        if hasattr(term, 'last_activity'):
+            dt_now = utcnow()
+            dt_inactive = dt_now - term.last_activity
+            # Compute idle properties
+            is_time = dt_inactive > timedelta(seconds=self.cull_inactive_timeout)
+            # Cull the kernel if all three criteria are met
+            if (is_time):
+                inactivity = int(dt_inactive.total_seconds())
+                self.log.warning("Culling terminal '%s' due to %s seconds of inactivity.", name, inactivity)
+                await self.terminate(name, force=True)

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -8,7 +8,7 @@
 
 
 from datetime import timedelta
-from notebook._tz import utcnow, isoformat
+from jupyter_server._tz import utcnow, isoformat
 from terminado import NamedTermManager
 from tornado import web
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -40,8 +40,9 @@ class TerminalManager(Configurable, NamedTermManager):
     def __init__(self, *args, **kwargs):
         super(TerminalManager, self).__init__(*args, **kwargs)
 
-    def create(self):
-        name, term = self.new_named_terminal()
+    def create(self, **kwargs):
+        """Create a new terminal."""
+        name, term = self.new_named_terminal(**kwargs)
         # Monkey-patch last-activity, similar to kernels.  Should we need
         # more functionality per terminal, we can look into possible sub-
         # classing or containment then.
@@ -50,14 +51,16 @@ class TerminalManager(Configurable, NamedTermManager):
         # Increase the metric by one because a new terminal was created
         TERMINAL_CURRENTLY_RUNNING_TOTAL.inc()
         # Ensure culler is initialized
-        self.initialize_culler()
+        self._initialize_culler()
         return model
 
     def get(self, name):
+        """Get terminal 'name'."""
         model = self.terminal_model(name)
         return model
 
     def list(self):
+        """Get a list of all running terminals."""
         models = [self.terminal_model(name) for name in self.terminals]
 
         # Update the metric below to the length of the list 'terms'
@@ -67,12 +70,19 @@ class TerminalManager(Configurable, NamedTermManager):
         return models
 
     async def terminate(self, name, force=False):
+        """Terminate terminal 'name'."""
         self._check_terminal(name)
         await super(TerminalManager, self).terminate(name, force=force)
 
         # Decrease the metric below by one
         # because a terminal has been shutdown
         TERMINAL_CURRENTLY_RUNNING_TOTAL.dec()
+
+    async def terminate_all(self):
+        """Terminate all terminals."""
+        terms = [name for name in self.terminals]
+        for term in terms:
+            await self.terminate(term, force=True)
 
     def terminal_model(self, name):
         """Return a JSON-safe dict representing a terminal.
@@ -91,7 +101,7 @@ class TerminalManager(Configurable, NamedTermManager):
         if name not in self.terminals:
             raise web.HTTPError(404, u'Terminal not found: %s' % name)
 
-    def initialize_culler(self):
+    def _initialize_culler(self):
         """Start culler if 'cull_inactive_timeout' is greater than zero.
         Regardless of that value, set flag that we've been here.
         """
@@ -103,25 +113,25 @@ class TerminalManager(Configurable, NamedTermManager):
                         self.cull_interval, self.cull_interval_default)
                     self.cull_interval = self.cull_interval_default
                 self._culler_callback = PeriodicCallback(
-                    self.cull_terminals, 1000*self.cull_interval)
+                    self._cull_terminals, 1000 * self.cull_interval)
                 self.log.info("Culling terminals with inactivity > %s seconds at %s second intervals ...",
                               self.cull_inactive_timeout, self.cull_interval)
                 self._culler_callback.start()
 
         self._initialized_culler = True
 
-    async def cull_terminals(self):
+    async def _cull_terminals(self):
         self.log.debug("Polling every %s seconds for terminals inactive for > %s seconds...",
                        self.cull_interval, self.cull_inactive_timeout)
         # Create a separate list of terminals to avoid conflicting updates while iterating
         for name in list(self.terminals):
             try:
-                await self.cull_inactive_terminal(name)
+                await self._cull_inactive_terminal(name)
             except Exception as e:
                 self.log.exception("The following exception was encountered while checking the "
                                    "activity of terminal {}: {}".format(name, e))
 
-    async def cull_inactive_terminal(self, name):
+    async def _cull_inactive_terminal(self, name):
         try:
             term = self.terminals[name]
         except KeyError:

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -6,13 +6,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import warnings
 
 from datetime import timedelta
 from jupyter_server._tz import utcnow, isoformat
 from terminado import NamedTermManager
 from tornado import web
 from tornado.ioloop import IOLoop, PeriodicCallback
-from traitlets import Integer
+from traitlets import Integer, validate
 from traitlets.config import Configurable
 from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 
@@ -25,7 +26,7 @@ class TerminalManager(Configurable, NamedTermManager):
     _initialized_culler = False
 
     cull_inactive_timeout = Integer(0, config=True,
-                                    help="""Timeout (in seconds) in which a terminal has been inactive and ready to be culled.
+        help="""Timeout (in seconds) in which a terminal has been inactive and ready to be culled.
         Values of 0 or lower disable culling."""
                                     )
 
@@ -33,6 +34,15 @@ class TerminalManager(Configurable, NamedTermManager):
     cull_interval = Integer(cull_interval_default, config=True,
         help="""The interval (in seconds) on which to check for terminals exceeding the inactive timeout value."""
                             )
+
+    @validate('cull_interval')
+    def _cull_interval_validate(self, proposal):
+        value = proposal['value']
+        if value <= 0:
+            warnings.warn("Invalid value for 'cull_interval' detected ({}) - using default value ({}).".
+                          format(value, self.cull_interval_default))
+            value = self.cull_interval_default
+        return value
 
     # -------------------------------------------------------------------------
     # Methods for managing terminals
@@ -47,7 +57,7 @@ class TerminalManager(Configurable, NamedTermManager):
         # more functionality per terminal, we can look into possible sub-
         # classing or containment then.
         term.last_activity = utcnow()
-        model = self.terminal_model(name)
+        model = self.get_terminal_model(name)
         # Increase the metric by one because a new terminal was created
         TERMINAL_CURRENTLY_RUNNING_TOTAL.inc()
         # Ensure culler is initialized
@@ -56,12 +66,12 @@ class TerminalManager(Configurable, NamedTermManager):
 
     def get(self, name):
         """Get terminal 'name'."""
-        model = self.terminal_model(name)
+        model = self.get_terminal_model(name)
         return model
 
     def list(self):
         """Get a list of all running terminals."""
-        models = [self.terminal_model(name) for name in self.terminals]
+        models = [self.get_terminal_model(name) for name in self.terminals]
 
         # Update the metric below to the length of the list 'terms'
         TERMINAL_CURRENTLY_RUNNING_TOTAL.set(
@@ -84,7 +94,7 @@ class TerminalManager(Configurable, NamedTermManager):
         for term in terms:
             await self.terminate(term, force=True)
 
-    def terminal_model(self, name):
+    def get_terminal_model(self, name):
         """Return a JSON-safe dict representing a terminal.
         For use in representing terminals in the JSON APIs.
         """
@@ -108,10 +118,6 @@ class TerminalManager(Configurable, NamedTermManager):
         if not self._initialized_culler and self.cull_inactive_timeout > 0:
             if self._culler_callback is None:
                 loop = IOLoop.current()
-                if self.cull_interval <= 0:  # handle case where user set invalid value
-                    self.log.warning("Invalid value for 'cull_interval' detected (%s) - using default value (%s).",
-                        self.cull_interval, self.cull_interval_default)
-                    self.cull_interval = self.cull_interval_default
                 self._culler_callback = PeriodicCallback(
                     self._cull_terminals, 1000 * self.cull_interval)
                 self.log.info("Culling terminals with inactivity > %s seconds at %s second intervals ...",

--- a/jupyter_server/tests/test_terminal.py
+++ b/jupyter_server/tests/test_terminal.py
@@ -5,6 +5,9 @@ import json
 import asyncio
 import sys
 
+from tornado.httpclient import HTTPClientError
+from traitlets.config import Config
+
 # Skip this whole module on Windows. The terminal API leads
 # to timeouts on Windows CI.
 if sys.platform.startswith('win'):
@@ -30,12 +33,42 @@ def terminal_path(tmp_path):
     shutil.rmtree(str(subdir), ignore_errors=True)
 
 
+CULL_TIMEOUT = 2
+CULL_INTERVAL = 3
+
+
+@pytest.fixture
+def jp_server_config():
+    return Config({
+        'ServerApp': {
+            'TerminalManager': {
+                'cull_inactive_timeout': CULL_TIMEOUT,
+                'cull_interval': CULL_INTERVAL
+            }
+        }
+    })
+
+
+async def test_no_terminals(jp_fetch):
+    resp_list = await jp_fetch(
+        'api', 'terminals',
+        method='GET',
+        allow_nonstandard_methods=True,
+    )
+
+    data = json.loads(resp_list.body.decode())
+
+    assert len(data) == 0
+
+
 async def test_terminal_create(jp_fetch, kill_all):
-    await jp_fetch(
+    resp = await jp_fetch(
         'api', 'terminals',
         method='POST',
         allow_nonstandard_methods=True,
     )
+    term = json.loads(resp.body.decode())
+    assert term['name'] == "1"
 
     resp_list = await jp_fetch(
         'api', 'terminals',
@@ -46,6 +79,7 @@ async def test_terminal_create(jp_fetch, kill_all):
     data = json.loads(resp_list.body.decode())
 
     assert len(data) == 1
+    assert data[0] == term
     await kill_all()
 
 
@@ -104,3 +138,41 @@ async def test_terminal_create_with_cwd(jp_fetch, jp_ws_fetch, terminal_path):
     ws.close()
 
     assert str(terminal_path) in message_stdout
+
+
+async def test_culling_config(jp_server_config, jp_configurable_serverapp):
+    terminal_mgr_config = jp_configurable_serverapp().config.ServerApp.TerminalManager
+    assert terminal_mgr_config.cull_inactive_timeout == CULL_TIMEOUT
+    assert terminal_mgr_config.cull_interval == CULL_INTERVAL
+    terminal_mgr_settings = jp_configurable_serverapp().web_app.settings['terminal_manager']
+    assert terminal_mgr_settings.cull_inactive_timeout == CULL_TIMEOUT
+    assert terminal_mgr_settings.cull_interval == CULL_INTERVAL
+
+
+async def test_culling(jp_server_config, jp_fetch):
+    # POST request
+    resp = await jp_fetch(
+        'api', 'terminals',
+        method='POST',
+        allow_nonstandard_methods=True,
+    )
+    term = json.loads(resp.body.decode())
+    term_1 = term['name']
+    last_activity = term['last_activity']
+
+    culled = False
+    for i in range(10):  # Culling should occur in a few seconds
+        try:
+            resp = await jp_fetch(
+                'api', 'terminals', term_1,
+                method='GET',
+                allow_nonstandard_methods=True,
+            )
+        except HTTPClientError as e:
+            assert e.code == 404
+            culled = True
+            break
+        else:
+            await asyncio.sleep(1)
+
+    assert culled


### PR DESCRIPTION
This PR brings from notebook the following PRs to enable the culling of terminals:

- Add ability to cull terminals and track last activity (https://github.com/jupyter/notebook/pull/5372)
- Install terminado for docs build (https://github.com/jupyter/notebook/pull/5462)
- Restore detection of missing terminado package (https://github.com/jupyter/notebook/pull/5465)

Resolves #432

(Note: I was seeing intermittent CI failures in CI-setup and post-test phases (install examples).  All failures were related to python installation issues and it felt like a repository was down or some kind of update was occurring since the issue would move around.  Since these shouldn't be related, I'm moving forward with submitting the PR.)