### PR TITLE
Set stacklevel on warning to point to the right place.

### DIFF
--- a/jupyter_server/transutils.py
+++ b/jupyter_server/transutils.py
@@ -10,7 +10,7 @@ import gettext
 
 def _trans_gettext_deprecation_helper(*args, **kwargs):
     warn_msg = "The alias `_()` will be deprecated. Use `_i18n()` instead."
-    warnings.warn(warn_msg, FutureWarning)
+    warnings.warn(warn_msg, FutureWarning, stacklevel=2)
     return trans.gettext(*args, **kwargs)
 
 


### PR DESCRIPTION
Without stacklevel=2, the warnings are a bit useless as we don't know
where the deprecated function is used.