### PR TITLE
pytest_plugin: allow user specified headers in jp_ws_fetch

### DIFF
--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -368,7 +368,7 @@ def jp_ws_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_http_port, 
         # Add auth keys to header
         headers.update(jp_auth_header)
         # Make request.
-        req = tornado.httpclient.HTTPRequest(url, headers=jp_auth_header, connect_timeout=120)
+        req = tornado.httpclient.HTTPRequest(url, headers=headers, connect_timeout=120)
         return tornado.websocket.websocket_connect(req)
 
     return client_fetch

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -316,7 +316,11 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
             ...
     """
 
-    def client_fetch(*parts, headers={}, params={}, **kwargs):
+    def client_fetch(*parts, headers=None, params=None, **kwargs):
+        if not headers:
+            headers = {}
+        if not params:
+            params = {}
         # Handle URL strings
         path_url = url_escape(url_path_join(*parts), plus=False)
         base_path_url = url_path_join(jp_base_url, path_url)
@@ -358,7 +362,11 @@ def jp_ws_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_http_port, 
             ...
     """
 
-    def client_fetch(*parts, headers={}, params={}, **kwargs):
+    def client_fetch(*parts, headers=None, params=None, **kwargs):
+        if not headers:
+            headers = {}
+        if not params:
+            params = {}
         # Handle URL strings
         path_url = url_escape(url_path_join(*parts), plus=False)
         base_path_url = url_path_join(jp_base_url, path_url)


### PR DESCRIPTION
Fixes a small error in the `jp_ws_fetch` fixture where the `headers` provided to `client_fetch` were ignored in requests.