### PR TITLE
Use kernel_id for new kernel if it doesn't exist in MappingKernelManager.start_kernel

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -179,7 +179,7 @@ class MappingKernelManager(MultiKernelManager):
             The name identifying which kernel spec to launch. This is ignored if
             an existing kernel is returned, but it may be checked in the future.
         """
-        if kernel_id is None:
+        if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -182,7 +182,8 @@ class MappingKernelManager(MultiKernelManager):
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
-            kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
+            kernel_id = await ensure_async(
+                self.pinned_superclass.start_kernel(self, kernel_id=kernel_id, **kwargs))
             self._kernel_connections[kernel_id] = 0
             self._kernel_ports[kernel_id] = self._kernels[kernel_id].ports
             self.start_watching_activity(kernel_id)

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -201,7 +201,6 @@ class MappingKernelManager(MultiKernelManager):
             ).inc()
 
         else:
-            self._check_kernel_id(kernel_id)
             self.log.info("Using existing kernel: %s" % kernel_id)
 
         # Initialize culling if not already

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -182,8 +182,11 @@ class MappingKernelManager(MultiKernelManager):
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
-            kernel_id = await ensure_async(
-                self.pinned_superclass.start_kernel(self, kernel_id=kernel_id, **kwargs))
+            if kernel_id:
+                kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, kernel_id=kernel_id, **kwargs))
+            else:
+                kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
+
             self._kernel_connections[kernel_id] = 0
             self._kernel_ports[kernel_id] = self._kernels[kernel_id].ports
             self.start_watching_activity(kernel_id)

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -182,11 +182,9 @@ class MappingKernelManager(MultiKernelManager):
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs['cwd'] = self.cwd_for_path(path)
-            if kernel_id:
-                kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, kernel_id=kernel_id, **kwargs))
-            else:
-                kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
-
+            if kernel_id is not None:
+                kwargs['kernel_id'] = kernel_id
+            kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
             self._kernel_ports[kernel_id] = self._kernels[kernel_id].ports
             self.start_watching_activity(kernel_id)


### PR DESCRIPTION
Closes https://github.com/jupyter-server/jupyter_server/issues/403. This change aligns the implementation of `MappingKernelManager.start_kernel` with its docstring. 

It is worth mentioning that in the [API Doc](https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html?highlight=post#post--api-kernels), there is currently no method for starting a kernel by specifying a `kernel_id`. As such, no changes are made to `jupyter_server/tests/services/kernels/test_api.py`. Nevertheless, this change provides a _possibility_ to support such functionality if that is required in future.