### PR TITLE
restore preference for SelectorEventLoop on Windows

### DIFF
--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -31,6 +31,12 @@ pytest_plugins = [
     # "jupyter_core.pytest_plugin"
 ]
 
+
+import asyncio
+if os.name == "nt" and sys.version_info >= (3, 7):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
 # ============ Move to Jupyter Core =============
 
 def mkdir(tmp_path, *parts):


### PR DESCRIPTION
tornado should still work better with Selector, even though 6.1 isn't *broken* with proactor. Picking Selector avoids the extra thread, which runs a Selector anyway.

So the choice is really between:

- Proactor in main thread for coroutines, but ~all IO in a Selector in another thread
- one Selector loop for everything

cf https://github.com/jupyter/notebook/pull/6052