### PR TITLE
Escape user input in handlers flagged during code scans

### DIFF
--- a/examples/simple/simple_ext1/handlers.py
+++ b/examples/simple/simple_ext1/handlers.py
@@ -1,5 +1,6 @@
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
+from jupyter_server.utils import url_escape
 
 class DefaultHandler(ExtensionHandlerMixin, JupyterHandler):
     def get(self):
@@ -19,8 +20,8 @@ class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):
         var1 = self.get_argument('var1', default=None)
         components = [x for x in self.request.path.split("/") if x]
         self.write('<h1>Hello Simple App 1 from Handler.</h1>')
-        self.write('<p>matched_part: {}</p>'.format(matched_part))
-        self.write('<p>var1: {}</p>'.format(var1))
+        self.write('<p>matched_part: {}</p>'.format(url_escape(matched_part)))
+        self.write('<p>var1: {}</p>'.format(url_escape(var1)))
         self.write('<p>components: {}</p>'.format(components))
 
 class BaseTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler): pass

--- a/examples/simple/simple_ext2/handlers.py
+++ b/examples/simple/simple_ext2/handlers.py
@@ -1,13 +1,14 @@
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
+from jupyter_server.utils import url_escape
 
 class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):
     def get(self, matched_part=None, *args, **kwargs):
         var1 = self.get_argument('var1', default=None)
         components = [x for x in self.request.path.split("/") if x]
         self.write('<h1>Hello Simple App 2 from Handler.</h1>')
-        self.write('<p>matched_part: {}</p>'.format(matched_part))
-        self.write('<p>var1: {}</p>'.format(var1))
+        self.write('<p>matched_part: {}</p>'.format(url_escape(matched_part)))
+        self.write('<p>var1: {}</p>'.format(url_escape(var1)))
         self.write('<p>components: {}</p>'.format(components))
 
 class BaseTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler): pass

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -282,7 +282,7 @@ class NotebooksRedirectHandler(JupyterHandler):
         self.redirect(url_path_join(
             self.base_url,
             'api/contents',
-            path
+            url_escape(path)
         ))
 
     put = patch = post = delete = get


### PR DESCRIPTION
This change runs user-input received as an argument on a few handlers through `url_escape`.  These instances had been flagged by the code analysis CI.

Resolves #447