### PR TITLE
init_httpserver at the end of initialize

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1864,13 +1864,13 @@ class ServerApp(JupyterApp):
         self.init_configurables()
         self.init_components()
         self.init_webapp()
-        if new_httpserver:
-            self.init_httpserver()
         self.init_terminals()
         self.init_signal()
         self.load_server_extensions()
         self.init_mime_overrides()
         self.init_shutdown_no_activity()
+        if new_httpserver:
+            self.init_httpserver()
 
     def cleanup_kernels(self):
         """Shutdown all kernels.


### PR DESCRIPTION
init_httpserver references IOLoop.current()

If a server extension sets an asyncio EventLoopPolicy, any prior reference to IOLoop.current or asyncio.get_event_loop() will be invalidated.

We should try to avoid this during intialize at all, or at least until the very end.

Arguably, the http server listen should occur in `.start()`

There is one other reference to the loop in terminado: https://github.com/jupyter/terminado/pull/102