### PR TITLE
allow pre_save_hook to cancel save with HTTPError

### DIFF
--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -118,7 +118,13 @@ class ContentsManager(LoggingConfigurable):
             try:
                 self.log.debug("Running pre-save hook on %s", path)
                 self.pre_save_hook(model=model, path=path, contents_manager=self, **kwargs)
+            except HTTPError:
+                # allow custom HTTPErrors to raise,
+                # rejecting the save with a message.
+                raise
             except Exception:
+                # unhandled errors don't prevent saving,
+                # which could cause frustrating data loss
                 self.log.error("Pre-save hook failed on %s", path, exc_info=True)
 
     checkpoints_class = Type(Checkpoints, config=True)


### PR DESCRIPTION
currently, all errors in pre_save_hook are caught and logged, making it impossible for pre_save_hook to be used for validation / quota enforcement / etc.

By allowing HTTPErrors to raise, save will be cancelled and the hook's error message will be shown to the user in a dialog.

For example:

```python
from tornado.web import HTTPError

def fail_save_forbidden(model, path, **kw):
    if "forbidden" in path.split("/"):
        raise HTTPError(400, "Can't save forbidden files!")

c.ContentsManager.pre_save_hook = fail_save_forbidden
```

Brought up on [the forum](https://discourse.jupyter.org/t/exit-abort-save-from-pre-save-hook/8410)