### PR TITLE
Use pending kernels

### DIFF
--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -177,6 +177,10 @@ class WebSocketMixin(object):
             self.ping_callback.stop()
             return
 
+        if self.ws_connection.client_terminated:
+            self.close()
+            return
+
         # check for timeout on pong.  Make sure that we really have sent a recent ping in
         # case the machine with both server and client has been suspended since the last ping.
         now = ioloop.IOLoop.current().time()

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -416,13 +416,16 @@ sample_kernel_json = {
 @pytest.fixture
 def jp_kernelspecs(jp_data_dir):
     """Configures some sample kernelspecs in the Jupyter data directory."""
-    spec_names = ["sample", "sample 2"]
+    spec_names = ["sample", "sample 2", "bad"]
     for name in spec_names:
         sample_kernel_dir = jp_data_dir.joinpath("kernels", name)
         sample_kernel_dir.mkdir(parents=True)
         # Create kernel json file
         sample_kernel_file = sample_kernel_dir.joinpath("kernel.json")
-        sample_kernel_file.write_text(json.dumps(sample_kernel_json))
+        kernel_json = sample_kernel_json.copy()
+        if name == "bad":
+            kernel_json["argv"] = ["non_existent_path"]
+        sample_kernel_file.write_text(json.dumps(kernel_json))
         # Create resources text
         sample_kernel_resources = sample_kernel_dir.joinpath("resource.txt")
         sample_kernel_resources.write_text(some_resource)
@@ -474,12 +477,24 @@ def jp_cleanup_subprocesses(jp_serverapp):
         terminal_cleanup = jp_serverapp.web_app.settings["terminal_manager"].terminate_all
         kernel_cleanup = jp_serverapp.kernel_manager.shutdown_all
         if asyncio.iscoroutinefunction(terminal_cleanup):
-            await terminal_cleanup()
+            try:
+                await terminal_cleanup()
+            except Exception as e:
+                print(e)
         else:
-            terminal_cleanup()
+            try:
+                await terminal_cleanup()
+            except Exception as e:
+                print(e)
         if asyncio.iscoroutinefunction(kernel_cleanup):
-            await kernel_cleanup()
+            try:
+                await kernel_cleanup()
+            except Exception as e:
+                print(e)
         else:
-            kernel_cleanup()
+            try:
+                kernel_cleanup()
+            except Exception as e:
+                print(e)
 
     return _

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -527,7 +527,7 @@ class MappingKernelManager(MultiKernelManager):
     def stop_watching_activity(self, kernel_id):
         """Stop watching IOPub messages on a kernel for activity."""
         kernel = self._kernels[kernel_id]
-        if getattr(kernel, '_activity_stream', None):
+        if getattr(kernel, "_activity_stream", None):
             kernel._activity_stream.close()
             kernel._activity_stream = None
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -527,7 +527,7 @@ class MappingKernelManager(MultiKernelManager):
     def stop_watching_activity(self, kernel_id):
         """Stop watching IOPub messages on a kernel for activity."""
         kernel = self._kernels[kernel_id]
-        if kernel._activity_stream:
+        if getattr(kernel, '_activity_stream', None):
             kernel._activity_stream.close()
             kernel._activity_stream = None
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -5,6 +5,7 @@
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import asyncio
 import os
 from collections import defaultdict
 from datetime import datetime
@@ -209,16 +210,14 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs["kernel_id"] = kernel_id
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
-            self._kernel_ports[kernel_id] = self._kernels[kernel_id].ports
-            self.start_watching_activity(kernel_id)
+            asyncio.ensure_future(self._finish_kernel_start(kernel_id))
+            # add busy/activity markers:
+            kernel = self.get_kernel(kernel_id)
+            kernel.execution_state = "starting"
+            kernel.reason = ""
+            kernel.last_activity = utcnow()
             self.log.info("Kernel started: %s" % kernel_id)
             self.log.debug("Kernel args: %r" % kwargs)
-            # register callback for failed auto-restart
-            self.add_restart_callback(
-                kernel_id,
-                lambda: self._handle_kernel_died(kernel_id),
-                "dead",
-            )
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1
@@ -232,6 +231,24 @@ class MappingKernelManager(MultiKernelManager):
             self.initialize_culler()
 
         return kernel_id
+
+    async def _finish_kernel_start(self, kernel_id):
+        km = self.get_kernel(kernel_id)
+        if hasattr(km, "ready"):
+            try:
+                await km.ready
+            except Exception:
+                self.log.exception(km.ready.exception())
+                return
+
+        self._kernel_ports[kernel_id] = km.ports
+        self.start_watching_activity(kernel_id)
+        # register callback for failed auto-restart
+        self.add_restart_callback(
+            kernel_id,
+            lambda: self._handle_kernel_died(kernel_id),
+            "dead",
+        )
 
     def ports_changed(self, kernel_id):
         """Used by ZMQChannelsHandler to determine how to coordinate nudge and replays.
@@ -448,6 +465,8 @@ class MappingKernelManager(MultiKernelManager):
             "execution_state": kernel.execution_state,
             "connections": self._kernel_connections.get(kernel_id, 0),
         }
+        if getattr(kernel, "reason", None):
+            model["reason"] = kernel.reason
         return model
 
     def list_kernels(self):
@@ -479,6 +498,7 @@ class MappingKernelManager(MultiKernelManager):
         kernel = self._kernels[kernel_id]
         # add busy/activity markers:
         kernel.execution_state = "starting"
+        kernel.reason = ""
         kernel.last_activity = utcnow()
         kernel._activity_stream = kernel.connect_iopub()
         session = Session(
@@ -561,6 +581,17 @@ class MappingKernelManager(MultiKernelManager):
 
     async def cull_kernel_if_idle(self, kernel_id):
         kernel = self._kernels[kernel_id]
+
+        if getattr(kernel, "execution_state") == "dead":
+            self.log.warning(
+                "Culling '%s' dead kernel '%s' (%s).",
+                kernel.execution_state,
+                kernel.kernel_name,
+                kernel_id,
+            )
+            await ensure_async(self.shutdown_kernel(kernel_id))
+            return
+
         if hasattr(
             kernel, "last_activity"
         ):  # last_activity is monkey-patched, so ensure that has occurred

--- a/jupyter_server/tests/services/kernels/test_cull.py
+++ b/jupyter_server/tests/services/kernels/test_cull.py
@@ -34,7 +34,7 @@ def jp_server_config():
     )
 
 
-async def test_culling(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
+async def test_cull_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
     kid = kernel["id"]
@@ -49,6 +49,30 @@ async def test_culling(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
     assert not culled
     ws.close()
     culled = await get_cull_status(kid, jp_fetch)  # not connected, should be culled
+    assert culled
+    await jp_cleanup_subprocesses()
+
+
+async def test_cull_dead(
+    jp_fetch, jp_ws_fetch, jp_serverapp, jp_cleanup_subprocesses, jp_kernelspecs
+):
+    if not hasattr(jp_serverapp.kernel_manager, "use_pending_kernels"):
+        return
+
+    jp_serverapp.kernel_manager.use_pending_kernels = True
+    jp_serverapp.kernel_manager.default_kernel_name = "bad"
+    r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
+    kernel = json.loads(r.body.decode())
+    kid = kernel["id"]
+
+    # Open a websocket connection.
+    with pytest.raises(HTTPClientError):
+        await jp_ws_fetch("api", "kernels", kid, "channels")
+
+    r = await jp_fetch("api", "kernels", kid, method="GET")
+    model = json.loads(r.body.decode())
+    assert model["connections"] == 0
+    culled = await get_cull_status(kid, jp_fetch)  # connected, should not be culled
     assert culled
     await jp_cleanup_subprocesses()
 

--- a/jupyter_server/tests/services/kernelspecs/test_api.py
+++ b/jupyter_server/tests/services/kernelspecs/test_api.py
@@ -9,7 +9,7 @@ from ...utils import some_resource
 
 
 async def test_list_kernelspecs_bad(jp_fetch, jp_kernelspecs, jp_data_dir):
-    bad_kernel_dir = jp_data_dir.joinpath(jp_data_dir, "kernels", "bad")
+    bad_kernel_dir = jp_data_dir.joinpath(jp_data_dir, "kernels", "bad2")
     bad_kernel_dir.mkdir(parents=True)
     bad_kernel_json = bad_kernel_dir.joinpath("kernel.json")
     bad_kernel_json.write_text("garbage")

--- a/jupyter_server/tests/services/sessions/test_api.py
+++ b/jupyter_server/tests/services/sessions/test_api.py
@@ -7,6 +7,7 @@ import tornado
 from jupyter_client.ioloop import AsyncIOLoopKernelManager
 from nbformat import writes
 from nbformat.v4 import new_notebook
+from tornado.httpclient import HTTPClientError
 from traitlets import default
 
 from ...utils import expected_http_error
@@ -39,10 +40,13 @@ class NewPortsMappingKernelManager(AsyncMappingKernelManager):
 )
 def jp_argv(request):
     if request.param == "NewPortsMappingKernelManager":
+        extra = []
+        if hasattr(AsyncMappingKernelManager, "use_pending_kernels"):
+            extra = ["--AsyncMappingKernelManager.use_pending_kernels=True"]
         return [
             "--ServerApp.kernel_manager_class=jupyter_server.tests.services.sessions.test_api."
             + request.param
-        ]
+        ] + extra
     return [
         "--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager."
         + request.param
@@ -68,7 +72,7 @@ class SessionClient:
     async def get(self, id):
         return await self._req(id, method="GET")
 
-    async def create(self, path, type="notebook", kernel_name="python", kernel_id=None):
+    async def create(self, path, type="notebook", kernel_name=None, kernel_id=None):
         body = {"path": path, "type": type, "kernel": {"name": kernel_name, "id": kernel_id}}
         return await self._req(method="POST", body=body)
 
@@ -151,7 +155,7 @@ def assert_session_equality(actual, expected):
     assert_kernel_equality(actual["kernel"], expected["kernel"])
 
 
-async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses):
+async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses, jp_serverapp):
     # Make sure no sessions exist.
     resp = await session_client.list()
     sessions = j(resp)
@@ -167,6 +171,17 @@ async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses):
     assert resp.headers["Location"] == url_path_join(
         jp_base_url, "/api/sessions/", new_session["id"]
     )
+
+    # Make sure kernel is in expected state
+    kid = new_session["kernel"]["id"]
+    kernel = jp_serverapp.kernel_manager.get_kernel(kid)
+
+    if hasattr(kernel, "ready"):
+        km = jp_serverapp.kernel_manager
+        if isinstance(km, AsyncMappingKernelManager):
+            assert kernel.ready.done() == (not km.use_pending_kernels)
+        else:
+            assert kernel.ready.done()
 
     # Check that the new session appears in list.
     resp = await session_client.list()
@@ -185,7 +200,60 @@ async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_create_file_session(session_client, jp_cleanup_subprocesses):
+async def test_create_bad(
+    session_client, jp_base_url, jp_cleanup_subprocesses, jp_serverapp, jp_kernelspecs
+):
+    if getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
+        return
+
+    # Make sure no sessions exist.
+    jp_serverapp.kernel_manager.default_kernel_name = "bad"
+    resp = await session_client.list()
+    sessions = j(resp)
+    assert len(sessions) == 0
+
+    # Create a session.
+    with pytest.raises(HTTPClientError):
+        await session_client.create("foo/nb1.ipynb")
+
+    # Need to find a better solution to this.
+    await session_client.cleanup()
+    await jp_cleanup_subprocesses()
+
+
+async def test_create_bad_pending(
+    session_client, jp_base_url, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp, jp_kernelspecs
+):
+    if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
+        return
+
+    # Make sure no sessions exist.
+    jp_serverapp.kernel_manager.default_kernel_name = "bad"
+    resp = await session_client.list()
+    sessions = j(resp)
+    assert len(sessions) == 0
+
+    # Create a session.
+    resp = await session_client.create("foo/nb1.ipynb")
+    assert resp.code == 201
+
+    # Open a websocket connection.
+    kid = j(resp)["kernel"]["id"]
+    with pytest.raises(HTTPClientError):
+        await jp_ws_fetch("api", "kernels", kid, "channels")
+
+    # Get the updated kernel state
+    resp = await session_client.list()
+    session = j(resp)[0]
+    assert session["kernel"]["execution_state"] == "dead"
+    assert "non_existent_path" in session["kernel"]["reason"]
+
+    # Need to find a better solution to this.
+    await session_client.cleanup()
+    await jp_cleanup_subprocesses()
+
+
+async def test_create_file_session(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.py", type="file")
     assert resp.code == 201
     newsession = j(resp)
@@ -195,7 +263,7 @@ async def test_create_file_session(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_create_console_session(session_client, jp_cleanup_subprocesses):
+async def test_create_console_session(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/abc123", type="console")
     assert resp.code == 201
     newsession = j(resp)
@@ -206,7 +274,7 @@ async def test_create_console_session(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_create_deprecated(session_client, jp_cleanup_subprocesses):
+async def test_create_deprecated(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create_deprecated("foo/nb1.ipynb")
     assert resp.code == 201
     newsession = j(resp)
@@ -219,7 +287,7 @@ async def test_create_deprecated(session_client, jp_cleanup_subprocesses):
 
 
 async def test_create_with_kernel_id(
-    session_client, jp_fetch, jp_base_url, jp_cleanup_subprocesses
+    session_client, jp_fetch, jp_base_url, jp_cleanup_subprocesses, jp_serverapp
 ):
     # create a new kernel
     resp = await jp_fetch("api/kernels", method="POST", allow_nonstandard_methods=True)
@@ -250,7 +318,18 @@ async def test_create_with_kernel_id(
     await jp_cleanup_subprocesses()
 
 
-async def test_delete(session_client, jp_cleanup_subprocesses):
+async def test_create_with_bad_kernel_id(session_client, jp_cleanup_subprocesses, jp_serverapp):
+    resp = await session_client.create("foo/nb1.py", type="file")
+    assert resp.code == 201
+    newsession = j(resp)
+    # TODO
+    assert newsession["path"] == "foo/nb1.py"
+    assert newsession["type"] == "file"
+    await session_client.cleanup()
+    await jp_cleanup_subprocesses()
+
+
+async def test_delete(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     newsession = j(resp)
     sid = newsession["id"]
@@ -270,7 +349,7 @@ async def test_delete(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_modify_path(session_client, jp_cleanup_subprocesses):
+async def test_modify_path(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     newsession = j(resp)
     sid = newsession["id"]
@@ -284,7 +363,7 @@ async def test_modify_path(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_modify_path_deprecated(session_client, jp_cleanup_subprocesses):
+async def test_modify_path_deprecated(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     newsession = j(resp)
     sid = newsession["id"]
@@ -298,7 +377,7 @@ async def test_modify_path_deprecated(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_modify_type(session_client, jp_cleanup_subprocesses):
+async def test_modify_type(session_client, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     newsession = j(resp)
     sid = newsession["id"]
@@ -312,7 +391,7 @@ async def test_modify_type(session_client, jp_cleanup_subprocesses):
     await jp_cleanup_subprocesses()
 
 
-async def test_modify_kernel_name(session_client, jp_fetch, jp_cleanup_subprocesses):
+async def test_modify_kernel_name(session_client, jp_fetch, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     before = j(resp)
     sid = before["id"]
@@ -329,13 +408,17 @@ async def test_modify_kernel_name(session_client, jp_fetch, jp_cleanup_subproces
     kernel_list = j(resp)
     after["kernel"].pop("last_activity")
     [k.pop("last_activity") for k in kernel_list]
-    assert kernel_list == [after["kernel"]]
+    if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
+        assert kernel_list == [after["kernel"]]
+    else:
+        assert len(kernel_list) == 2
+
     # Need to find a better solution to this.
     await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
-async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesses):
+async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesses, jp_serverapp):
     resp = await session_client.create("foo/nb1.ipynb")
     before = j(resp)
     sid = before["id"]
@@ -359,7 +442,10 @@ async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesse
 
     kernel.pop("last_activity")
     [k.pop("last_activity") for k in kernel_list]
-    assert kernel_list == [kernel]
+    if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
+        assert kernel_list == [kernel]
+    else:
+        assert len(kernel_list) == 2
 
     # Need to find a better solution to this.
     await session_client.cleanup()
@@ -369,7 +455,6 @@ async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesse
 async def test_restart_kernel(
     session_client, jp_base_url, jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses
 ):
-
     # Create a session.
     resp = await session_client.create("foo/nb1.ipynb")
     assert resp.code == 201

--- a/jupyter_server/tests/services/sessions/test_api.py
+++ b/jupyter_server/tests/services/sessions/test_api.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import time
 
@@ -246,7 +247,8 @@ async def test_create_bad_pending(
     resp = await session_client.list()
     session = j(resp)[0]
     assert session["kernel"]["execution_state"] == "dead"
-    assert "non_existent_path" in session["kernel"]["reason"]
+    if os.name != "nt":
+        assert "non_existent_path" in session["kernel"]["reason"]
 
     # Need to find a better solution to this.
     await session_client.cleanup()

--- a/jupyter_server/tests/services/sessions/test_api.py
+++ b/jupyter_server/tests/services/sessions/test_api.py
@@ -444,8 +444,6 @@ async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesse
     [k.pop("last_activity") for k in kernel_list]
     if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
         assert kernel_list == [kernel]
-    else:
-        assert len(kernel_list) == 2
 
     # Need to find a better solution to this.
     await session_client.cleanup()

--- a/jupyter_server/tests/services/sessions/test_api.py
+++ b/jupyter_server/tests/services/sessions/test_api.py
@@ -177,7 +177,7 @@ async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses, jp_s
     kid = new_session["kernel"]["id"]
     kernel = jp_serverapp.kernel_manager.get_kernel(kid)
 
-    if hasattr(kernel, "ready"):
+    if hasattr(kernel, "ready") and os.name != "nt":
         km = jp_serverapp.kernel_manager
         if isinstance(km, AsyncMappingKernelManager):
             assert kernel.ready.done() == (not km.use_pending_kernels)
@@ -412,8 +412,6 @@ async def test_modify_kernel_name(session_client, jp_fetch, jp_cleanup_subproces
     [k.pop("last_activity") for k in kernel_list]
     if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
         assert kernel_list == [after["kernel"]]
-    else:
-        assert len(kernel_list) == 2
 
     # Need to find a better solution to this.
     await session_client.cleanup()


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_server/issues/592.
Fixes https://github.com/jupyterlab/jupyterlab/issues/11338
Requires https://github.com/jupyter/jupyter_client/pull/712 in order to use the new feature.

We cannot make `use_pending_kernels` default to `True` before a major version bump because clients like JupyterLab are expecting kernel process startup errors to be given as part of the response to a POST on `/api/sessions`.  
This PR needs an alternate way of surfacing that error as discussed in #592.
There is also a behavior change of a restart being ignored (and erroring) if the process has not yet started.

- [x] Do not depend on `use_pending_kernels` being available so we maintain compat with older `jupyter_client` versions
- [x] Wait for the kernel to be ready in the WebSocket handler and catch the error appropriately.  
   - Set the `execution_state` to `"dead"` and set the `"reason"` based on the startup error
   - Add handling of the `"reason"` field to the kernel response model
   - Make sure to clear the `"reason"` field at kernel startup
- [x] Cull dead kernels in the kernel culler and add test
- [x] Do not wait for kernel shutdown when switching kernels in a session when `use_pending_kernels` is set
- [x] Better handling of synchronous process startup errors - fixes https://github.com/jupyterlab/jupyterlab/issues/11338
- [x] Make all kernel/session tests work with and without `use_pending_kernels`
- [x] Add tests for bad kernelspecs in kernel and sessions API
- [x] Add prototype in JupyterLab - https://github.com/jupyterlab/jupyterlab/pull/11358

<img width="512" alt="image" src="https://user-images.githubusercontent.com/2096628/139239903-9e2d3728-c733-4764-87c7-67dea983bdc3.png">

