### PR TITLE
test_api: Normalize file name and path

### DIFF
--- a/jupyter_server/tests/services/contents/test_api.py
+++ b/jupyter_server/tests/services/contents/test_api.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 from base64 import decodebytes
 from base64 import encodebytes
+from unicodedata import normalize
 
 import pytest
 import tornado
@@ -101,8 +102,8 @@ async def test_list_notebooks(jp_fetch, contents, path, name):
     data = json.loads(response.body.decode())
     nbs = notebooks_only(data)
     assert len(nbs) > 0
-    assert name + ".ipynb" in [n["name"] for n in nbs]
-    assert url_path_join(path, name + ".ipynb") in [n["path"] for n in nbs]
+    assert name + ".ipynb" in [normalize("NFC", n["name"]) for n in nbs]
+    assert url_path_join(path, name + ".ipynb") in [normalize("NFC", n["path"]) for n in nbs]
 
 
 @pytest.mark.parametrize("path,name", dirs)


### PR DESCRIPTION
test_list_notebooks was failing on file systems with unicode
normalization different from the encoding used in the strings. In particular on macOS with HFS+ I got failures for four of the file names. This is because HFS+ uses normalization form D while normalization form C is more commonly used, especially on Linux.

By normalizing the name and path read from disk to NFC we avoid the mismatch as long as no NFD strings are added to the `dirs` tuples. There are other unicode normal forms and normalization is not necessarily invertible so this is not a perfect solution.

I can think of two alternative solutions:

1. Refrain from using any unicode symbols that have different representations in the various normal forms.
2. Write temporary files to disk somewhere, the read back the paths and filenames and use those instead of the original strings in the test.