### PR TITLE
Fix jupyter_client warning

### DIFF
--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -9,7 +9,11 @@ from urllib.parse import urlparse
 
 import tornado
 from ipython_genutils.py3compat import cast_unicode
-from jupyter_client.jsonutil import date_default
+
+try:
+    from jupyter_client.jsonutil import json_default
+except ImportError:
+    from jupyter_client.jsonutil import date_default as json_default
 from jupyter_client.jsonutil import extract_dates
 from jupyter_client.session import Session
 from tornado import ioloop
@@ -39,7 +43,7 @@ def serialize_binary_message(msg):
     buffers = list(msg.pop("buffers"))
     if sys.version_info < (3, 4):
         buffers = [x.tobytes() for x in buffers]
-    bmsg = json.dumps(msg, default=date_default).encode("utf8")
+    bmsg = json.dumps(msg, default=json_default).encode("utf8")
     buffers.insert(0, bmsg)
     nbufs = len(buffers)
     offsets = [4 * (nbufs + 1)]
@@ -227,7 +231,7 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             buf = serialize_binary_message(msg)
             return buf
         else:
-            smsg = json.dumps(msg, default=date_default)
+            smsg = json.dumps(msg, default=json_default)
             return cast_unicode(smsg)
 
     def _on_zmq_reply(self, stream, msg_list):

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -6,7 +6,10 @@ Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-27%3A-
 # Distributed under the terms of the Modified BSD License.
 import json
 
-from jupyter_client.jsonutil import date_default
+try:
+    from jupyter_client.jsonutil import json_default
+except ImportError:
+    from jupyter_client.jsonutil import date_default as json_default
 from tornado import web
 
 from jupyter_server.base.handlers import APIHandler
@@ -77,7 +80,7 @@ class ContentsHandler(APIHandler):
             self.set_header("Location", location)
         self.set_header("Last-Modified", model["last_modified"])
         self.set_header("Content-Type", "application/json")
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
     @web.authenticated
     async def get(self, path=""):
@@ -237,7 +240,7 @@ class CheckpointsHandler(APIHandler):
         """get lists checkpoints for a file"""
         cm = self.contents_manager
         checkpoints = await ensure_async(cm.list_checkpoints(path))
-        data = json.dumps(checkpoints, default=date_default)
+        data = json.dumps(checkpoints, default=json_default)
         self.finish(data)
 
     @web.authenticated
@@ -245,7 +248,7 @@ class CheckpointsHandler(APIHandler):
         """post creates a new checkpoint"""
         cm = self.contents_manager
         checkpoint = await ensure_async(cm.create_checkpoint(path))
-        data = json.dumps(checkpoint, default=date_default)
+        data = json.dumps(checkpoint, default=json_default)
         location = url_path_join(
             self.base_url,
             "api/contents",

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -10,7 +10,11 @@ from textwrap import dedent
 
 from ipython_genutils.py3compat import cast_unicode
 from jupyter_client import protocol_version as client_protocol_version
-from jupyter_client.jsonutil import date_default
+
+try:
+    from jupyter_client.jsonutil import json_default
+except ImportError:
+    from jupyter_client.jsonutil import date_default as json_default
 from tornado import gen
 from tornado import web
 from tornado.concurrent import Future
@@ -29,7 +33,7 @@ class MainKernelHandler(APIHandler):
     async def get(self):
         km = self.kernel_manager
         kernels = await ensure_async(km.list_kernels())
-        self.finish(json.dumps(kernels, default=date_default))
+        self.finish(json.dumps(kernels, default=json_default))
 
     @web.authenticated
     async def post(self):
@@ -45,7 +49,7 @@ class MainKernelHandler(APIHandler):
         location = url_path_join(self.base_url, "api", "kernels", url_escape(kernel_id))
         self.set_header("Location", location)
         self.set_status(201)
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
 
 class KernelHandler(APIHandler):
@@ -53,7 +57,7 @@ class KernelHandler(APIHandler):
     async def get(self, kernel_id):
         km = self.kernel_manager
         model = await ensure_async(km.kernel_model(kernel_id))
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
     @web.authenticated
     async def delete(self, kernel_id):
@@ -79,7 +83,7 @@ class KernelActionHandler(APIHandler):
                 self.set_status(500)
             else:
                 model = await ensure_async(km.kernel_model(kernel_id))
-                self.write(json.dumps(model, default=date_default))
+                self.write(json.dumps(model, default=json_default))
         self.finish()
 
 
@@ -443,7 +447,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                 "stream", content={"text": error_message + "\n", "name": "stderr"}, parent=parent
             )
             msg["channel"] = "iopub"
-            self.write_message(json.dumps(msg, default=date_default))
+            self.write_message(json.dumps(msg, default=json_default))
 
         channel = getattr(stream, "channel", None)
         msg_type = msg["header"]["msg_type"]
@@ -610,7 +614,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             iopub.flush()
         msg = self.session.msg("status", {"execution_state": status})
         msg["channel"] = "iopub"
-        self.write_message(json.dumps(msg, default=date_default))
+        self.write_message(json.dumps(msg, default=json_default))
 
     def on_kernel_restarted(self):
         logging.warn("kernel %s restarted", self.kernel_id)

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -6,7 +6,10 @@ Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-16%3A-
 # Distributed under the terms of the Modified BSD License.
 import json
 
-from jupyter_client.jsonutil import date_default
+try:
+    from jupyter_client.jsonutil import json_default
+except ImportError:
+    from jupyter_client.jsonutil import date_default as json_default
 from jupyter_client.kernelspec import NoSuchKernel
 from tornado import web
 
@@ -21,7 +24,7 @@ class SessionRootHandler(APIHandler):
         # Return a list of running sessions
         sm = self.session_manager
         sessions = await ensure_async(sm.list_sessions())
-        self.finish(json.dumps(sessions, default=date_default))
+        self.finish(json.dumps(sessions, default=json_default))
 
     @web.authenticated
     async def post(self):
@@ -79,7 +82,7 @@ class SessionRootHandler(APIHandler):
         location = url_path_join(self.base_url, "api", "sessions", model["id"])
         self.set_header("Location", location)
         self.set_status(201)
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
 
 class SessionHandler(APIHandler):
@@ -88,7 +91,7 @@ class SessionHandler(APIHandler):
         # Returns the JSON model for a single session
         sm = self.session_manager
         model = await sm.get_session(session_id=session_id)
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
     @web.authenticated
     async def patch(self, session_id):
@@ -142,7 +145,7 @@ class SessionHandler(APIHandler):
             # kernel_id changed because we got a new kernel
             # shutdown the old one
             await ensure_async(km.shutdown_kernel(before["kernel"]["id"]))
-        self.finish(json.dumps(model, default=date_default))
+        self.finish(json.dumps(model, default=json_default))
 
     @web.authenticated
     async def delete(self, session_id):


### PR DESCRIPTION
Fix the jupyter_client warning:

```
/home/martin/miniconda3/envs/xeus-python/lib/python3.9/json/encoder.py:257: 
UserWarning: date_default is deprecated since jupyter_client 7.0.0. Use jupyter_client.jsonutil.json_default.
```