### PR TITLE
Expose a public property to sort extensions deterministically.

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -273,6 +273,11 @@ class ExtensionManager(LoggingConfigurable):
         """
     )
 
+    @property
+    def sorted_extensions(self):
+        """Returns an extensions dictionary, sorted alphabetically."""
+        return dict(sorted(self.extensions.items()))
+
     # The `_linked_extensions` attribute tracks when each extension
     # has been successfully linked to a ServerApp. This helps prevent
     # extensions from being re-linked recursively unintentionally if another
@@ -350,7 +355,7 @@ class ExtensionManager(LoggingConfigurable):
         """
         # Sort the extension names to enforce deterministic linking
         # order.
-        for name in sorted(self.extensions.keys()):
+        for name in self.sorted_extensions.keys():
             self.link_extension(name, serverapp)
 
     def load_all_extensions(self, serverapp):
@@ -359,5 +364,5 @@ class ExtensionManager(LoggingConfigurable):
         """
         # Sort the extension names to enforce deterministic loading
         # order.
-        for name in sorted(self.extensions.keys()):
+        for name in self.sorted_extensions.keys():
             self.load_extension(name, serverapp)


### PR DESCRIPTION
This provides a single, public property in the server extension API to return a deterministic list of server extensions.

This doesn't change much in server. We were already sorting extensions alphabetically by their keys. This change allows nbclassic to monkey-patch this property (as a special case) and provide a list of server extensions with nbclassic *always* first and the rest sorted alphabetically. See jupyterlab/nbclassic#56 for more details.

