### PR TITLE
Persistent session storage

### DIFF
--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -28,10 +28,10 @@ class SessionManager(LoggingConfigurable):
     database_filepath = Unicode(
         default_value=":memory:",
         help=(
-            "Filesystem path to SQLite Database file. Does "
-            "not write to file by default. :memory: (default) stores the "
-            "database in-memory and is not persistent beyond "
-            "the current session."
+            "Th filesystem path to SQLite Database file "
+            "(e.g. /path/to/session_database.db). By default, the session "
+            "database is stored in-memory (i.e. `:memory:` setting from sqlite3) "
+            "and does not persist when the current Jupyter Server shuts down."
         )
     ).tag(config=True)
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -2,8 +2,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import os
-import uuid
 import pathlib
+import uuid
 
 try:
     import sqlite3
@@ -32,7 +32,7 @@ class SessionManager(LoggingConfigurable):
             "(e.g. /path/to/session_database.db). By default, the session "
             "database is stored in-memory (i.e. `:memory:` setting from sqlite3) "
             "and does not persist when the current Jupyter Server shuts down."
-        )
+        ),
     ).tag(config=True)
 
     @validate("database_filepath")
@@ -44,14 +44,16 @@ class SessionManager(LoggingConfigurable):
         if path.exists():
             # Verify that the database path is not a directory.
             if path.is_dir():
-                raise TraitError("`database_filepath` expected a file path, but the given path is a directory.")
+                raise TraitError(
+                    "`database_filepath` expected a file path, but the given path is a directory."
+                )
             # If the file exists, but it's empty, its a valid entry.
             if os.stat(path).st_size == 0:
                 return value
             # Verify that database path is an SQLite 3 Database by checking its header.
             with open(value, "rb") as f:
                 header = f.read(100)
-            if not header.startswith(b'SQLite format 3'):
+            if not header.startswith(b"SQLite format 3"):
                 raise TraitError("The file does not look like ")
         return value
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -1,7 +1,6 @@
 """A base class session manager."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import os
 import pathlib
 import uuid
 
@@ -47,14 +46,12 @@ class SessionManager(LoggingConfigurable):
                 raise TraitError(
                     "`database_filepath` expected a file path, but the given path is a directory."
                 )
-            # If the file exists, but it's empty, its a valid entry.
-            if os.stat(path).st_size == 0:
-                return value
             # Verify that database path is an SQLite 3 Database by checking its header.
             with open(value, "rb") as f:
                 header = f.read(100)
-            if not header.startswith(b"SQLite format 3"):
-                raise TraitError("The file does not look like ")
+
+            if not header.startswith(b"SQLite format 3") and not header == b"":
+                raise TraitError("The given file is not an SQLite database file.")
         return value
 
     kernel_manager = Instance("jupyter_server.services.kernels.kernelmanager.MappingKernelManager")

--- a/jupyter_server/tests/services/sessions/test_manager.py
+++ b/jupyter_server/tests/services/sessions/test_manager.py
@@ -274,6 +274,7 @@ async def test_bad_database_filepath(jp_runtime_dir):
 
     # Try to write to a path that's a directory, not a file.
     path_id_directory = str(jp_runtime_dir)
+    # Should raise an error because the path is a directory.
     with pytest.raises(TraitError) as err:
          SessionManager(
             kernel_manager=kernel_manager,
@@ -281,10 +282,12 @@ async def test_bad_database_filepath(jp_runtime_dir):
             database_filepath=str(path_id_directory)
         )
 
-    # Try writing to file that's not a database
+    # Try writing to file that's not a valid SQLite 3 database file.
     non_db_file = jp_runtime_dir.joinpath("non_db_file.db")
     non_db_file.write_bytes(b"this is a bad file")
 
+    # Should raise an error because the file doesn't
+    # start with an SQLite database file header.
     with pytest.raises(TraitError) as err:
          SessionManager(
             kernel_manager=kernel_manager,

--- a/jupyter_server/tests/services/sessions/test_manager.py
+++ b/jupyter_server/tests/services/sessions/test_manager.py
@@ -1,5 +1,4 @@
 import pytest
-import pathlib
 from tornado import web
 from traitlets import TraitError
 
@@ -268,7 +267,6 @@ async def test_bad_delete_session(session_manager):
         await session_manager.delete_session(session_id="23424")  # nonexistent
 
 
-
 async def test_bad_database_filepath(jp_runtime_dir):
     kernel_manager = DummyMKM()
 
@@ -276,10 +274,10 @@ async def test_bad_database_filepath(jp_runtime_dir):
     path_id_directory = str(jp_runtime_dir)
     # Should raise an error because the path is a directory.
     with pytest.raises(TraitError) as err:
-         SessionManager(
+        SessionManager(
             kernel_manager=kernel_manager,
             contents_manager=ContentsManager(),
-            database_filepath=str(path_id_directory)
+            database_filepath=str(path_id_directory),
         )
 
     # Try writing to file that's not a valid SQLite 3 database file.
@@ -289,10 +287,10 @@ async def test_bad_database_filepath(jp_runtime_dir):
     # Should raise an error because the file doesn't
     # start with an SQLite database file header.
     with pytest.raises(TraitError) as err:
-         SessionManager(
+        SessionManager(
             kernel_manager=kernel_manager,
             contents_manager=ContentsManager(),
-            database_filepath=str(non_db_file)
+            database_filepath=str(non_db_file),
         )
 
 
@@ -306,7 +304,7 @@ async def test_good_database_filepath(jp_runtime_dir):
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
         contents_manager=ContentsManager(),
-        database_filepath=str(empty_file)
+        database_filepath=str(empty_file),
     )
 
     await session_manager.create_session(
@@ -322,10 +320,11 @@ async def test_good_database_filepath(jp_runtime_dir):
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
         contents_manager=ContentsManager(),
-        database_filepath=str(empty_file)
+        database_filepath=str(empty_file),
     )
 
     assert session_manager.database_filepath == str(empty_file)
+
 
 async def test_session_persistence(jp_runtime_dir):
     session_db_path = jp_runtime_dir.joinpath("test-session.db")
@@ -337,7 +336,7 @@ async def test_session_persistence(jp_runtime_dir):
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
         contents_manager=ContentsManager(),
-        database_filepath=str(session_db_path)
+        database_filepath=str(session_db_path),
     )
 
     session = await session_manager.create_session(
@@ -350,7 +349,7 @@ async def test_session_persistence(jp_runtime_dir):
     with open(session_db_path, "rb") as f:
         header = f.read(100)
 
-    assert header.startswith(b'SQLite format 3')
+    assert header.startswith(b"SQLite format 3")
 
     # Close the current session manager
     del session_manager
@@ -359,7 +358,7 @@ async def test_session_persistence(jp_runtime_dir):
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
         contents_manager=ContentsManager(),
-        database_filepath=str(session_db_path)
+        database_filepath=str(session_db_path),
     )
 
     # Assert that the session database persists.

--- a/jupyter_server/tests/services/sessions/test_manager.py
+++ b/jupyter_server/tests/services/sessions/test_manager.py
@@ -1,5 +1,7 @@
 import pytest
+import pathlib
 from tornado import web
+from traitlets import TraitError
 
 from jupyter_server._tz import isoformat
 from jupyter_server._tz import utcnow
@@ -264,3 +266,98 @@ async def test_bad_delete_session(session_manager):
         await session_manager.delete_session(bad_kwarg="23424")  # Bad keyword
     with pytest.raises(web.HTTPError):
         await session_manager.delete_session(session_id="23424")  # nonexistent
+
+
+
+async def test_bad_database_filepath(jp_runtime_dir):
+    kernel_manager = DummyMKM()
+
+    # Try to write to a path that's a directory, not a file.
+    path_id_directory = str(jp_runtime_dir)
+    with pytest.raises(TraitError) as err:
+         SessionManager(
+            kernel_manager=kernel_manager,
+            contents_manager=ContentsManager(),
+            database_filepath=str(path_id_directory)
+        )
+
+    # Try writing to file that's not a database
+    non_db_file = jp_runtime_dir.joinpath("non_db_file.db")
+    non_db_file.write_bytes(b"this is a bad file")
+
+    with pytest.raises(TraitError) as err:
+         SessionManager(
+            kernel_manager=kernel_manager,
+            contents_manager=ContentsManager(),
+            database_filepath=str(non_db_file)
+        )
+
+
+async def test_good_database_filepath(jp_runtime_dir):
+    kernel_manager = DummyMKM()
+
+    # Try writing to an empty file.
+    empty_file = jp_runtime_dir.joinpath("empty.db")
+    empty_file.write_bytes(b"")
+
+    session_manager = SessionManager(
+        kernel_manager=kernel_manager,
+        contents_manager=ContentsManager(),
+        database_filepath=str(empty_file)
+    )
+
+    await session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="python", type="notebook"
+    )
+    # Assert that the database file exists
+    assert empty_file.exists()
+
+    # Close the current session manager
+    del session_manager
+
+    # Try writing to a file that already exists.
+    session_manager = SessionManager(
+        kernel_manager=kernel_manager,
+        contents_manager=ContentsManager(),
+        database_filepath=str(empty_file)
+    )
+
+    assert session_manager.database_filepath == str(empty_file)
+
+async def test_session_persistence(jp_runtime_dir):
+    session_db_path = jp_runtime_dir.joinpath("test-session.db")
+    # Kernel manager needs to persist.
+    kernel_manager = DummyMKM()
+
+    # Initialize a session and start a connection.
+    # This should create the session database the first time.
+    session_manager = SessionManager(
+        kernel_manager=kernel_manager,
+        contents_manager=ContentsManager(),
+        database_filepath=str(session_db_path)
+    )
+
+    session = await session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="python", type="notebook"
+    )
+
+    # Assert that the database file exists
+    assert session_db_path.exists()
+
+    with open(session_db_path, "rb") as f:
+        header = f.read(100)
+
+    assert header.startswith(b'SQLite format 3')
+
+    # Close the current session manager
+    del session_manager
+
+    # Get a new session_manager
+    session_manager = SessionManager(
+        kernel_manager=kernel_manager,
+        contents_manager=ContentsManager(),
+        database_filepath=str(session_db_path)
+    )
+
+    # Assert that the session database persists.
+    session = await session_manager.get_session(session_id=session["id"])


### PR DESCRIPTION

Fixes #611

Makes the session database path a configurable trait and avoids overwriting the database if it exists.

Also, sets the database's isolation level to `None` so that it autocommits all changes after every change.