### PR TITLE
PR: Add a new preferred-dir traitlet

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1356,7 +1356,7 @@ class ServerApp(JupyterApp):
         else:
             return os.getcwd()
 
-    def _normalize_root_or_preferred_dir(self, value):
+    def _normalize_dir(self, value):
         # Strip any trailing slashes
         # *except* if it's root
         _, path = os.path.splitdrive(value)
@@ -1370,13 +1370,13 @@ class ServerApp(JupyterApp):
 
     @validate('root_dir')
     def _root_dir_validate(self, proposal):
-        value = self._normalize_root_or_preferred_dir(proposal['value'])
+        value = self._normalize_dir(proposal['value'])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
         return value
 
     preferred_dir = Unicode(config=True,
-        help=trans.gettext("Prefered starting directory to use for notebooks and kernels.")
+        help=trans.gettext("Preferred starting directory to use for notebooks and kernels.")
     )
 
     @default('preferred_dir')
@@ -1385,7 +1385,7 @@ class ServerApp(JupyterApp):
 
     @validate('preferred_dir')
     def _preferred_dir_validate(self, proposal):
-        value = self._normalize_root_or_preferred_dir(proposal['value'])
+        value = self._normalize_dir(proposal['value'])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such preferred dir: '%r'") % value)
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -610,6 +610,7 @@ aliases.update({
     'certfile': 'ServerApp.certfile',
     'client-ca': 'ServerApp.client_ca',
     'notebook-dir': 'ServerApp.root_dir',
+    'preferred-dir': 'ServerApp.preferred_dir',
     'browser': 'ServerApp.browser',
     'pylab': 'ServerApp.pylab',
     'gateway-url': 'GatewayClient.url',
@@ -1355,9 +1356,7 @@ class ServerApp(JupyterApp):
         else:
             return os.getcwd()
 
-    @validate('root_dir')
-    def _root_dir_validate(self, proposal):
-        value = proposal['value']
+    def _normalize_root_or_preferred_dir(self, value):
         # Strip any trailing slashes
         # *except* if it's root
         _, path = os.path.splitdrive(value)
@@ -1367,13 +1366,41 @@ class ServerApp(JupyterApp):
         if not os.path.isabs(value):
             # If we receive a non-absolute path, make it absolute.
             value = os.path.abspath(value)
+        return value
+
+    @validate('root_dir')
+    def _root_dir_validate(self, proposal):
+        value = self._normalize_root_or_preferred_dir(proposal['value'])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
+        return value
+
+    preferred_dir = Unicode(config=True,
+        help=trans.gettext("Prefered starting directory to use for notebooks and kernels.")
+    )
+
+    @default('preferred_dir')
+    def _default_prefered_dir(self):
+        return self.root_dir
+
+    @validate('preferred_dir')
+    def _preferred_dir_validate(self, proposal):
+        value = self._normalize_root_or_preferred_dir(proposal['value'])
+        if not os.path.isdir(value):
+            raise TraitError(trans.gettext("No such preferred dir: '%r'") % value)
+
+        # preferred_dir must be equal or a subdir of root_dir
+        if not value.startswith(self.root_dir):
+            raise TraitError(trans.gettext("preferred_dir must be equal or a subdir of root_dir: '%r'") % value)
+
         return value
 
     @observe('root_dir')
     def _root_dir_changed(self, change):
         self._root_dir_set = True
+        if not self.preferred_dir.startswith(change['new']):
+            self.log.warning(trans.gettext("Value of preferred_dir updated to use value of root_dir"))
+            self.preferred_dir = change['new']
 
     @observe('server_extensions')
     def _update_server_extensions(self, change):


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_server/issues/534

- Add a new trait to represent the "preferred" or "starting" directory (e.g., preferred_dir)
- preferred_dir
  - will default to root_dir (aka notebook_dir)
  - is required to be an existing directory residing at or within root_dir
  - is a "suggestion" to client applications. Client applications can honor preferred_dir and start their file-browser at preferred_dir instead of root_dir.
  - If root_dir is updated and preferred dir is no longer a subdir or equal to root_dir, then it will be updated to use the root_dir and emit a warning.

 