### PR TITLE
Fix nbconvert handler

### DIFF
--- a/jupyter_server/services/nbconvert/handlers.py
+++ b/jupyter_server/services/nbconvert/handlers.py
@@ -1,10 +1,13 @@
 import json
+import asyncio
 
 from anyio.to_thread import run_sync
 from tornado import web
 
 from ...base.handlers import APIHandler
 
+
+LOCK = asyncio.Lock()
 
 class NbconvertRootHandler(APIHandler):
 
@@ -20,7 +23,8 @@ class NbconvertRootHandler(APIHandler):
         exporters = await run_sync(base.get_export_names)
         for exporter_name in exporters:
             try:
-                exporter_class = await run_sync(base.get_exporter, exporter_name)
+                async with LOCK:
+                    exporter_class = await run_sync(base.get_exporter, exporter_name)
             except ValueError:
                 # I think the only way this will happen is if the entrypoint
                 # is uninstalled while this method is running


### PR DESCRIPTION
It looks like the call to [nbconvert's `get_exporter` function](https://github.com/jupyter/nbconvert/blob/90b3911ed9b155e8ca3680ca4581d9344aa10be0/nbconvert/exporters/base.py#L92-L129) is not thread-safe:
https://github.com/jupyter-server/jupyter_server/blob/450010eae202ccc6d7a92515629c1c765068451e/jupyter_server/services/nbconvert/handlers.py#L23
And I can see that JupyterLab makes multiple concurrent requests to `/api/nbconvert`. This PR works around that issue using a lock.

Fixes https://github.com/jupyterlab/jupyterlab/issues/10442