### PR TITLE
Fix allow_origin_pat property to properly parse regex

### DIFF
--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -53,7 +53,7 @@ class LoginHandler(JupyterHandler):
                 if self.allow_origin:
                     allow = self.allow_origin == origin
                 elif self.allow_origin_pat:
-                    allow = bool(self.allow_origin_pat.match(origin))
+                    allow = bool(re.match(self.allow_origin_pat, origin))
             if not allow:
                 # not allowed, use default
                 self.log.warning("Not allowing login redirect to %r" % url)

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -295,8 +295,7 @@ class JupyterHandler(AuthenticatedHandler):
     @property
     def allow_origin_pat(self):
         """Regular expression version of allow_origin"""
-        pat_str = self.settings.get("allow_origin_pat", None)
-        return re.compile(pat_str) if pat_str else None
+        return self.settings.get("allow_origin_pat", None)
 
     @property
     def allow_credentials(self):
@@ -310,7 +309,7 @@ class JupyterHandler(AuthenticatedHandler):
             self.set_header("Access-Control-Allow-Origin", self.allow_origin)
         elif self.allow_origin_pat:
             origin = self.get_origin()
-            if origin and self.allow_origin_pat.match(origin):
+            if origin and re.match(self.allow_origin_pat, origin):
                 self.set_header("Access-Control-Allow-Origin", origin)
         elif self.token_authenticated and "Access-Control-Allow-Origin" not in self.settings.get(
             "headers", {}
@@ -383,7 +382,7 @@ class JupyterHandler(AuthenticatedHandler):
         if self.allow_origin:
             allow = self.allow_origin == origin
         elif self.allow_origin_pat:
-            allow = bool(self.allow_origin_pat.match(origin))
+            allow = bool(re.match(self.allow_origin_pat, origin))
         else:
             # No CORS headers deny the request
             allow = False
@@ -428,7 +427,7 @@ class JupyterHandler(AuthenticatedHandler):
         if self.allow_origin:
             allow = self.allow_origin == origin
         elif self.allow_origin_pat:
-            allow = bool(self.allow_origin_pat.match(origin))
+            allow = bool(re.match(self.allow_origin_pat, origin))
         else:
             # No CORS settings, deny the request
             allow = False

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -295,7 +295,8 @@ class JupyterHandler(AuthenticatedHandler):
     @property
     def allow_origin_pat(self):
         """Regular expression version of allow_origin"""
-        return self.settings.get("allow_origin_pat", None)
+        pat_str = self.settings.get("allow_origin_pat", None)
+        return re.compile(pat_str) if pat_str else None
 
     @property
     def allow_credentials(self):

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -3,6 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
+import re
 import struct
 import sys
 from urllib.parse import urlparse
@@ -139,7 +140,7 @@ class WebSocketMixin(object):
         if self.allow_origin:
             allow = self.allow_origin == origin
         elif self.allow_origin_pat:
-            allow = bool(self.allow_origin_pat.match(origin))
+            allow = bool(re.match(self.allow_origin_pat, origin))
         else:
             # No CORS headers deny the request
             allow = False


### PR DESCRIPTION
This PR fixes a bug with the `allow_origin_pat` which prevented the Jupyter server from recognizing and parsing regex patterns.  Follows from discussions with @mariobuikhuizen on https://github.com/mariobuikhuizen/voila-embed/issues/24.  Example traceback of the current broken implementation that this PR fixes is 
```
Traceback (most recent call last):
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/http1connection.py", line 273, in _read_message
    delegate.finish()
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/routing.py", line 268, in finish
    self.delegate.finish()
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/web.py", line 2290, in finish
    self.execute()
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/web.py", line 2309, in execute
    self.handler = self.handler_class(
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/web.py", line 227, in __init__
    self.clear()
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/tornado/web.py", line 328, in clear
    self.set_default_headers()
  File "/Users/bcherinka/anaconda3/envs/havokve/lib/python3.8/site-packages/jupyter_server/base/handlers.py", line 300, in set_default_headers
    if origin and self.allow_origin_pat.match(origin):
AttributeError: 'str' object has no attribute 'match'
```


