### PR TITLE
small test changes

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - name: Checkout
@@ -22,11 +23,14 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install ".[test]"
+        pip install "."
         pip install --pre --upgrade jupyterlab_server[test] jupyterlab[test] nbclassic[test]
         pip freeze
     - name: Run tests
+      working-directory: ../
       run: |
+        # NOTE: tests won't pass from inside the working copy because of
+        # conftest.py:pytest_plugins (must be at the top level)
         pytest --pyargs jupyterlab_server
         python -m jupyterlab.browser_check --no-browser-test
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,4 +44,4 @@ jobs:
         pip check
     - name: Run the tests
       run: |
-        pytest -vv --integration_tests jupyter_server
+        pytest -vv --integration_tests=true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -28,7 +28,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -45,17 +45,17 @@ jobs:
     - name: Run the tests
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |
-        pytest -vv jupyter_server --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
+        pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
     - name: Run the tests on pypy
       if: ${{ matrix.python-version == 'pypy3' }}
       run: |
-        pytest -vv jupyter_server
+        pytest -vv
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .
     - name: Run the tests for the examples
       run: |
-        pytest examples/simple/tests/test_handlers.py
+        pytest examples/simple/tests/test_handlers.py --confcutdir=$PWD
     - name: Coverage
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -28,7 +28,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -45,17 +45,17 @@ jobs:
     - name: Run the tests
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |
-        pytest -vv jupyter_server --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
+        pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered
     - name: Run the tests on pypy
       if: ${{ matrix.python-version == 'pypy3' }}
       run: |
-        pytest -vv jupyter_server
+        pytest -vv
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .
     - name: Run the tests for the examples
       run: |
-        pytest examples/simple/tests/test_handlers.py
+        pytest examples/simple/tests/test_handlers.py --confcutdir=$PWD
     - name: Coverage
       if: ${{ matrix.python-version != 'pypy3' }}
       run: |

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos]
-        python-version: [ '3.6', '3.7', '3.8', '3.9', 'pypy3' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10-dev', 'pypy3' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -28,7 +28,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/python-windows.yml
+++ b/.github/workflows/python-windows.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-

--- a/.github/workflows/python-windows.yml
+++ b/.github/workflows/python-windows.yml
@@ -49,10 +49,10 @@ jobs:
         # the file descriptions opened by the asyncio IOLoop.
         # This leads to a nasty, flaky race condition that we haven't
         # been able to solve.
-        pytest -vv jupyter_server -s
+        pytest -vv -s
     - name: Install the Python dependencies for the examples
       run: |
         cd examples/simple && pip install -e .
     - name: Run the tests for the examples
       run: |
-        pytest examples/simple/tests/test_handlers.py
+        pytest examples/simple/tests/test_handlers.py --confcutdir=$PWD

--- a/.github/workflows/python-windows.yml
+++ b/.github/workflows/python-windows.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
@@ -28,7 +28,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,10 +58,12 @@ Running Tests
 Install dependencies::
 
     pip install -e .[test]
+    pip install -e examples/simple
 
 To run the Python tests, use::
 
     pytest
+    pytest examples/simple
 
 Building the Docs
 =================

--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ Launch with:
 
 ### Testing
 
-To test an installed `jupyter_server`, run the following:
-
-    pip install jupyter_server[test]
-    pytest jupyter_server
+See [CONTRIBUTING](https://github.com/jupyter-server/jupyter_server/blob/master/CONTRIBUTING.rst#running-tests).
 
 ## Contributing
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,9 +6,6 @@ pytest_plugins = [
 ]
 
 
-import pytest
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--integration_tests",
@@ -26,7 +23,7 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    is_integration_test = any([mark for mark in item.iter_markers(name="integration_test")])
+    is_integration_test = any(mark for mark in item.iter_markers(name="integration_test"))
 
     if item.config.getoption("--integration_tests") is True:
         if not is_integration_test:

--- a/examples/simple/tests/conftest.py
+++ b/examples/simple/tests/conftest.py
@@ -1,3 +1,0 @@
-pytest_plugins = [
-    'jupyter_server.pytest_plugin'
-]

--- a/jupyter_server/auth/security.py
+++ b/jupyter_server/auth/security.py
@@ -43,8 +43,8 @@ def passwd(passphrase=None, algorithm='argon2'):
 
     Examples
     --------
-    >>> passwd('mypassword')
-    'sha1:7cf3:b7d6da294ea9592a9480c8f52e63cd42cfb9dd12'
+    >>> passwd('mypassword')  # doctest: +ELLIPSIS
+    'argon2:...'
 
     """
     if passphrase is None:
@@ -94,11 +94,11 @@ def passwd_check(hashed_passphrase, passphrase):
 
     Examples
     --------
-    >>> from jupyter_server.auth.security import passwd_check
-    >>> passwd_check('argon2:...', 'mypassword')
+    >>> myhash = passwd('mypassword')
+    >>> passwd_check(myhash, 'mypassword')
     True
 
-    >>> passwd_check('argon2:...', 'otherpassword')
+    >>> passwd_check(myhash, 'otherpassword')
     False
 
     >>> passwd_check('sha1:0e112c3ddfce:a68df677475c2b47b6e86d0467eec97ac5f4b85a',

--- a/jupyter_server/traittypes.py
+++ b/jupyter_server/traittypes.py
@@ -50,13 +50,15 @@ except ImportError:
         'an object'
         >>> describe("a", type(object))
         'a type'
+
         Definite description:
-        >>> describe("the", object())
-        "the object at '0x10741f1b0'"
+        >>> describe("the", object())  # doctest: +ELLIPSIS
+        "the object at '0x...'"
         >>> describe("the", object)
-        "the type 'object'"
+        'the object object'
         >>> describe("the", type(object))
-        "the type 'type'"
+        'the type type'
+
         Definitely named description:
         >>> describe("the", object(), "I made")
         'the object I made'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "jupyter_packaging.build_api"
 factory = "jupyter_packaging.npm_builder"
 
 [tool.check-manifest]
-ignore = ["tbump.toml", ".*", "*.yml", "package-lock.json", "bootstrap*"]
+ignore = ["tbump.toml", ".*", "*.yml", "package-lock.json", "bootstrap*", "conftest.py"]
 
 [tool.pytest.ini_options]
 # Exclude the example tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ factory = "jupyter_packaging.npm_builder"
 ignore = ["tbump.toml", ".*", "*.yml", "package-lock.json", "bootstrap*", "conftest.py"]
 
 [tool.pytest.ini_options]
-# Exclude the example tests.
-norecursedirs = "examples/*"
+addopts = "--doctest-modules"
+testpaths = [
+    "jupyter_server"
+]
 
 [tool.tbump.version]
 current = "1.10.0.dev0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,17 @@ install_requires =
     requests-unixsocket
 
 [options.extras_require]
-test = coverage; pytest; pytest-cov; pytest-mock; requests; pytest-tornasync; pytest-console-scripts; ipykernel
+test =
+    coverage
+    pytest>=6.0
+    pytest-cov
+    pytest-mock
+    requests
+    pytest-tornasync
+    pytest-console-scripts
+    ipykernel
+    # NOTE: we cannot auto install examples/simple here because of:
+    # https://github.com/pypa/pip/issues/6658
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Some small test changes:

* Use the hash of the `setup.py` file for pip caching  (rather than `setup.py`)  in all actions.

  One action is already using the `setup.cfg` file:
  https://github.com/jupyter-server/jupyter_server/blob/51e3ec362b2b12af48f0e101959c4cbec9d5cb33/.github/workflows/check-release.yml#L27

  The others aren't:

  https://github.com/jupyter-server/jupyter_server/blob/51e3ec362b2b12af48f0e101959c4cbec9d5cb33/.github/workflows/python-linux.yml#L34

  The pip environment may have been frozen for a little while because of this?
* Define `pytest_plugins` in a top-level conftest file to support pytest 4+.
* Pin pytest>=6 as earlier versions ignored the configuration in the `pytest.toml` file.
* Run doctests in pytest (0.34% coverage increase :laughing:).
* Test against Python 3.10-dev (except on Windows due to pywin32 incompatibility)
* Bump the versions of checkout/cache/setup-python actions.