### PR TITLE
Fix typo in allow_password_change help

### DIFF
--- a/docs/source/other/full-config.rst
+++ b/docs/source/other/full-config.rst
@@ -135,7 +135,7 @@ ServerApp.allow_password_change : Bool
 
     Allow password to be changed at login for the Jupyter server.
 
-    While loggin in with a token, the Jupyter server UI will give the opportunity to
+    While logging in with a token, the Jupyter server UI will give the opportunity to
     the user to enter a new password at the same time that will replace
     the token login mechanism.
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -973,7 +973,7 @@ class ServerApp(JupyterApp):
     allow_password_change = Bool(True, config=True,
                     help="""Allow password to be changed at login for the Jupyter server.
 
-                    While loggin in with a token, the Jupyter server UI will give the opportunity to
+                    While logging in with a token, the Jupyter server UI will give the opportunity to
                     the user to enter a new password at the same time that will replace
                     the token login mechanism.
 


### PR DESCRIPTION
I spotted a typo in the help output for `allow_password_change`