### PR TITLE
Do not log connection error if the kernel is already shutdown

### DIFF
--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -392,7 +392,14 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                 self.create_stream()
                 connected = self.nudge()
             except web.HTTPError as e:
-                self.log.error("Error opening stream: %s", e)
+                # Do not log error if the kernel is already shutdown,
+                # as it's normal that it's not responding
+                try:
+                    self.kernel_manager.get_kernel(kernel_id)
+
+                    self.log.error("Error opening stream: %s", e)
+                except KeyError:
+                    pass
                 # WebSockets don't respond to traditional error codes so we
                 # close the connection.
                 for channel, stream in self.channels.items():


### PR DESCRIPTION
I had the following error locally:

```
[Voila] Kernel shutdown: c7f832d5-6b46-4f77-9f98-f0b9ca6e7ac8
[Voila] WARNING | Timeout waiting for kernel_info reply from c7f832d5-6b46-4f77-9f98-f0b9ca6e7ac8
[Voila] ERROR | Error opening stream: HTTP 404: Not Found (Kernel does not exist: c7f832d5-6b46-4f77-9f98-f0b9ca6e7ac8)
```

This was because I closed the Voila application before the client could
finish connecting to the kernel.

With this PR, it should shutdown the kernel properly and be silent after
not being able to connect.