### PR TITLE
fix: make command line aliases work again

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -492,6 +492,7 @@ class ExtensionApp(JupyterApp):
             find_extensions = False
         serverapp = ServerApp.instance(
             jpserver_extensions=jpserver_extensions, **kwargs)
+        serverapp.aliases.update(cls.aliases)
         serverapp.initialize(
             argv=argv,
             starter_extension=cls.name,


### PR DESCRIPTION
This was broken by an unintentionally removed line in 0d11ffca.

Fixes #550