### PR TITLE
set default config dir name

### DIFF
--- a/jupyter_server/services/config/manager.py
+++ b/jupyter_server/services/config/manager.py
@@ -15,7 +15,7 @@ class ConfigManager(LoggingConfigurable):
     """Config Manager used for storing frontend config"""
 
     config_dir_name = Unicode(
-        default="serverconfig",
+        "serverconfig",
         help="""Name of the config directory."""
     ).tag(config=True)
 


### PR DESCRIPTION
`default` is not a kwarg of the traitlet constructor (default_value is)

The result was a warning on every jupyter server startup that tag metadata was being stored, but this is deprecated. The default value was *not* being set.