### PR TITLE
Add Changelog to Sphinx Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ config.rst
 /.project
 /.pydevproject
 
+# copied changelog file
+docs/source/other/changelog.md
+

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -8,4 +8,5 @@ prometheus_client
 sphinxcontrib_github_alt
 sphinxcontrib-openapi
 sphinxemoji
-git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
+myst-parser
+pydata_sphinx_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,17 +1,6 @@
 name: jupyter_server_docs
 dependencies:
-- python=3.7
+- python=3.8
+- pip
 - pip:
-  - sphinx
-  - jinja2
-  - tornado
-  - jupyter_client
-  - ipykernel
-  - nbformat
-  - Send2Trash
-  - prometheus_client
-  - sphinxcontrib_github_alt
-  - sphinxcontrib-openapi
-  - sphinxemoji
-  - terminado
-  - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
+  - -r doc-requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,12 @@
 
 import sys
 import os
+import os.path as osp
 import shlex
+import shutil
+
+HERE = osp.abspath(osp.dirname(__file__))
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -63,6 +68,7 @@ if os.environ.get('READTHEDOCS', ''):
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'myst_parser',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -73,6 +79,8 @@ extensions = [
     'sphinxcontrib.openapi',
     'sphinxemoji.sphinxemoji'
 ]
+
+myst_enable_extensions = ["html_image"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -371,3 +379,8 @@ spelling_word_list_filename='spelling_wordlist.txt'
 
 # import before any doc is built, so _ is guaranteed to be injected
 import jupyter_server.transutils
+
+
+def setup(app):
+    dest = osp.join(HERE, 'other', 'changelog.md')
+    shutil.copy(osp.join(HERE, '..', '..', 'CHANGELOG.md'), dest)

--- a/docs/source/developers/contents.rst
+++ b/docs/source/developers/contents.rst
@@ -281,7 +281,7 @@ An asynchronous version of the Contents API is available to run slow IO processe
 
 .. note::
 
-   .. _contentfree:
+   .. _asynccontents:
 
    In most cases, the non-asynchronous Contents API is performant for local filesystems.
    However, if the Jupyter Notebook web application is interacting with a high-latent virtual filesystem, you may see performance gains by using the asynchronous version.

--- a/docs/source/other/full-config.rst
+++ b/docs/source/other/full-config.rst
@@ -1388,3 +1388,4 @@ GatewayClient.ws_url : Unicode
 
     The websocket url of the Kernel or Enterprise Gateway server.  If not provided, this value
     will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (JUPYTER_GATEWAY_WS_URL env var)
+

--- a/docs/source/other/index.rst
+++ b/docs/source/other/index.rst
@@ -7,3 +7,4 @@ Other helpful documentation
    links
    faq
    full-config
+   changelog


### PR DESCRIPTION
- Copy the changelog into the docs source when building
- Use the MyST parser for markdown files
- Clean up docs requirements files
