### PR TITLE
Add Styling to the HTML Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,15 +6,9 @@ docs/man/*.gz
 docs/source/api/generated
 docs/source/config.rst
 docs/gh-pages
-notebook/i18n/*/LC_MESSAGES/*.mo
-notebook/i18n/*/LC_MESSAGES/nbjs.json
-notebook/static/components
-notebook/static/style/*.min.css*
-notebook/static/*/js/built/
-notebook/static/*/built/
-notebook/static/built/
-notebook/static/*/js/main.min.js*
-notebook/static/lab/*bundle.js
+jupyter_server/i18n/*/LC_MESSAGES/*.mo
+jupyter_server/i18n/*/LC_MESSAGES/nbjs.json
+jupyter_server/static/style/*.min.css*
 node_modules
 *.py[co]
 __pycache__
@@ -40,6 +34,3 @@ config.rst
 /.project
 /.pydevproject
 
-package-lock.json
-geckodriver.log
-yarn.lock

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,6 +19,8 @@ Setting Up a Development Environment
 Installing the Jupyter Server
 -----------------------------
 
+The development version of the server requires `node <https://nodejs.org/en/download/>`_ and `pip <https://pip.pypa.io/en/stable/installing/>`_.
+
 Once you have installed the dependencies mentioned above, use the following
 steps::
 

--- a/jupyter_server/static/style/index.css
+++ b/jupyter_server/static/style/index.css
@@ -1,0 +1,92 @@
+
+#jupyter_server {
+    padding-left: 0px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+}
+
+#jupyter_server img {
+    height: 28px;
+}
+
+#jupyter-main-app {
+    padding-top: 50px;
+    text-align: center;
+}
+
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 1.42857143;
+    color: #000;
+}
+
+body > #header {
+    display: block;
+    background-color: #fff;
+    position: relative;
+    z-index: 100;
+}
+
+body > #header #header-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 5px;
+        padding-top: 5px;
+        padding-bottom: 5px;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+}
+
+body > #header .header-bar {
+    width: 100%;
+    height: 1px;
+    background: #e7e7e7;
+    margin-bottom: -1px;
+}
+
+.navbar-brand {
+    float: left;
+    height: 30px;
+    padding: 6px 0px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    padding-left: 0px;
+    font-size: 17px;
+    line-height: 18px;
+}
+
+.navbar-brand, .navbar-nav > li > a {
+    text-shadow: 0 1px 0 rgba(255,255,255,.25);
+}
+
+.nav {
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+}
+
+.center-nav {
+    display: inline-block;
+    margin-bottom: -4px;
+}
+
+
+div.error {
+    margin: 2em;
+    text-align: center;
+}
+
+div.error > h1 {
+    font-size: 500%;
+    line-height: normal;
+}
+
+div.error > p {
+    font-size: 200%;
+    line-height: normal;
+}

--- a/jupyter_server/templates/browser-open.html
+++ b/jupyter_server/templates/browser-open.html
@@ -5,12 +5,12 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="refresh" content="1;url={{ open_url }}" />
-    <title>Opening Jupyter Notebook</title>
+    <title>Opening Jupyter Application</title>
 </head>
 <body>
 
 <p>
-    This page should redirect you to Jupyter Notebook. If it doesn't,
+    This page should redirect you to a Jupyter application. If it doesn't,
     <a href="{{ open_url }}">click here to go to Jupyter</a>.
 </p>
 

--- a/jupyter_server/templates/error.html
+++ b/jupyter_server/templates/error.html
@@ -1,17 +1,26 @@
 {% extends "page.html" %}
 
+{% block stylesheet %}
+{{super()}}
+<style type="text/css">
+    /* disable initial hide */
+    div#header,
+    div#site {
+        display: block;
+    }
+</style>
+{% endblock %}
 {% block site %}
 
 <div class="error">
     {% block h1_error %}
     <h1>{{status_code}} : {{status_message}}</h1>
     {% endblock h1_error %}
-
     {% block error_detail %}
     {% if message %}
     <p>{% trans %}The error was:{% endtrans %}</p>
     <div class="traceback-wrapper">
-    <pre class="traceback">{{message}}</pre>
+        <pre class="traceback">{{message}}</pre>
     </div>
     {% endif %}
     {% endblock error_detail %}
@@ -19,3 +28,5 @@
 
 {% endblock %}
 
+{% block script %}
+{% endblock script %}

--- a/jupyter_server/templates/login.html
+++ b/jupyter_server/templates/login.html
@@ -1,98 +1,117 @@
 {% extends "page.html" %}
 
-{% block stylesheet %}
-<style>
-.form {
-    margin-left: 50px;
-    margin-right: 50px;
-}
 
-.content {
-    margin-left: 50px;
-    margin-right: 50px;
-    margin-bottom: 50px;
-}
-</style>
+{% block stylesheet %}
 {% endblock %}
 
 {% block site %}
-{% if message %}
-{% for key in message %}
-<div class="content">
-    {{message[key]}}
-</div>
-{% endfor %}
-{% endif %}
-<form class="form" action="{{base_url}}login?next={{next}}" method="post">
-    {{ xsrf_form_html() | safe }}
-    <label for="password_input"><strong>{% trans %}Password or token:{% endtrans %}</strong></label>
-    <input type="password" name="password" id="password_input">
-    <button type="submit" id="login_submit">{% trans %}Log in{% endtrans %}</button>
-</form>
 
-{% if token_available %}
-{% block token_message %}
-<div class="content">
-    <h3>
-        Token authentication is enabled
-    </h3>
-    <p>
-        If no password has been configured, you need to open the
-        server with its login token in the URL, or paste it above.
-        This requirement will be lifted if you
-        <b><a href='https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html'>
-                enable a password</a></b>.
-    </p>
-    <p>
-        The command:
-    <pre>jupyter server list</pre>
-    will show you the URLs of running servers with their tokens,
-    which you can copy and paste into your browser. For example:
-    </p>
-    <pre>Currently running servers:
+<div id="jupyter-main-app" class="container">
+    {% if login_available %}
+    {# login_available means password-login is allowed. Show the form. #}
+    <div class="row">
+        <div class="navbar col-sm-8">
+            <div class="navbar-inner">
+                <div class="container">
+                    <div class="center-nav">
+                        <form action="{{base_url}}login?next={{next}}" method="post" class="navbar-form pull-left">
+                            {{ xsrf_form_html() | safe }}
+                            {% if token_available %}
+                            <label for="password_input"><strong>{% trans %}Password or token:{% endtrans
+                                    %}</strong></label>
+                            {% else %}
+                            <label for="password_input"><strong>{% trans %}Password:{% endtrans %}</strong></label>
+                            {% endif %}
+                            <input type="password" name="password" id="password_input" class="form-control">
+                            <button type="submit" class="btn btn-default" id="login_submit">{% trans %}Log in{% endtrans
+                                %}</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% else %}
+    <p>{% trans %}No login available, you shouldn't be seeing this page.{% endtrans %}</p>
+    {% endif %}
+    {% if message %}
+    <div class="row">
+        {% for key in message %}
+        <div class="message {{key}}">
+            {{message[key]}}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% if token_available %}
+    {% block token_message %}
+    <div class="col-sm-6 col-sm-offset-3 text-left rendered_html">
+        <h3>
+            Token authentication is enabled
+        </h3>
+        <p>
+            If no password has been configured, you need to open the
+            server with its login token in the URL, or paste it above.
+            This requirement will be lifted if you
+            <b><a href='https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html'>
+                    enable a password</a></b>.
+        </p>
+        <p>
+            The command:
+        <pre>jupyter server list</pre>
+        will show you the URLs of running servers with their tokens,
+        which you can copy and paste into your browser. For example:
+        </p>
+        <pre>Currently running servers:
 http://localhost:8888/?token=c8de56fa... :: /Users/you/notebooks
 </pre>
-    <p>
-        or you can paste just the token value into the password field on this
-        page.
-    </p>
-    <p>
-        See
-        <b><a href='https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html'>
-                the documentation on how to enable a password</a>
-        </b>
-        in place of token authentication,
-        if you would like to avoid dealing with random tokens.
-    </p>
-    <p>
-        Cookies are required for authenticated access to notebooks.
-    </p>
-    {% if allow_password_change %}
-    <h3>{% trans %}Setup a Password{% endtrans %}</h3>
-    <p> You can also setup a password by entering your token and a new password
-        on the fields below:</p>
-    <form action="{{base_url}}login?next={{next}}" method="post" class="">
-        {{ xsrf_form_html() | safe }}
-        <div class="form-group">
-            <label for="token_input">
-                <h4>Token</h4>
-            </label>
-            <input type="password" name="password" id="token_input" class="form-control">
-        </div>
-        <div class="form-group">
-            <label for="new_password_input">
-                <h4>New Password</h4>
-            </label>
-            <input type="password" name="new_password" id="new_password_input" class="form-control" required>
-        </div>
-        <div class="form-group">
-            <button type="submit" class="btn btn-default" id="login_new_pass_submit">{% trans %}Log in and set new
-                password{% endtrans %}</button>
-        </div>
-    </form>
+        <p>
+            or you can paste just the token value into the password field on this
+            page.
+        </p>
+        <p>
+            See
+            <b><a href='https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html'>
+                    the documentation on how to enable a password</a>
+            </b>
+            in place of token authentication,
+            if you would like to avoid dealing with random tokens.
+        </p>
+        <p>
+            Cookies are required for authenticated access to the Jupyter server.
+        </p>
+        {% if allow_password_change %}
+        <h3>{% trans %}Setup a Password{% endtrans %}</h3>
+        <p> You can also setup a password by entering your token and a new password
+            on the fields below:</p>
+        <form action="{{base_url}}login?next={{next}}" method="post" class="">
+            {{ xsrf_form_html() | safe }}
+            <div class="form-group">
+                <label for="token_input">
+                    <h4>Token</h4>
+                </label>
+                <input type="password" name="password" id="token_input" class="form-control">
+            </div>
+            <div class="form-group">
+                <label for="new_password_input">
+                    <h4>New Password</h4>
+                </label>
+                <input type="password" name="new_password" id="new_password_input" class="form-control" required>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-default" id="login_new_pass_submit">{% trans %}Log in and set new
+                    password{% endtrans %}</button>
+            </div>
+        </form>
+        {% endif %}
+
+    </div>
+    {% endblock token_message %}
     {% endif %}
 </div>
-{% endblock token_message %}
-{% endif %}
-    
-{% endblock site %}
+
+{% endblock %}
+
+
+{% block script %}
+{% endblock %}

--- a/jupyter_server/templates/logout.html
+++ b/jupyter_server/templates/logout.html
@@ -1,13 +1,35 @@
 {% extends "page.html" %}
 
-{% block site %}
-{% if message %}
-{% for key in message %}
-<div>
-  {{message[key]}}
-</div>
-{% endfor %}
-{% endif %}
+{# This template is rendered in response to an authenticated request, so the
+user is technically logged in. But when the user sees it, the cookie is
+cleared by the Javascript, so we should render this as if the user was logged
+out, without e.g. authentication tokens.
+#}
+{% set logged_in = False %}
 
-{% trans %}Proceed to the <a href="{{base_url}}login">login page{% endtrans %}</a>.
+{% block stylesheet %}
 {% endblock %}
+
+{% block site %}
+
+<div id="jupyter-main-app" class="container">
+
+  {% if message %}
+  {% for key in message %}
+  <div class="message {{key}}">
+    {{message[key]}}
+  </div>
+  {% endfor %}
+  {% endif %}
+
+  {% if not login_available %}
+  {% trans %}Proceed to the <a href="{{base_url}}">dashboard{% endtrans %}</a>.
+  {% else %}
+  {% trans %}Proceed to the <a href="{{base_url}}login">login page{% endtrans %}</a>.
+  {% endif %}
+
+
+  <div />
+
+  {% endblock %}
+

--- a/jupyter_server/templates/main.html
+++ b/jupyter_server/templates/main.html
@@ -1,5 +1,7 @@
 {% extends "page.html" %}
 
 {% block site %}
+    <div id=jupyter-main-app>
     <h1>A Jupyter Server is running.</h1>
+    </div>
 {% endblock site %}

--- a/jupyter_server/templates/page.html
+++ b/jupyter_server/templates/page.html
@@ -2,24 +2,56 @@
 <html>
 
 <head>
-    
+
     <meta charset="utf-8">
 
     <title>{% block title %}Jupyter Server{% endblock %}</title>
-    {% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{ static_url("favicon.ico") }}">{% endblock %}
+    {% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{ static_url("favicon.ico") }}">
+    {% endblock %}
+    <link rel="stylesheet" href="{{static_url("style/bootstrap.min.css") }}" />
+    <link rel="stylesheet" href="{{static_url("style/bootstrap-theme.min.css") }}" />
+    <link rel="stylesheet" href="{{static_url("style/index.css") }}" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% block stylesheet %}
-    {% endblock %}
-    
+    {% endblock stylesheet %}
+
     {% block meta %}
-    {% endblock %}
-   
+    {% endblock meta %}
+
 </head>
 
-<body>
-  
+<body class="{% block bodyclasses %}{% endblock %}" {% block params %} {% if logged_in and token %}
+  data-jupyter-api-token="{{token | urlencode}}" {% endif %} {% endblock params %} dir="ltr">
+
+  <noscript>
+    <div id='noscript'>
+      {% trans %}Jupyter Server requires JavaScript.{% endtrans %}<br>
+      {% trans %}Please enable it to proceed. {% endtrans %}
+    </div>
+  </noscript>
+
+  <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
+    <div id="header-container" class="container">
+      <div id="jupyter_server" class="nav navbar-brand"><a href="{{default_url}}
+    {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
+          {% block logo %}<img src='{{static_url("logo/logo.png") }}' alt='Jupyter Server' />{% endblock %}
+        </a></div>
+
+      {% block headercontainer %}
+      {% endblock headercontainer %}
+
+      {% block header_buttons %}
+      {% endblock header_buttons %}
+
+    </div>
+    <div class="header-bar"></div>
+
+    {% block header %}
+    {% endblock header %}
+  </div>
+
   <div id="site">
     {% block site %}
     {% endblock site %}
@@ -28,6 +60,34 @@
   {% block after_site %}
   {% endblock after_site %}
 
+  {% block script %}
+  {% endblock script %}
+
+  <script type='text/javascript'>
+    function _remove_token_from_url() {
+      if (window.location.search.length <= 1) {
+        return;
+      }
+      var search_parameters = window.location.search.slice(1).split('&');
+      for (var i = 0; i < search_parameters.length; i++) {
+        if (search_parameters[i].split('=')[0] === 'token') {
+          // remote token from search parameters
+          search_parameters.splice(i, 1);
+          var new_search = '';
+          if (search_parameters.length) {
+            new_search = '?' + search_parameters.join('&');
+          }
+          var new_url = window.location.origin +
+            window.location.pathname +
+            new_search +
+            window.location.hash;
+          window.history.replaceState({}, "", new_url);
+          return;
+        }
+      }
+    }
+    _remove_token_from_url();
+  </script>
 </body>
 
 </html>

--- a/jupyter_server/templates/view.html
+++ b/jupyter_server/templates/view.html
@@ -9,13 +9,18 @@
 
 <body>
   <style type="text/css">
-    html, body, #container {
+    html,
+    body,
+    #container {
       height: 100%;
     }
-    body, #container {
+
+    body,
+    #container {
       overflow: hidden;
       margin: 0;
     }
+
     #iframe {
       width: 100%;
       height: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,588 @@
+{
+  "name": "jupyter_server",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "BSD",
+      "dependencies": {
+        "bootstrap": "^3.4.0",
+        "copyfiles": "^2.4.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/bootstrap": {
+      "version": "3.4.1",
+      "resolved": "http://localhost:5559/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.0"
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0"
+    },
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "http://localhost:5559/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4"
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "copyfiles": {
+      "version": "2.4.1",
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "emoji-regex": {
+      "version": "8.0.0"
+    },
+    "escalade": {
+      "version": "3.1.1"
+    },
+    "fs.realpath": {
+      "version": "1.0.0"
+    },
+    "get-caller-file": {
+      "version": "2.0.5"
+    },
+    "glob": {
+      "version": "7.1.6",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4"
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0"
+    },
+    "isarray": {
+      "version": "0.0.1"
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4"
+    },
+    "noms": {
+      "version": "0.0.0",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1"
+    },
+    "process-nextick-args": {
+      "version": "2.0.1"
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1"
+    },
+    "safe-buffer": {
+      "version": "5.1.2"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
+    },
+    "string-width": {
+      "version": "4.2.2",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "untildify": {
+      "version": "4.0.0"
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2"
+    },
+    "xtend": {
+      "version": "4.0.2"
+    },
+    "y18n": {
+      "version": "5.0.5"
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.7"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jupyter_server",
+  "private": true,
+  "version": "1.0.0",
+  "license": "BSD",
+  "scripts": {
+    "build": "copyfiles -f node_modules/bootstrap/dist/css/*.min.* jupyter_server/static/style"
+  },
+  "dependencies": {
+    "bootstrap": "^3.4.0",
+    "copyfiles": "^2.4.1"
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import (
     setup,
 )
 from setupbase import (
-    get_version,
+    get_version, create_cmdclass, install_npm
 )
 
 here = pathlib.Path('.')
@@ -14,6 +14,10 @@ VERSION = get_version(str(version_path))
 readme_path = here.joinpath('README.md')
 README = readme_path.read_text()
 
+cmdclass = create_cmdclass('jsdeps')
+cmdclass['jsdeps'] = install_npm()
+
+
 setup_args = dict(
     name             = 'jupyter_server',
     description      = 'The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications.',
@@ -22,6 +26,7 @@ setup_args = dict(
     version          = VERSION,
     packages         = find_packages('.', exclude=['tests*', 'docs*', 'examples*']),
     include_package_data = True,
+    cmdclass         = cmdclass,
     author           = 'Jupyter Development Team',
     author_email     = 'jupyter@googlegroups.com',
     url              = 'http://jupyter.org',


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_server/issues/271

Copies more the templates and styling from `notebook`, including the use of `bootstrap`.

Including `bootstrap` adds an `npm` build step and brings the package from 275kB to 405kB.

<img width="488" alt="1" src="https://user-images.githubusercontent.com/159529/112003471-d7260080-8b18-11eb-8971-165be86f4234.png">

<img width="246" alt="2" src="https://user-images.githubusercontent.com/159529/112003491-dc834b00-8b18-11eb-9745-19e7f16102dd.png">

<img width="571" alt="3" src="https://user-images.githubusercontent.com/159529/112003515-df7e3b80-8b18-11eb-9e1e-49cd6b92b68a.png">

<img width="492" alt="4" src="https://user-images.githubusercontent.com/159529/112003524-e2792c00-8b18-11eb-8048-4485f3be23a8.png">
