### PR TITLE
await _finish_kernel_start

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -210,7 +210,7 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs["kernel_id"] = kernel_id
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
-            asyncio.ensure_future(self._finish_kernel_start(kernel_id))
+            await asyncio.ensure_future(self._finish_kernel_start(kernel_id))
             # add busy/activity markers:
             kernel = self.get_kernel(kernel_id)
             kernel.execution_state = "starting"

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -210,7 +210,9 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs["kernel_id"] = kernel_id
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
-            await asyncio.ensure_future(self._finish_kernel_start(kernel_id))
+            fut = asyncio.ensure_future(self._finish_kernel_start(kernel_id))
+            if not getattr(self, "use_pending_kernels", None):
+                await fut
             # add busy/activity markers:
             kernel = self.get_kernel(kernel_id)
             kernel.execution_state = "starting"


### PR DESCRIPTION
This is the result of investigating the failing `js-services` tests in JupyterLab: https://github.com/jupyterlab/jupyterlab/issues/11548

Looking at the code, it looks like this future is ensured with `asyncio.ensure_future` but never awaited.