### PR TITLE
Include backtrace in debug output when extension fails to load

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -1,4 +1,6 @@
 import importlib
+import sys
+import traceback
 
 from traitlets.config import LoggingConfigurable
 
@@ -339,6 +341,7 @@ class ExtensionManager(LoggingConfigurable):
                 extension.load_all_points(serverapp)
                 self.log.info("{name} | extension was successfully loaded.".format(name=name))
             except Exception as e:
+                self.log.debug("".join(traceback.format_exception(*sys.exc_info())))
                 self.log.warning("{name} | extension failed loading with message: {error}".format(name=name,error=str(e)))
 
     def link_all_extensions(self, serverapp):


### PR DESCRIPTION
This is helpful when developing and debugging extensions