### PR TITLE
ExtensionPoint: return True on successful validate()

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -129,6 +129,8 @@ class ExtensionPoint(HasTraits):
             self._get_loader()
         except Exception:
             return False
+        else:
+            return True
 
     def link(self, serverapp):
         """Link the extension to a Jupyter ServerApp object.

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -306,7 +306,8 @@ class ListServerExtensionsApp(BaseExtensionApp):
                                 GREEN_ENABLED if enabled else RED_DISABLED))
                 try:
                     self.log.info("    - Validating {}...".format(name))
-                    extension.validate()
+                    if not extension.validate():
+                        raise ValueError("validation failed")
                     version = extension.version
                     self.log.info(
                         "      {} {} {}".format(name, version, GREEN_OK)

--- a/jupyter_server/tests/extension/test_manager.py
+++ b/jupyter_server/tests/extension/test_manager.py
@@ -30,6 +30,7 @@ def test_extension_point_api():
     assert app is not None
     assert callable(e.load)
     assert callable(e.link)
+    assert e.validate()
 
 
 def test_extension_point_metadata_error():
@@ -59,6 +60,7 @@ def test_extension_package_api():
     assert hasattr(e, "extension_points")
     assert len(e.extension_points) == len(metadata_list)
     assert app.name in e.extension_points
+    assert e.validate()
 
 
 def test_extension_package_notfound_error():


### PR DESCRIPTION
Related to #500, but doesn't actually fix the main issue there (failure to identify extensions that are not importable).

Current situation:

- ExtensionPoint.validate always returns a falsy value (None or False)
- ExtensionPackage only checks the falsiness, which means it always returns False
- ListServerExtensionApp never checked validate return value, meaning all extensions were always considered valid, even though all extensions actually self-reported as invalid

This fixes:

- ExtensionPoint.validate returns True on successful validation
- ListServerExtensionApp checks the return value of validate

The original error causing failed validation is still swallowed and not logged, which should probably be addressed at some point as well, but at least now values are correct.

This came up when I was trying to write some tests validating an image, where I had:

```python
def test_extensions():
    from jupyter_core.paths import jupyter_config_path
    from jupyter_server.extension.manager import ExtensionManager
    from jupyter_server.extension.config import ExtensionConfigManager

    m = ExtensionManager(
        config_manager=ExtensionConfigManager(read_config_paths=jupyter_config_path())
    )
    for name, ext in m.extensions.items():
        print(f"Validating extension {name}")
        assert ext.validate()
```

and was surprised to see that all the extensions were actually invalid.