### PR TITLE
Fix examples/simple test execution

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,7 +63,7 @@ Install dependencies::
 To run the Python tests, use::
 
     pytest
-    pytest examples/simple
+    pytest examples/simple --confcutdir=$PWD
 
 Building the Docs
 =================


### PR DESCRIPTION
`pytest examples/simple` gives the following error:
```
==================================================================== test session starts =====================================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/david/github/davidbrochart/jupyter_server/examples/simple, configfile: pytest.ini
plugins: tornasync-0.6.0.post2, console-scripts-1.2.0, anyio-3.2.1, cov-2.12.1, mock-3.6.1
collected 2 items                                                                                                                                            

examples/simple/tests/test_handlers.py EE                                                                                                              [100%]

=========================================================================== ERRORS ===========================================================================
___________________________________________________________ ERROR at setup of test_handler_default ___________________________________________________________
file /home/david/github/davidbrochart/jupyter_server/examples/simple/tests/test_handlers.py, line 15
  async def test_handler_default(jp_fetch):
      r = await jp_fetch(
          'simple_ext1/default',
          method='GET'
      )
      assert r.code == 200
      print(r.body.decode())
      assert r.body.decode().index('Hello Simple 1 - I am the default...') > -1
E       fixture 'jp_fetch' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, class_mocker, cov, doctest_namespace, http_client, http_server, http_server_client, http_server_port, io_loop, jp_server_config, mocker, module_mocker, monkeypatch, no_cover, package_mocker, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, script_cwd, script_launch_mode, script_runner, session_mocker, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/david/github/davidbrochart/jupyter_server/examples/simple/tests/test_handlers.py:15
__________________________________________________________ ERROR at setup of test_handler_template ___________________________________________________________
file /home/david/github/davidbrochart/jupyter_server/examples/simple/tests/test_handlers.py, line 25
  async def test_handler_template(jp_fetch):
      r = await jp_fetch(
          'simple_ext1/template1/test',
          method='GET'
      )
      assert r.code == 200
E       fixture 'jp_fetch' not found
>       available fixtures: anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, class_mocker, cov, doctest_namespace, http_client, http_server, http_server_client, http_server_port, io_loop, jp_server_config, mocker, module_mocker, monkeypatch, no_cover, package_mocker, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, script_cwd, script_launch_mode, script_runner, session_mocker, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/david/github/davidbrochart/jupyter_server/examples/simple/tests/test_handlers.py:25
================================================================== short test summary info ===================================================================
ERROR examples/simple/tests/test_handlers.py::test_handler_default
ERROR examples/simple/tests/test_handlers.py::test_handler_template
===================================================================== 2 errors in 0.56s ======================================================================
```