### PR TITLE
Consistent logging method

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2710,7 +2710,8 @@ def list_running_servers(runtime_dir=None, log=None):
                 try:
                     os.unlink(os.path.join(runtime_dir, file_name))
                 except OSError as e:
-                    log.warning(_i18n("Deleting server info file failed: %s.") % e)
+                    if log:
+                        log.warning(_i18n("Deleting server info file failed: %s.") % e)
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -558,7 +558,7 @@ class JupyterServerStopApp(JupyterApp):
             pass
 
     def start(self):
-        servers = list(list_running_servers(self.runtime_dir))
+        servers = list(list_running_servers(self.runtime_dir, log=self.log))
         if not servers:
             self.exit("There are no running servers (per %s)" % self.runtime_dir)
         for server in servers:
@@ -619,7 +619,7 @@ class JupyterServerListApp(JupyterApp):
     )
 
     def start(self):
-        serverinfo_list = list(list_running_servers(self.runtime_dir))
+        serverinfo_list = list(list_running_servers(self.runtime_dir, log=self.log))
         if self.jsonlist:
             print(json.dumps(serverinfo_list, indent=2))
         elif self.json:
@@ -2682,7 +2682,7 @@ class ServerApp(JupyterApp):
                 self.io_loop.add_callback(self._stop)
 
 
-def list_running_servers(runtime_dir=None):
+def list_running_servers(runtime_dir=None, log=None):
     """Iterate over the server info files of running Jupyter servers.
 
     Given a runtime directory, find jpserver-* files in the security directory,
@@ -2709,8 +2709,8 @@ def list_running_servers(runtime_dir=None):
                 # If the process has died, try to delete its info file
                 try:
                     os.unlink(os.path.join(runtime_dir, file_name))
-                except OSError:
-                    pass  # TODO: This should warn or log or something
+                except OSError as e:
+                    log.warning(_i18n("Deleting server info file failed: %s.") % e)
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -5,7 +5,6 @@ Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-16%3A-
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import json
-import logging
 from textwrap import dedent
 
 from ipython_genutils.py3compat import cast_unicode

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -624,11 +624,11 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         self.write_message(json.dumps(msg, default=json_default))
 
     def on_kernel_restarted(self):
-        logging.warn("kernel %s restarted", self.kernel_id)
+        self.log.warning("kernel %s restarted", self.kernel_id)
         self._send_status_message("restarting")
 
     def on_restart_failed(self):
-        logging.error("kernel %s restarted failed!", self.kernel_id)
+        self.log.error("kernel %s restarted failed!", self.kernel_id)
         self._send_status_message("dead")
 
     def _on_error(self, msg):


### PR DESCRIPTION
### Problem
This closes #605 

Two methods in the class `ZMQChannelsHandler` were using the `logging` function directly instead of `self.log` method to emit logs. We already have a [default format](https://github.com/jupyter-server/jupyter_server/blob/90f619cf11eec842a27eec25692f9d65adccf169/jupyter_server/extension/application.py#L212) set for all Jupyter server logs, so this PR updates the following methods' logging calls to keep the format consistent. 

- `on_kernel_restarted`
- `on_restart_failed`

### Changes made

- Replace all logs emitted with direct use of `logging` with the instantiated class's own logging method: `self.log`.
- Add optional `log` parameter to `list_running_servers` to add missing warning log for failed server info file deletion.

### Tests
While trying to reproduce the logs with `logging`, I found out that logs emitted with the `logging` function weren't getting propagated. 

To reproduce the issue, I tested logging in the `ZMQChannelsHandler.on_iopub` method - [code](https://github.com/jupyter-server/jupyter_server/blob/ac93dd8f60de54db99167016f0396959826b8ed9/jupyter_server/services/kernels/handlers.py#L184). (I didn't know how to reproduce/trigger calls to `ZMQChannelsHandler.<on_kernel_restarted, on_restart_failed>`). I replaced `self.log` with`logging`.

```python
def on_iopub(msg):
            self.log.debug("!!!!!!!!!!! UPDATED LOGGING METHOD")
            logging.debug("Nudge: IOPub received: %s", self.kernel_id)
            if not iopub_future.done():
```

To emit the logs, I did the following:

1. Start Jupyter server: `jupyter server --ServerApp.log_level=DEBUG --ServerApp.jpserver_extensions='{"jupyterlab": True}'`
2. Create a python kernel
3. Restarte the python kernel

The "IoPub received" log wasn't emitted. 
```bash
[D 2021-11-06 10:15:34.214 ServerApp] !!!!!!!!!!! UPDATED LOGGING METHOD
[D 2021-11-06 10:15:34.214 ServerApp] Nudge: resolving iopub future: e1b8b87c-4d10-4782-bad7-50e7cf1cf732
[D 2021-11-06 10:15:34.214 ServerApp] Nudge: shell info reply received: e1b8b87c-4d10-4782-bad7-50e7cf1cf732
```

With `self.log`, the logs are emitted:
```bash
[D 2021-11-06 10:15:07.030 ServerApp] !!!!!!!!!!! UPDATED LOGGING METHOD
[D 2021-11-06 10:15:07.030 ServerApp] Nudge: IOPub received: 1e48ec11-17c0-487b-bd53-f24bce96617a
[D 2021-11-06 10:15:07.030 ServerApp] Nudge: resolving iopub future: 1e48ec11-17c0-487b-bd53-f24bce96617a
[D 2021-11-06 10:15:07.031 ServerApp] Nudge: shell info reply received: 1e48ec11-17c0-487b-bd53-f24bce96617a
```

At some point, we may want to figure out a way to encourage usage of `self.log` instead of `logging`.