### PR TITLE
Update description for kernel restarted in the API docs

### DIFF
--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -502,7 +502,7 @@ paths:
         - kernels
       responses:
         200:
-          description: Kernel interrupted
+          description: Kernel restarted
           headers:
             Location:
               description: URL for kernel commands


### PR DESCRIPTION
Update the following description for the `restart` endpoint:

![image](https://user-images.githubusercontent.com/591645/113051697-8fe9e080-91a6-11eb-850d-2009e99a4ab7.png)
