### PR TITLE
adds `GatewayClient.auth_scheme` configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,6 @@ src
 
 *.swp
 *.map
-.idea/
-.vscode/
 Read the Docs
 config.rst
 
@@ -36,4 +34,14 @@ config.rst
 
 # copied changelog file
 docs/source/other/changelog.md
+
+# jetbrains ide stuff
+*.iml
+.idea/
+
+# vscode ide stuff
+*.code-workspace
+.history
+.vscode/*
+!.vscode/*.template
 


### PR DESCRIPTION
This lets you configure the "\<type\>" string that gets added (along with a space) to the front of the auth token in the header of all HTTP requests made to a gateway.

Technically, the current default (`"token"`) is invalid with respect to the authorization header spec, but I kept it for backwards compatibility: https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#authentication_schemes