### PR TITLE
Fix loading of sibling extensions

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -477,13 +477,18 @@ class ExtensionApp(JupyterApp):
         The `launch_instance` method uses this method to initialize
         and start a server.
         """
+        jpserver_extensions = {cls.get_extension_package(): True}
+        find_extensions = cls.load_other_extensions
+        if 'jpserver_extensions' in cls.serverapp_config:
+            jpserver_extensions.update(cls.serverapp_config['jpserver_extensions'])
+            cls.serverapp_config['jpserver_extensions'] = jpserver_extensions
+            find_extensions = False
         serverapp = ServerApp.instance(
-            jpserver_extensions={cls.get_extension_package(): True}, **kwargs)
-        serverapp.aliases.update(cls.aliases)
+            jpserver_extensions=jpserver_extensions, **kwargs)
         serverapp.initialize(
             argv=argv,
             starter_extension=cls.name,
-            find_extensions=cls.load_other_extensions,
+            find_extensions=find_extensions,
         )
         return serverapp
 
@@ -510,7 +515,6 @@ class ExtensionApp(JupyterApp):
         # before initializing server to make sure these
         # arguments trigger actions from the extension not the server.
         _preparse_for_stopping_flags(cls, args)
-
         serverapp = cls.initialize_server(argv=args)
 
         # Log if extension is blocking other extensions from loading.

--- a/jupyter_server/tests/extension/mockextensions/app.py
+++ b/jupyter_server/tests/extension/mockextensions/app.py
@@ -47,6 +47,12 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
     mock_trait = Unicode('mock trait', config=True)
     loaded = False
 
+    serverapp_config = {
+        "jpserver_extensions": {
+            "jupyter_server.tests.extension.mockextensions.mock1": True
+        }
+    }
+
     @staticmethod
     def get_extension_package():
         return "jupyter_server.tests.extension.mockextensions"

--- a/jupyter_server/tests/extension/test_app.py
+++ b/jupyter_server/tests/extension/test_app.py
@@ -89,3 +89,15 @@ OPEN_BROWSER_COMBINATIONS = (
 def test_browser_open(monkeypatch, jp_environ, config, expected_value):
     serverapp = MockExtensionApp.initialize_server(config=Config(config))
     assert serverapp.open_browser == expected_value
+
+
+
+def test_load_parallel_extensions(monkeypatch, jp_environ):
+    serverapp = MockExtensionApp.initialize_server()
+    exts = serverapp.extension_manager.extensions
+    assert 'jupyter_server.tests.extension.mockextensions.mock1' in exts
+    assert 'jupyter_server.tests.extension.mockextensions' in exts
+
+    exts = serverapp.jpserver_extensions
+    assert exts['jupyter_server.tests.extension.mockextensions.mock1']
+    assert exts['jupyter_server.tests.extension.mockextensions']


### PR DESCRIPTION
Prior to this change, an extension app either had to load all all extensions using `load_other_extensions`, or else only load itself.  This change allows an extension app to declare a set of sibling extensions to load using `serverapp_config`.