### PR TITLE
[BUG]: allow None for min_open_files_limit trait

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1020,6 +1020,7 @@ class ServerApp(JupyterApp):
         OSError: [Errno 24] Too many open files.
         This is not applicable when running on Windows.
         """,
+        allow_none=True
     )
 
     @default("min_open_files_limit")

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1020,7 +1020,7 @@ class ServerApp(JupyterApp):
         OSError: [Errno 24] Too many open files.
         This is not applicable when running on Windows.
         """,
-        allow_none=True
+        allow_none=True,
     )
 
     @default("min_open_files_limit")


### PR DESCRIPTION
The default value for this `min_open_files_limit` is `None` on Windows, but this trait doesn't (currently) allow `None`. This was causing issues in nbclassic unit tests, https://github.com/jupyterlab/nbclassic/pull/63