### PR TITLE
extensions: allow extensions in namespace packages

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -20,7 +20,7 @@ from jupyter_core.application import JupyterApp, NoStart
 
 from jupyter_server.serverapp import ServerApp
 from jupyter_server.transutils import _i18n
-from jupyter_server.utils import url_path_join
+from jupyter_server.utils import url_path_join, is_namespace_package
 from .handler import ExtensionHandlerMixin
 
 # -----------------------------------------------------------------------------
@@ -174,7 +174,11 @@ class ExtensionApp(JupyterApp):
 
     @classmethod
     def get_extension_package(cls):
-        return cls.__module__.split('.')[0]
+        parts = cls.__module__.split('.')
+        if is_namespace_package(parts[0]):
+            # in this case the package name is `<namespace>.<package>`.
+            return '.'.join(parts[0:2])
+        return parts[0]
 
     @classmethod
     def get_extension_point(cls):

--- a/jupyter_server/tests/namespace-package-test/README.md
+++ b/jupyter_server/tests/namespace-package-test/README.md
@@ -1,0 +1,3 @@
+Blank namespace package for use in testing.
+
+https://www.python.org/dev/peps/pep-0420/

--- a/jupyter_server/tests/namespace-package-test/setup.cfg
+++ b/jupyter_server/tests/namespace-package-test/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+name = namespace-package-test
+
+[options]
+packages = find_namespace:

--- a/jupyter_server/tests/test_utils.py
+++ b/jupyter_server/tests/test_utils.py
@@ -1,19 +1,25 @@
+from pathlib import Path
+import sys
+
 import pytest
 
 from traitlets.tests.utils import check_help_all_output
-from jupyter_server.utils import url_escape, url_unescape
+from jupyter_server.utils import (
+    url_escape,
+    url_unescape,
+    is_namespace_package
+)
 
 
 def test_help_output():
     check_help_all_output('jupyter_server')
 
 
-
 @pytest.mark.parametrize(
     'unescaped,escaped',
     [
         (
-            '/this is a test/for spaces/', 
+            '/this is a test/for spaces/',
             '/this%20is%20a%20test/for%20spaces/'
         ),
         (
@@ -37,3 +43,30 @@ def test_url_escaping(unescaped, escaped):
     # Test unescaping.
     path = url_unescape(escaped)
     assert path == unescaped
+
+
+@pytest.fixture
+def namespace_package_test(monkeypatch):
+    """Adds a blank namespace package into the PYTHONPATH for testing.
+
+    Yields the name of the importable namespace.
+    """
+    monkeypatch.setattr(
+        sys,
+        'path',
+        [
+            str(Path(__file__).parent / 'namespace-package-test'),
+            *sys.path
+        ]
+    )
+    yield 'test_namespace'
+
+
+def test_is_namespace_package(namespace_package_test):
+    # returns True if it is a namespace package
+    assert is_namespace_package(namespace_package_test)
+    # returns False if it isn't a namespace package
+    assert not is_namespace_package('sys')
+    assert not is_namespace_package('jupyter_server')
+    # returns None if it isn't importable
+    assert is_namespace_package('not_a_python_namespace') is None

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -3,8 +3,10 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from _frozen_importlib_external import _NamespacePath
 import asyncio
 import errno
+import importlib.util
 import inspect
 import os
 import socket
@@ -352,3 +354,19 @@ async def async_fetch(
     with _request_for_tornado_client(urlstring) as request:
         response = await AsyncHTTPClient(io_loop).fetch(request)
     return response
+
+
+def is_namespace_package(namespace):
+    """Is the provided namespace a Python Namespace Package (PEP420).
+
+    https://www.python.org/dev/peps/pep-0420/#specification
+
+    Returns `None` if module is not importable.
+
+    """
+    # NOTE: using submodule_search_locations because the loader can be None
+    spec = importlib.util.find_spec(namespace)
+    if not spec:
+        # e.g. module not installed
+        return None
+    return isinstance(spec.submodule_search_locations, _NamespacePath)


### PR DESCRIPTION
This allows Jupyter extensions to be developed in [Python namespace packages](https://packaging.python.org/guides/packaging-namespace-packages/).

Related to: https://github.com/jupyter-server/jupyter_server/issues/222#issuecomment-624774795

See [PEP420](https://www.python.org/dev/peps/pep-0420/#id24).

Currently Jupyter Server extensions developed in Python namespace packages fall over with some nasty traceback:

```console
$ t_ns_jps_ext
[I 2021-05-19 12:40:39.457 ServerApp] t_namespace | extension was successfully linked.
Traceback (most recent call last):
  File ".../t_ns_jps_ext", line 33, in <module>
    sys.exit(load_entry_point('jps-namespace-extension', 'console_scripts', 't_ns_jps_ext')())
  File ".../python3.9/site-packages/jupyter_server/extension/application.py", line 518, in launch_instance
    serverapp = cls.initialize_server(argv=args)
  File ".../python3.9/site-packages/jupyter_server/extension/application.py", line 488, in initialize_server
    serverapp.initialize(
  File ".../python3.9/site-packages/traitlets/config/application.py", line 87, in inner
    return method(app, *args, **kwargs)
  File ".../python3.9/site-packages/jupyter_server/serverapp.py", line 1855, in initialize
    point = self.extension_manager.extension_points[starter_extension]
KeyError: 'test_namespace_extension'
```

Here's an example extension developed in a Python namespace package: https://github.com/oliver-sanders/jupyter-server-namespace-extension-test