### PR TITLE
Remove requests-unixsocket dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     prometheus_client
     anyio>=3.1.0,<4
     websocket-client
-    requests-unixsocket
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Unix socket support was ported from Notebook which has a test that uses `requests-unixsocket` to test the functionality.  Later, we updated the Notebook test to use a lazy import so we could [remove this dependency on Windows](https://github.com/jupyter/notebook/pull/5650).

The tests within jupyter_server are quite different and it appears, based on the successful tests, that this dependency isn't required at all.  I'm sure it was just an artifact from the original port.  This pull request removes the dependency.

Fixes: #598