### PR TITLE
Fixes AsyncContentsManager#exists

### DIFF
--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -628,7 +628,7 @@ class AsyncContentsManager(ContentsManager):
         exists : bool
             Whether the target exists.
         """
-        return await (ensure_async(self.file_exists(path)) or ensure_async(self.dir_exists(path)))
+        return await ensure_async(self.file_exists(path)) or await ensure_async(self.dir_exists(path))
 
     async def get(self, path, content=True, type=None, format=None):
         """Get a file or directory model."""


### PR DESCRIPTION
There is a bug in AsyncContentsManager#exists.

```
async def exists(self, path):
    return await (ensure_async(self.file_exists(path)) or ensure_async(self.dir_exists(path)))
```

it always returns `False` when `file_exists` returns `False`


reproduce code:
```
from jupyter_server.utils import ensure_async
import asyncio


async def dir_exists():
    return True


async def file_exists():
    return False


async def exists():
    return await (ensure_async(file_exists()) or ensure_async(dir_exists()))


if __name__ == '__main__':
    a = asyncio.get_event_loop().run_until_complete(exists())
    print(a)
```