### PR TITLE
Fix activity tracking and nudge issues when kernel ports change on restarts

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -47,6 +47,8 @@ class MappingKernelManager(MultiKernelManager):
 
     _kernel_connections = Dict()
 
+    _kernel_ports = Dict()
+
     _culler_callback = None
 
     _initialized_culler = False
@@ -183,6 +185,7 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs['cwd'] = self.cwd_for_path(path)
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
+            self._kernel_ports[kernel_id] = self._kernels[kernel_id].ports
             self.start_watching_activity(kernel_id)
             self.log.info("Kernel started: %s" % kernel_id)
             self.log.debug("Kernel args: %r" % kwargs)
@@ -207,6 +210,40 @@ class MappingKernelManager(MultiKernelManager):
             self.initialize_culler()
 
         return kernel_id
+
+    def ports_changed(self, kernel_id):
+        """Used by ZMQChannelsHandler to determine how to coordinate nudge and replays.
+
+        Ports are captured when starting a kernel (via MappingKernelManager).  Ports
+        are considered changed (following restarts) if the referenced KernelManager
+        is using a set of ports different from those captured at startup.  If changes
+        are detected, the captured set is updated and a value of True is returned.
+
+        NOTE: Use is exclusive to ZMQChannelsHandler because this object is a singleton
+        instance while ZMQChannelsHandler instances are per WebSocket connection that
+        can vary per kernel lifetime.
+        """
+        changed_ports = self._get_changed_ports(kernel_id)
+        if changed_ports:
+            # If changed, update captured ports and return True, else return False.
+            self.log.debug(f"Port change detected for kernel: {kernel_id}")
+            self._kernel_ports[kernel_id] = changed_ports
+            return True
+        return False
+
+    def _get_changed_ports(self, kernel_id):
+        """Internal method to test if a kernel's ports have changed and, if so, return their values.
+
+        This method does NOT update the captured ports for the kernel as that can only be done
+        by ZMQChannelsHandler, but instead returns the new list of ports if they are different
+        than those captured at startup.  This enables the ability to conditionally restart
+        activity monitoring immediately following a kernel's restart (if ports have changed).
+        """
+        # Get current ports and return comparison with ports captured at startup.
+        km = self.get_kernel(kernel_id)
+        if km.ports != self._kernel_ports[kernel_id]:
+            return km.ports
+        return None
 
     def start_buffering(self, kernel_id, session_key, channels):
         """Start buffering messages for a kernel
@@ -300,10 +337,7 @@ class MappingKernelManager(MultiKernelManager):
     def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        kernel = self._kernels[kernel_id]
-        if kernel._activity_stream:
-            kernel._activity_stream.close()
-            kernel._activity_stream = None
+        self.stop_watching_activity(kernel_id)
         self.stop_buffering(kernel_id)
         self._kernel_connections.pop(kernel_id, None)
 
@@ -319,6 +353,7 @@ class MappingKernelManager(MultiKernelManager):
         # method is synchronous.  However, we'll keep the relative call orders the same from
         # a maintenance perspective.
         self._kernel_connections.pop(kernel_id, None)
+        self._kernel_ports.pop(kernel_id, None)
 
     async def restart_kernel(self, kernel_id, now=False):
         """Restart a kernel by kernel_id"""
@@ -359,6 +394,10 @@ class MappingKernelManager(MultiKernelManager):
         channel.on_recv(on_reply)
         loop = IOLoop.current()
         timeout = loop.add_timeout(loop.time() + self.kernel_info_timeout, on_timeout)
+        # Re-establish activity watching if ports have changed...
+        if self._get_changed_ports(kernel_id) is not None:
+            self.stop_watching_activity(kernel_id)
+            self.start_watching_activity(kernel_id)
         return future
 
     def notify_connect(self, kernel_id):
@@ -440,6 +479,13 @@ class MappingKernelManager(MultiKernelManager):
 
         kernel._activity_stream.on_recv(record_activity)
 
+    def stop_watching_activity(self, kernel_id):
+        """Stop watching IOPub messages on a kernel for activity."""
+        kernel = self._kernels[kernel_id]
+        if kernel._activity_stream:
+            kernel._activity_stream.close()
+            kernel._activity_stream = None
+
     def initialize_culler(self):
         """Start idle culler if 'cull_idle_timeout' is greater than zero.
 
@@ -511,10 +557,7 @@ class AsyncMappingKernelManager(MappingKernelManager, AsyncMultiKernelManager):
     async def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        kernel = self._kernels[kernel_id]
-        if kernel._activity_stream:
-            kernel._activity_stream.close()
-            kernel._activity_stream = None
+        self.stop_watching_activity(kernel_id)
         self.stop_buffering(kernel_id)
 
         # Decrease the metric of number of kernels
@@ -526,4 +569,5 @@ class AsyncMappingKernelManager(MappingKernelManager, AsyncMultiKernelManager):
         # Finish shutting down the kernel before clearing state to avoid a race condition.
         ret = await self.pinned_superclass.shutdown_kernel(self, kernel_id, now=now, restart=restart)
         self._kernel_connections.pop(kernel_id, None)
+        self._kernel_ports.pop(kernel_id, None)
         return ret


### PR DESCRIPTION
This change adds the ability for the `ZMQChannelsHandler` and activity watching logic to determine if ports have changed when restoring connections and restarting kernels, respectively.  

By determining that ports have changed during restarts, the `MappingKernelManager` can also restart the activity monitor since it listens on the iopub channel.  This will preserve proper functionality for culling behaviors as well as allow the "nudge" functionality to determine the kernel is busy - bypassing the time-based attempts to send/recieve a kernel-info request.

`ZMQChannelsHandler.open()` makes use of the fact that the kernel's ports have changed when _restoring_ a connection (which essentially consists of loading state from previously recorded buffers).  Prior to this change, the nudge functionality within this branch would use the kernel's previous iopub channel to listen for replies and time out.  It will now use the kernel's current iopub channel when port changes are detected.

I made an attempt to write a test for this but this requires buffering to occur and I'm not certain what else the front end is doing.  However, use of the tests's `NewPortsMappingKernelManager` and `NewPortsKernelManager` subclasses make introducing port-changes on restarts rather simple and I decided to retain this class's use in the tests in cases other port-related issues are encountered.

With these subclasses, this issue can be reproduced by running the following command:
```
jupyter lab --debug --ServerApp.kernel_manager_class=jupyter_server.tests.services.sessions.test_api.NewPortsMappingKernelManager
```
You will also need to change the result of the new internal method `MappingKernelManager._get_changed_ports()` to return `None` to disable port-change detection.

Resolved #481