### PR TITLE
Fix for UnboundLocalError in shutdown

### DIFF
--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -224,5 +224,7 @@ def run_sync(maybe_async):
             if str(e) == 'This event loop is already running':
                 # just return a Future, hoping that it will be awaited
                 result = asyncio.ensure_future(maybe_async)
+            else:
+                raise e
         return result
     return wrapped()


### PR DESCRIPTION
Partial Fix for jupyter-server/jupyter_server#439

This will allow us to see what the actual underlying error is when it happens again.