### PR TITLE
Update link to meeting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ If you are interested in contributing to the project, see [`CONTRIBUTING.rst`](C
 
 * When: Thursdays [8:00am, Pacific time](https://www.thetimezoneconverter.com/?t=8%3A00%20am&tz=San%20Francisco&)
 * Where: [Jovyan Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
-* What: [Meeting notes](https://github.com/jupyter/jupyter_server/issues/126)
+* What: [Meeting notes](https://github.com/jupyter-server/team-compass/issues/4)
 
 See our tentative [roadmap here](https://github.com/jupyter/jupyter_server/issues/127).


### PR DESCRIPTION
Old link was still pointing to issue in this repo but it was transferred to https://github.com/jupyter-server/team-compass/issues/1 and then replaced by new issue for 2020. Should both links be included, or just the current one?