### PR TITLE
decode bytes from secure cookie

### DIFF
--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -172,6 +172,8 @@ class LoginHandler(JupyterHandler):
         if user_id is None:
             get_secure_cookie_kwargs  = handler.settings.get('get_secure_cookie_kwargs', {})
             user_id = handler.get_secure_cookie(handler.cookie_name, **get_secure_cookie_kwargs )
+            if user_id:
+                user_id = user_id.decode()
         else:
             cls.set_login_cookie(handler, user_id)
             # Record that the current request has been authenticated with a token.


### PR DESCRIPTION
The get_secure_cookie interface returns bytes not str.

https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_secure_cookie

This fixes a minor issue where `handler.get_current_user` would return bytes rather than str.

#### Instructions to replicate

Log the result of `handler.get_current_user()`, minimal example:

```python
class MyExtensionHandler(ExtensionHandlerMixin, JupyterHandler):  

    @tornado.web.authenticated
    def get(self):
        user = self.get_current_user()
        self.log.info(user)                                                 
        self.write('hello world')  
```

Remove the token from the URL and reload the page (forces server to load the cookie value).

You should see the same token (because it was cashed in the cookie) but as bytes:

```
[I 2021-07-28 16:21:32.922 MyExtensionApp] 16046493615940198642c40b2fae7cb3
[I 2021-07-28 16:21:37.210 MyExtensionApp] b'16046493615940198642c40b2fae7cb3'
```

After this PR both should be str.