### PR TITLE
Avoid dependency on NBConvert versions for REST API test

### DIFF
--- a/jupyter_server/tests/services/nbconvert/test_api.py
+++ b/jupyter_server/tests/services/nbconvert/test_api.py
@@ -4,7 +4,11 @@ import json
 async def test_list_formats(jp_fetch):
     r = await jp_fetch("api", "nbconvert", method="GET")
     formats = json.loads(r.body.decode())
+    # Verify the type of the response.
     assert isinstance(formats, dict)
-    assert "python" in formats
-    assert "html" in formats
-    assert formats["python"]["output_mimetype"] == "text/x-python"
+    # Verify that all returned formats have an
+    # output mimetype defined.
+    required_keys_present = []
+    for name, data in formats.items():
+        required_keys_present.append("output_mimetype" in data)
+    assert all(required_keys_present), "All returned formats must have a `output_mimetype` key."


### PR DESCRIPTION
Relaxes one of the NBConvert API tests, so it's not dependent on NBConvert versions and only tests the REST API.  