### PR TITLE
Update to Python 3.10 in the CI workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -11,8 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos]
-        python-version:
-          ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7-v7.3.3"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7-v7.3.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [macos]
         python-version:
-          ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy-3.7-v7.3.3"]
+          ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7-v7.3.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Spotted while looking at the content of the workflows.

Normally it should be fine to switch to `3.10` final now.