### PR TITLE
Add the needed space in the welcome message

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2329,7 +2329,7 @@ class ServerApp(JupyterApp):
             info(_i18n("Welcome to Project Jupyter! Explore the various tools available"
                  " and their corresponding documentation. If you are interested"
                  " in contributing to the platform, please visit the community"
-                 "resources section at https://jupyter.org/community.html."))
+                 " resources section at https://jupyter.org/community.html."))
 
         self.write_server_info_file()
         self.write_browser_open_files()


### PR DESCRIPTION
 Ensure the needed space is present between `community`and `resources` to fix the following welcome message.

` in contributing to the platform, please visit the communityresources section at https://jupyter.org/community.html``

