### PR TITLE
Delete the extra “or” that prevents easy cut-and-paste of URLs.

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1523,7 +1523,7 @@ class ServerApp(JupyterApp):
 
         url = (
             self.get_url(ip=ip, path=path, token=token)
-            + '\n or '
+            + '\n    '
             + self.get_url(ip='127.0.0.1', path=path, token=token)
         )
         return url


### PR DESCRIPTION
Before this PR, the default output of server urls looks like:

    Or copy and paste one of these URLs:
        http://localhost:8888/?token=…
     or http://127.0.0.1:8888/?token=…

This makes it easy to triple-click on the first line to copy and paste it into a browser. However, triple-clicking on the second line picks up the extra “or”, so you can’t just copy and paste it into the browser. Instead, you have to explicitly select each character by dragging your mouse, avoiding the “or”.

This change deletes the “or” so you can just triple-click on the second line to copy and paste the url.
