### PR TITLE
Remove some of ipython_genutils no-op.

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -26,7 +26,6 @@ from jupyter_server._sysinfo import get_sys_info
 
 from traitlets.config import Application
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import string_types
 
 from jupyter_core.paths import is_hidden
 import jupyter_server
@@ -785,7 +784,7 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
     def initialize(self, path, default_filename=None, no_cache_paths=None):
         self.no_cache_paths = no_cache_paths or []
 
-        if isinstance(path, string_types):
+        if isinstance(path, str):
             path = [path]
 
         self.root = tuple(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -95,7 +95,6 @@ from traitlets import (
     Any, Dict, Unicode, Integer, List, Bool, Bytes, Instance,
     TraitError, Type, Float, observe, default, validate
 )
-from ipython_genutils import py3compat
 from jupyter_core.paths import jupyter_runtime_dir, jupyter_path
 from jupyter_server._sysinfo import get_sys_info
 
@@ -201,7 +200,7 @@ class ServerWebApplication(web.Application):
             "template_path",
             jupyter_app.template_file_path,
         )
-        if isinstance(_template_path, py3compat.string_types):
+        if isinstance(_template_path, str):
             _template_path = (_template_path,)
         template_path = [os.path.expanduser(path) for path in _template_path]
 
@@ -229,7 +228,7 @@ class ServerWebApplication(web.Application):
         now = utcnow()
 
         root_dir = contents_manager.root_dir
-        home = py3compat.str_to_unicode(os.path.expanduser('~'), encoding=sys.getfilesystemencoding())
+        home = os.path.expanduser("~")
         if root_dir.startswith(home + os.path.sep):
             # collapse $HOME to ~
             root_dir = '~' + root_dir[len(home):]
@@ -953,8 +952,6 @@ class ServerApp(JupyterApp):
             # Address is a hostname
             for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
                 addr = info[4][0]
-                if not py3compat.PY3:
-                    addr = addr.decode('ascii')
 
                 try:
                     parsed = ipaddress.ip_address(addr.split('%')[0])
@@ -1281,7 +1278,7 @@ class ServerApp(JupyterApp):
             self._root_dir_set = True
             return os.path.dirname(os.path.abspath(self.file_to_run))
         else:
-            return py3compat.getcwd()
+            return os.getcwd()
 
     @validate('root_dir')
     def _root_dir_validate(self, proposal):

--- a/jupyter_server/services/config/handlers.py
+++ b/jupyter_server/services/config/handlers.py
@@ -8,7 +8,6 @@ import io
 import errno
 from tornado import web
 
-from ipython_genutils.py3compat import PY3
 from ...base.handlers import APIHandler
 
 class ConfigHandler(APIHandler):

--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -16,7 +16,6 @@ from .fileio import AsyncFileManagerMixin, FileManagerMixin
 
 from anyio import run_sync_in_worker_thread
 from jupyter_core.utils import ensure_dir_exists
-from ipython_genutils.py3compat import getcwd
 from traitlets import Unicode
 
 from jupyter_server import _tz as tz
@@ -48,7 +47,7 @@ class FileCheckpoints(FileManagerMixin, Checkpoints):
         try:
             return self.parent.root_dir
         except AttributeError:
-            return getcwd()
+            return os.getcwd()
 
     # ContentsManager-dependent checkpoint API
     def create_checkpoint(self, contents_mgr, path):

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -21,7 +21,6 @@ from jupyter_server.utils import (
 )
 import nbformat
 
-from ipython_genutils.py3compat import str_to_unicode
 
 from traitlets.config import Configurable
 from traitlets import Bool
@@ -231,7 +230,7 @@ class FileManagerMixin(Configurable):
                 # this may not work perfectly on unicode paths on Python 2,
                 # but nobody should be doing that anyway.
                 if not os_path:
-                    os_path = str_to_unicode(e.filename or 'unknown file')
+                    os_path = e.filename or "unknown file"
                 path = to_api_path(os_path, root=self.root_dir)
                 raise HTTPError(403, u'Permission denied: %s' % path) from e
             else:

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -22,7 +22,6 @@ from .manager import AsyncContentsManager, ContentsManager
 
 from ipython_genutils.importstring import import_item
 from traitlets import Any, Unicode, Bool, TraitError, observe, default, validate
-from ipython_genutils.py3compat import getcwd, string_types
 
 from jupyter_core.paths import exists, is_hidden, is_file_hidden
 from jupyter_server import _tz as tz
@@ -47,7 +46,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         try:
             return self.parent.root_dir
         except AttributeError:
-            return getcwd()
+            return os.getcwd()
 
     post_save_hook = Any(None, config=True, allow_none=True,
         help="""Python callable or importstring thereof
@@ -70,7 +69,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     @validate('post_save_hook')
     def _validate_post_save_hook(self, proposal):
         value = proposal['value']
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             value = import_item(value)
         if not callable(value):
             raise TraitError("post_save_hook must be callable")

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -29,7 +29,6 @@ from traitlets import (
     validate,
     default,
 )
-from ipython_genutils.py3compat import string_types
 from jupyter_server.transutils import _i18n
 from jupyter_server.utils import ensure_async
 
@@ -106,7 +105,7 @@ class ContentsManager(LoggingConfigurable):
     @validate('pre_save_hook')
     def _validate_pre_save_hook(self, proposal):
         value = proposal['value']
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             value = import_item(self.pre_save_hook)
         if not callable(value):
             raise TraitError("pre_save_hook must be callable")

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -25,7 +25,6 @@ from traitlets import (Any, Bool, Dict, List, Unicode, TraitError, Integer,
 
 from jupyter_server.utils import to_os_path, ensure_async
 from jupyter_server._tz import utcnow, isoformat
-from ipython_genutils.py3compat import getcwd
 
 from jupyter_server.prometheus.metrics import KERNEL_CURRENTLY_RUNNING_TOTAL
 
@@ -58,7 +57,7 @@ class MappingKernelManager(MultiKernelManager):
         try:
             return self.parent.root_dir
         except AttributeError:
-            return getcwd()
+            return os.getcwd()
 
     @validate('root_dir')
     def _update_root_dir(self, proposal):

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -14,7 +14,6 @@ except ImportError:
 from tornado import web
 
 from traitlets.config.configurable import LoggingConfigurable
-from ipython_genutils.py3compat import unicode_type
 from traitlets import Instance
 
 from jupyter_server.utils import ensure_async
@@ -81,7 +80,7 @@ class SessionManager(LoggingConfigurable):
 
     def new_session_id(self):
         "Create a uuid for a new session"
-        return unicode_type(uuid.uuid4())
+        return str(uuid.uuid4())
 
     async def create_session(self, path=None, name=None, type=None, kernel_name=None, kernel_id=None):
         """Creates a session and returns its model"""

--- a/jupyter_server/tests/nbconvert/test_handlers.py
+++ b/jupyter_server/tests/nbconvert/test_handlers.py
@@ -8,7 +8,7 @@ from nbformat.v4 import (
     new_notebook, new_markdown_cell, new_code_cell, new_output,
 )
 
-from ipython_genutils.py3compat import which
+from shutil import which
 
 
 from base64 import encodebytes

--- a/jupyter_server/tests/test_gateway.py
+++ b/jupyter_server/tests/test_gateway.py
@@ -7,7 +7,6 @@ import uuid
 from datetime import datetime
 from tornado.web import HTTPError
 from tornado.httpclient import HTTPRequest, HTTPResponse
-from ipython_genutils.py3compat import str_to_unicode
 from jupyter_server.serverapp import ServerApp
 from jupyter_server.gateway.managers import GatewayClient
 from jupyter_server.utils import ensure_async
@@ -51,7 +50,7 @@ async def mock_gateway_request(url, **kwargs):
 
     # Fetch all kernelspecs
     if endpoint.endswith('/api/kernelspecs') and method == 'GET':
-        response_buf = StringIO(str_to_unicode(json.dumps(kernelspecs)))
+        response_buf = StringIO(json.dumps(kernelspecs))
         response = await ensure_async(HTTPResponse(request, 200, buffer=response_buf))
         return response
 
@@ -60,7 +59,7 @@ async def mock_gateway_request(url, **kwargs):
         requested_kernelspec = endpoint.rpartition('/')[2]
         kspecs = kernelspecs.get('kernelspecs')
         if requested_kernelspec in kspecs:
-            response_buf = StringIO(str_to_unicode(json.dumps(kspecs.get(requested_kernelspec))))
+            response_buf = StringIO(json.dumps(kspecs.get(requested_kernelspec)))
             response = await ensure_async(HTTPResponse(request, 200, buffer=response_buf))
             return response
         else:
@@ -75,7 +74,7 @@ async def mock_gateway_request(url, **kwargs):
         assert name == kspec_name   # Ensure that KERNEL_ env values get propagated
         model = generate_model(name)
         running_kernels[model.get('id')] = model  # Register model as a running kernel
-        response_buf = StringIO(str_to_unicode(json.dumps(model)))
+        response_buf = StringIO(json.dumps(model))
         response = await ensure_async(HTTPResponse(request, 201, buffer=response_buf))
         return response
 
@@ -85,7 +84,7 @@ async def mock_gateway_request(url, **kwargs):
         for kernel_id in running_kernels.keys():
             model = running_kernels.get(kernel_id)
             kernels.append(model)
-        response_buf = StringIO(str_to_unicode(json.dumps(kernels)))
+        response_buf = StringIO(json.dumps(kernels))
         response = await ensure_async(HTTPResponse(request, 200, buffer=response_buf))
         return response
 
@@ -101,8 +100,12 @@ async def mock_gateway_request(url, **kwargs):
                 raise HTTPError(404, message='Kernel does not exist: %s' % requested_kernel_id)
         elif action == 'restart':
             if requested_kernel_id in running_kernels:
-                response_buf = StringIO(str_to_unicode(json.dumps(running_kernels.get(requested_kernel_id))))
-                response = await ensure_async(HTTPResponse(request, 204, buffer=response_buf))
+                response_buf = StringIO(
+                    json.dumps(running_kernels.get(requested_kernel_id))
+                )
+                response = await ensure_async(
+                    HTTPResponse(request, 204, buffer=response_buf)
+                )
                 return response
             else:
                 raise HTTPError(404, message='Kernel does not exist: %s' % requested_kernel_id)
@@ -120,8 +123,12 @@ async def mock_gateway_request(url, **kwargs):
     if endpoint.rfind('/api/kernels/') >= 0 and method == 'GET':
         requested_kernel_id = endpoint.rpartition('/')[2]
         if requested_kernel_id in running_kernels:
-            response_buf = StringIO(str_to_unicode(json.dumps(running_kernels.get(requested_kernel_id))))
-            response = await ensure_async(HTTPResponse(request, 200, buffer=response_buf))
+            response_buf = StringIO(
+                json.dumps(running_kernels.get(requested_kernel_id))
+            )
+            response = await ensure_async(
+                HTTPResponse(request, 200, buffer=response_buf)
+            )
             return response
         else:
             raise HTTPError(404, message='Kernel does not exist: %s' % requested_kernel_id)

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -13,7 +13,6 @@ from distutils.version import LooseVersion
 from urllib.parse import quote, unquote, urlparse, urljoin
 from urllib.request import pathname2url
 
-from ipython_genutils import py3compat
 
 
 def url_path_join(*pieces):
@@ -59,8 +58,8 @@ def url_escape(path):
 
     Turns '/foo bar/' into '/foo%20bar/'
     """
-    parts = py3compat.unicode_to_str(path, encoding='utf8').split('/')
-    return u'/'.join([quote(p) for p in parts])
+    parts = path.split("/")
+    return "/".join([quote(p) for p in parts])
 
 
 def url_unescape(path):
@@ -68,10 +67,7 @@ def url_unescape(path):
 
     Turns '/foo%20bar/' into '/foo bar/'
     """
-    return u'/'.join([
-        py3compat.str_to_unicode(unquote(p), encoding='utf8')
-        for p in py3compat.unicode_to_str(path, encoding='utf8').split('/')
-    ])
+    return "/".join([unquote(p) for p in path.split("/")])
 
 
 def samefile_simple(path, other_path):


### PR DESCRIPTION
ipython_genutils is complicated to package on some linux distro because
of nose, and in general not useful as it mostly offered python 2/3
compat layer.

Goal always has been to remove any usage of ipython_genutils