### PR TITLE
Increase minimum jupyter_core dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     argon2-cffi
     ipython_genutils
     traitlets>=4.2.1
-    jupyter_core>=4.4.0
+    jupyter_core>=4.6.0
     jupyter_client>=6.1.1
     jupyter_packaging~=0.9
     nbformat


### PR DESCRIPTION
This bumps the minimum core dependency to `4.6.0` since that version of core is the first to include the `is_hidden()` method - on which the server relies.  These dependencies had been inherited from Notebook and it defines `is_hidden()` locally so the previous core dependency (`4.4.0`) is still valid in that scenario.

Fixes #496