### PR TITLE
Enable Server Tests on Windows

### DIFF
--- a/jupyter_server/tests/extension/test_manager.py
+++ b/jupyter_server/tests/extension/test_manager.py
@@ -83,7 +83,8 @@ def test_extension_manager_api():
     }
     manager = ExtensionManager()
     assert manager.config_manager
-    assert _normalize_path(manager.config_manager.read_config_path) == _normalize_path(jupyter_config_path())
+    expected = _normalize_path(os.path.join(jupyter_config_path()[0], 'serverconfig'))
+    assert _normalize_path(manager.config_manager.read_config_path[0]) == expected
     manager.from_jpserver_extensions(jpserver_extensions)
     assert len(manager.extensions) == 1
     assert "jupyter_server.tests.extension.mockextensions" in manager.extensions

--- a/jupyter_server/tests/test_terminal.py
+++ b/jupyter_server/tests/test_terminal.py
@@ -1,4 +1,4 @@
-# Only Run tests on MacOS and Linux
+import os
 import shutil
 import pytest
 import json
@@ -7,11 +7,6 @@ import sys
 
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
-
-# Skip this whole module on Windows. The terminal API leads
-# to timeouts on Windows CI.
-if sys.platform.startswith('win'):
-    pytest.skip("Terminal API tests time out on Windows.", allow_module_level=True)
 
 
 # Kill all running terminals after each test to avoid cross-test issues
@@ -137,7 +132,7 @@ async def test_terminal_create_with_cwd(jp_fetch, jp_ws_fetch, terminal_path):
 
     ws.close()
 
-    assert str(terminal_path) in message_stdout
+    assert os.path.basename(terminal_path) in message_stdout
 
 
 async def test_culling_config(jp_server_config, jp_configurable_serverapp):


### PR DESCRIPTION
Windows Terminal tests were disabled in jupyter-server/jupyter_server#201, but can now be enabled based on improvements in `pywinpty` 1.1. Also fixes test failure introduced in jupyter-server/jupyter_server#504