### PR TITLE
stop hook for extensions

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -156,6 +156,10 @@ The basic structure of an ExtensionApp is shown below:
             ...
             # Change the jinja templating environment
 
+        def stop_extension(self):
+            ...
+            # Perform any required shut down steps
+
 
 The ``ExtensionApp`` uses the following methods and properties to connect your extension to the Jupyter server. You do not need to define a ``_load_jupyter_server_extension`` function for these apps. Instead, overwrite the pieces below to add your custom settings, handlers and templates:
 
@@ -164,6 +168,7 @@ Methods
 * ``initialize_setting()``: adds custom settings to the Tornado Web Application.
 * ``initialize_handlers()``: appends handlers to the Tornado Web Application.
 * ``initialize_templates()``: initialize the templating engine (e.g. jinja2) for your frontend.
+* ``stop_extension()``: called on server shut down.
 
 Properties
 

--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -156,7 +156,7 @@ The basic structure of an ExtensionApp is shown below:
             ...
             # Change the jinja templating environment
 
-        def stop_extension(self):
+        async def stop_extension(self):
             ...
             # Perform any required shut down steps
 

--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -165,7 +165,7 @@ The ``ExtensionApp`` uses the following methods and properties to connect your e
 
 Methods
 
-* ``initialize_setting()``: adds custom settings to the Tornado Web Application.
+* ``initialize_settings()``: adds custom settings to the Tornado Web Application.
 * ``initialize_handlers()``: appends handlers to the Tornado Web Application.
 * ``initialize_templates()``: initialize the templating engine (e.g. jinja2) for your frontend.
 * ``stop_extension()``: called on server shut down.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -419,6 +419,8 @@ class ExtensionApp(JupyterApp):
     def stop(self):
         """Stop the underlying Jupyter server.
         """
+        if hasattr(self, 'stop_extension'):
+            self.stop_extension()
         self.serverapp.stop()
         self.serverapp.clear_instance()
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -416,11 +416,12 @@ class ExtensionApp(JupyterApp):
         # Start the server.
         self.serverapp.start()
 
+    async def stop_extension(self):
+        """Cleanup any resources managed by this extension."""
+
     def stop(self):
         """Stop the underlying Jupyter server.
         """
-        if hasattr(self, 'stop_extension'):
-            self.stop_extension()
         self.serverapp.stop()
         self.serverapp.clear_instance()
 

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -18,7 +18,7 @@ from traitlets.config import Config
 
 from jupyter_server.extension import serverextension
 from jupyter_server.serverapp import ServerApp
-from jupyter_server.utils import url_path_join
+from jupyter_server.utils import url_path_join, run_sync
 from jupyter_server.services.contents.filemanager import FileContentsManager
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 
@@ -284,7 +284,7 @@ def jp_serverapp(
     """Starts a Jupyter Server instance based on the established configuration values."""
     app = jp_configurable_serverapp(config=jp_server_config, argv=jp_argv)
     yield app
-    app._cleanup()
+    run_sync(app._cleanup())
 
 
 @pytest.fixture

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -43,7 +43,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from jupyter_core.paths import secure_write
 from jupyter_server.transutils import trans, _i18n
-from jupyter_server.utils import run_sync
+from jupyter_server.utils import run_sync_in_loop
 
 # the minimum viable tornado version: needs to be kept in sync with setup.py
 MIN_TORNADO = (6, 1, 0)
@@ -2068,7 +2068,7 @@ class ServerApp(JupyterApp):
         n_kernels = len(self.kernel_manager.list_kernel_ids())
         kernel_msg = trans.ngettext('Shutting down %d kernel', 'Shutting down %d kernels', n_kernels)
         self.log.info(kernel_msg % n_kernels)
-        await self.kernel_manager.shutdown_all()
+        await run_sync_in_loop(self.kernel_manager.shutdown_all())
 
     async def cleanup_terminals(self):
         """Shutdown all terminals.
@@ -2083,7 +2083,7 @@ class ServerApp(JupyterApp):
         n_terminals = len(terminal_manager.list())
         terminal_msg = trans.ngettext('Shutting down %d terminal', 'Shutting down %d terminals', n_terminals)
         self.log.info(terminal_msg % n_terminals)
-        await terminal_manager.terminate_all()
+        await run_sync_in_loop(terminal_manager.terminate_all())
 
     async def cleanup_extensions(self):
         """Call shutdown hooks in all extensions."""
@@ -2094,7 +2094,9 @@ class ServerApp(JupyterApp):
             n_extensions
         )
         self.log.info(extension_msg % n_extensions)
-        await self.extension_manager.stop_all_extensions(self)
+        await run_sync_in_loop(
+            self.extension_manager.stop_all_extensions(self)
+        )
 
     def running_server_info(self, kernel_count=True):
         "Return the current working directory and the server url information"

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2094,7 +2094,7 @@ class ServerApp(JupyterApp):
             n_extensions
         )
         self.log.info(extension_msg % n_extensions)
-        self.extension_manager.stop_all_extensions(self)
+        run_sync(self.extension_manager.stop_all_extensions(self))
 
     def running_server_info(self, kernel_count=True):
         "Return the current working directory and the server url information"
@@ -2353,8 +2353,6 @@ class ServerApp(JupyterApp):
             self.io_loop.start()
         except KeyboardInterrupt:
             self.log.info(_i18n("Interrupted..."))
-        finally:
-            self._cleanup()
 
     def init_ioloop(self):
         """init self.io_loop so that an extension can use it by io_loop.call_later() to create background tasks"""

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2085,6 +2085,17 @@ class ServerApp(JupyterApp):
         self.log.info(terminal_msg % n_terminals)
         run_sync(terminal_manager.terminate_all())
 
+    def cleanup_extensions(self):
+        """Call shutdown hooks in all extensions."""
+        n_extensions = len(self.extension_manager.extension_apps)
+        extension_msg = trans.ngettext(
+            'Shutting down %d extension',
+            'Shutting down %d extensions',
+            n_extensions
+        )
+        self.log.info(extension_msg % n_extensions)
+        self.extension_manager.stop_all_extensions(self)
+
     def running_server_info(self, kernel_count=True):
         "Return the current working directory and the server url information"
         info = self.contents_manager.info_string() + "\n"
@@ -2329,6 +2340,7 @@ class ServerApp(JupyterApp):
         self.remove_browser_open_files()
         self.cleanup_kernels()
         self.cleanup_terminals()
+        self.cleanup_extensions()
 
     def start_ioloop(self):
         """Start the IO Loop."""

--- a/jupyter_server/tests/extension/test_app.py
+++ b/jupyter_server/tests/extension/test_app.py
@@ -113,8 +113,9 @@ def test_stop_extension(jp_serverapp, caplog):
 
     # load extensions (make sure we only have the one extension loaded
     jp_serverapp.extension_manager.load_all_extensions(jp_serverapp)
+    extension_name = 'jupyter_server.tests.extension.mockextensions'
     assert list(jp_serverapp.extension_manager.extension_apps) == [
-        'jupyter_server.tests.extension.mockextensions'
+        extension_name
     ]
 
     # add a stop_extension method for the extension app
@@ -133,11 +134,10 @@ def test_stop_extension(jp_serverapp, caplog):
         msg
         for *_, msg in caplog.record_tuples
     ] == [
-        'Shutting down 1 extension'
+        'Shutting down 1 extension',
+        '{} | extension app "mockextension" stopping'.format(extension_name),
+        '{} | extension app "mockextension" stopped'.format(extension_name),
     ]
-
-    # check the extension_apps dictionary is updated
-    assert list(jp_serverapp.extension_manager.extension_apps) == []
 
     # check the shutdown method was called once
     assert calls == 1

--- a/jupyter_server/tests/extension/test_app.py
+++ b/jupyter_server/tests/extension/test_app.py
@@ -1,6 +1,7 @@
 import pytest
 from traitlets.config import Config
 from jupyter_server.serverapp import ServerApp
+from jupyter_server.utils import run_sync
 from .mockextensions.app import MockExtensionApp
 
 
@@ -127,7 +128,7 @@ def test_stop_extension(jp_serverapp, caplog):
 
     # call cleanup_extensions, check the logging is correct
     caplog.clear()
-    jp_serverapp.cleanup_extensions()
+    run_sync(jp_serverapp.cleanup_extensions())
     assert [
         msg
         for *_, msg in caplog.record_tuples

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -230,6 +230,29 @@ def run_sync(maybe_async):
     return wrapped()
 
 
+async def run_sync_in_loop(maybe_async):
+    """Runs a function synchronously whether it is an async function or not.
+
+    If async, runs maybe_async and blocks until it has executed.
+
+    If not async, just returns maybe_async as it is the result of something
+    that has already executed.
+
+    Parameters
+    ----------
+    maybe_async : async or non-async object
+        The object to be executed, if it is async.
+
+    Returns
+    -------
+    result
+        Whatever the async object returns, or the object itself.
+    """
+    if not inspect.isawaitable(maybe_async):
+        return maybe_async
+    return await maybe_async
+
+
 def urlencode_unix_socket_path(socket_path):
     """Encodes a UNIX socket path string from a socket path for the `http+unix` URI form."""
     return socket_path.replace('/', '%2F')


### PR DESCRIPTION
closes https://github.com/jupyter-server/jupyter_server/issues/241

Call a `stop_extension` method for each extension app on server shutdown if present.

Not sure how to go about testing this, any examples for the other `cleanup_*` methods?