### PR TITLE
Add ReadTheDocs config

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,5 +1,6 @@
 name: jupyter_server_docs
 dependencies:
+- nodejs=14
 - python=3.8
 - pip
 - pip:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+sphinx:
+  configuration: docs/source/conf.py
+conda:
+  environment: docs/environment.yml
+python:
+  version: 3.8
+  install:
+    # install itself with pip install .
+    - method: pip
+      path: .


### PR DESCRIPTION
Builds are failing due to installing with `python setup.py install`, so enforce `pip install .`