### PR TITLE
Make terminal_class configurable and provide a manager to detect terminal status on linux systems

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -147,6 +147,11 @@ try:
 except ImportError:
     terminado_available = False
 
+
+    class TerminalManager:
+        # Compatible with terminal_manager_class configuration
+        ...
+
 # -----------------------------------------------------------------------------
 # Module globals
 # -----------------------------------------------------------------------------
@@ -1673,7 +1678,7 @@ class ServerApp(JupyterApp):
 
     terminal_manager_class = Type(
         default_value=TerminalManager,
-        klass=TerminalManager,
+        klass=TerminalManager if terminado_available else object,
         config=True,
         help=_i18n(
             """The terminal manager class to use.

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -147,10 +147,10 @@ try:
 except ImportError:
     terminado_available = False
 
-
     class TerminalManager:
         # Compatible with terminal_manager_class configuration
         ...
+
 
 # -----------------------------------------------------------------------------
 # Module globals

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -351,6 +351,7 @@ class ServerWebApplication(web.Application):
             server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=terminado_available and jupyter_app.terminals_enabled,
+            stateful_terminals_enabled=jupyter_app.stateful_terminals_enabled,
             serverapp=jupyter_app,
         )
 
@@ -1668,6 +1669,18 @@ class ServerApp(JupyterApp):
          Terminals may also be automatically disabled if the terminado package
          is not available.
          """
+        ),
+    )
+
+    stateful_terminals_enabled = Bool(
+        False,
+        config=True,
+        help=_i18n(
+            """Set to True to enable stateful terminals.
+
+            Terminals may also be automatically disabled if the terminado package
+         is not available.
+            """
         ),
     )
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -178,6 +178,7 @@ JUPYTER_SERVICE_HANDLERS = dict(
 # Added for backwards compatibility from classic notebook server.
 DEFAULT_SERVER_PORT = DEFAULT_JUPYTER_SERVER_PORT
 
+
 # -----------------------------------------------------------------------------
 # Helper functions
 # -----------------------------------------------------------------------------
@@ -351,7 +352,7 @@ class ServerWebApplication(web.Application):
             server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=terminado_available and jupyter_app.terminals_enabled,
-            stateful_terminals_enabled=jupyter_app.stateful_terminals_enabled,
+            terminal_manager_class=jupyter_app.terminal_manager_class,
             serverapp=jupyter_app,
         )
 
@@ -526,7 +527,6 @@ def shutdown_server(server_info, timeout=5, log=None):
 
 
 class JupyterServerStopApp(JupyterApp):
-
     version = __version__
     description = "Stop currently running Jupyter server for a given port"
 
@@ -666,7 +666,6 @@ flags["autoreload"] = (
     """,
 )
 
-
 # Add notebook manager flags
 flags.update(
     boolean_flag(
@@ -695,13 +694,13 @@ aliases.update(
     }
 )
 
+
 # -----------------------------------------------------------------------------
 # ServerApp
 # -----------------------------------------------------------------------------
 
 
 class ServerApp(JupyterApp):
-
     name = "jupyter-server"
     version = __version__
     description = _i18n(
@@ -1672,15 +1671,16 @@ class ServerApp(JupyterApp):
         ),
     )
 
-    stateful_terminals_enabled = Bool(
-        False,
+    terminal_manager_class = Type(
+        default_value=TerminalManager,
+        klass=TerminalManager,
         config=True,
         help=_i18n(
-            """Set to True to enable stateful terminals.
+            """The terminal manager class to use.
 
-            Terminals may also be automatically disabled if the terminado package
-         is not available.
-            """
+        Only when terminals_enabled is instantiated,
+        the call to init_terminals function will get self.terminal_manager
+        """
         ),
     )
 

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -373,8 +373,8 @@ class AsyncFileManagerMixin(FileManagerMixin):
 
             # Move the bad file aside, restore the intermediate, and try again.
             invalid_file = path_to_invalid(os_path)
-            async_replace_file(os_path, invalid_file)
-            async_replace_file(tmp_path, os_path)
+            await async_replace_file(os_path, invalid_file)
+            await async_replace_file(tmp_path, os_path)
             return await self._read_notebook(os_path, as_version)
 
     async def _save_notebook(self, os_path, nb):

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -12,7 +12,7 @@ from ipython_genutils.py3compat import which
 from jupyter_server.utils import url_path_join as ujoin
 from . import api_handlers
 from .handlers import TermSocket
-from .terminalmanager import TerminalManager
+from .terminalmanager import TerminalManager, StatefulTerminalManager
 
 
 def initialize(webapp, root_dir, connection_url, settings):
@@ -29,7 +29,8 @@ def initialize(webapp, root_dir, connection_url, settings):
     # the user has specifically set a preferred shell command.
     if os.name != "nt" and shell_override is None and not sys.stdout.isatty():
         shell.append("-l")
-    terminal_manager = webapp.settings["terminal_manager"] = TerminalManager(
+    terminal_class = StatefulTerminalManager if webapp.settings['stateful_terminals_enabled'] else TerminalManager
+    terminal_manager = webapp.settings['terminal_manager'] = terminal_class(
         shell_command=shell,
         extra_env={
             "JUPYTER_SERVER_ROOT": root_dir,

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -29,12 +29,9 @@ def initialize(webapp, root_dir, connection_url, settings):
     # the user has specifically set a preferred shell command.
     if os.name != "nt" and shell_override is None and not sys.stdout.isatty():
         shell.append("-l")
-    terminal_class = (
-        StatefulTerminalManager
-        if webapp.settings["stateful_terminals_enabled"]
-        else TerminalManager
-    )
-    terminal_manager = webapp.settings["terminal_manager"] = terminal_class(
+    terminal_manager = webapp.settings["terminal_manager"] = webapp.settings[
+        "terminal_manager_class"
+    ](
         shell_command=shell,
         extra_env={
             "JUPYTER_SERVER_ROOT": root_dir,

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -29,8 +29,12 @@ def initialize(webapp, root_dir, connection_url, settings):
     # the user has specifically set a preferred shell command.
     if os.name != "nt" and shell_override is None and not sys.stdout.isatty():
         shell.append("-l")
-    terminal_class = StatefulTerminalManager if webapp.settings['stateful_terminals_enabled'] else TerminalManager
-    terminal_manager = webapp.settings['terminal_manager'] = terminal_class(
+    terminal_class = (
+        StatefulTerminalManager
+        if webapp.settings["stateful_terminals_enabled"]
+        else TerminalManager
+    )
+    terminal_manager = webapp.settings["terminal_manager"] = terminal_class(
         shell_command=shell,
         extra_env={
             "JUPYTER_SERVER_ROOT": root_dir,

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -2,17 +2,15 @@
 """Tornado handlers for the terminal emulator."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-
 import terminado
 from tornado import web
 
-from jupyter_server._tz import utcnow
 from ..base.handlers import JupyterHandler
 from ..base.zmqhandlers import WebSocketMixin
+from jupyter_server._tz import utcnow
 
 
 class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
-
     def origin_check(self):
         """Terminado adds redundant origin_check
         Tornado already calls check_origin, so don't do anything here.
@@ -42,7 +40,7 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             self.terminal_manager.terminals[self.term_name].last_activity = utcnow()
 
     def _set_state_busy_if_stateful(self):
-        if not hasattr(self.terminal_manager, 'set_state_idle_if_return'):
+        if not hasattr(self.terminal_manager, "set_state_idle_if_return"):
             return
         if self.term_name in self.terminal_manager.terminals:
-            self.terminal_manager.terminals[self.term_name].execution_state = 'busy'
+            self.terminal_manager.terminals[self.term_name].execution_state = "busy"

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -2,7 +2,6 @@
 """Tornado handlers for the terminal emulator."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import json
 
 import terminado
 from tornado import web
@@ -35,24 +34,6 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
     def write_message(self, message, binary=False):
         super(TermSocket, self).write_message(message, binary=binary)
         self._update_activity()
-        self._set_state_idle_if_return(message)
-
-    def _set_state_idle_if_return(self, message):
-        if not self.term_name in self.terminal_manager.terminals:
-            return
-        message_seg = json.loads(message)
-        first_stdout = getattr(self.terminal_manager.terminals[self.term_name], 'first_stdout', '')
-
-        if not first_stdout and message_seg[0] == 'stdout':
-            # Record the first output to identify the terminal return
-            # It works well for jupyterhub-singleuser and should also work for other debian-based mirrors
-            # fixme: May fail if terminal is not properly separated with ':' or change user after connect
-            #        (Any change to the user, hostname or environment may render it invalid)
-            first_stdout = message_seg[1].split(':')[0].lstrip()
-            self.terminal_manager.terminals[self.term_name].first_stdout = first_stdout
-            self.log.debug(f'take "{first_stdout}" as terminal returned')
-        if isinstance(message_seg[1], str) and message_seg[1].lstrip().startswith(first_stdout):
-            self._set_state_idle()
 
     def _update_activity(self):
         self.application.settings["terminal_last_activity"] = utcnow()
@@ -63,8 +44,3 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
     def _set_state_busy(self):
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].execution_state = 'busy'
-
-    def _set_state_idle(self):
-        if self.term_name in self.terminal_manager.terminals:
-            self.log.debug('set terminal execution_state as idle')
-            self.terminal_manager.terminals[self.term_name].execution_state = 'idle'

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -42,7 +42,7 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             self.terminal_manager.terminals[self.term_name].last_activity = utcnow()
 
     def _set_state_busy(self):
-        self.log.info('set terminal execution_state as busy')
+        self.log.debug('set terminal execution_state as busy')
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].execution_state = 'busy'
 

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -47,6 +47,6 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             self.terminal_manager.terminals[self.term_name].execution_state = 'busy'
 
     def _set_state_idle(self):
-        self.log.info('set terminal execution_state as idle')
+        self.log.debug('set terminal execution_state as idle')
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].execution_state = 'idle'

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -2,6 +2,8 @@
 """Tornado handlers for the terminal emulator."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import json
+
 import terminado
 from tornado import web
 
@@ -11,6 +13,10 @@ from ..base.zmqhandlers import WebSocketMixin
 
 
 class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
+    def initialize(self, *args, **kwargs):
+        super(TermSocket, self).initialize(*args, **kwargs)
+        self._first_stdout = ''
+
     def origin_check(self):
         """Terminado adds redundant origin_check
         Tornado already calls check_origin, so don't do anything here.
@@ -31,8 +37,15 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
 
     def write_message(self, message, binary=False):
         super(TermSocket, self).write_message(message, binary=binary)
-        self._update_activity()
-        if message != '["stdout", "\\r\\n"]':
+        message_seg = json.loads(message)
+        if not self._first_stdout and message_seg[0] == 'stdout':
+            # Record the first output to identify the terminal return
+            # It works well for jupyterhub-singleuser and should also work for other debian-based mirrors
+            # fixme: May fail if terminal is not properly separated with ':' or change user after connect
+            #        (Any change to the user, hostname or environment may render it invalid)
+            self._first_stdout = message_seg[1].split(':')[0].lstrip()
+            self.log.debug(f'take "{self._first_stdout}" as terminal returned')
+        if isinstance(message_seg[1], str) and message_seg[1].lstrip().startswith(self._first_stdout):
             self._set_state_idle()
 
     def _update_activity(self):
@@ -42,11 +55,10 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             self.terminal_manager.terminals[self.term_name].last_activity = utcnow()
 
     def _set_state_busy(self):
-        self.log.debug('set terminal execution_state as busy')
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].execution_state = 'busy'
 
     def _set_state_idle(self):
-        self.log.debug('set terminal execution_state as idle')
         if self.term_name in self.terminal_manager.terminals:
+            self.log.debug('set terminal execution_state as idle')
             self.terminal_manager.terminals[self.term_name].execution_state = 'idle'

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -29,7 +29,7 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
     def on_message(self, message):
         super(TermSocket, self).on_message(message)
         self._update_activity()
-        self._set_state_busy()
+        self._set_state_busy_if_stateful()
 
     def write_message(self, message, binary=False):
         super(TermSocket, self).write_message(message, binary=binary)
@@ -41,6 +41,8 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].last_activity = utcnow()
 
-    def _set_state_busy(self):
+    def _set_state_busy_if_stateful(self):
+        if not hasattr(self.terminal_manager, 'set_state_idle_if_return'):
+            return
         if self.term_name in self.terminal_manager.terminals:
             self.terminal_manager.terminals[self.term_name].execution_state = 'busy'

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -37,6 +37,10 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
 
     def write_message(self, message, binary=False):
         super(TermSocket, self).write_message(message, binary=binary)
+        self._update_activity()
+        self._set_state_idle_if_return(message)
+
+    def _set_state_idle_if_return(self, message):
         message_seg = json.loads(message)
         if not self._first_stdout and message_seg[0] == 'stdout':
             # Record the first output to identify the terminal return

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -13,9 +13,9 @@ from tornado.ioloop import PeriodicCallback
 from traitlets import Integer
 from traitlets.config import LoggingConfigurable
 
-from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 from jupyter_server._tz import isoformat
 from jupyter_server._tz import utcnow
+from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 
 
 class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
@@ -96,6 +96,7 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
         model = {
             "name": name,
             "last_activity": isoformat(term.last_activity),
+            'execution_state': getattr(term, 'execution_state', 'not connected yet')
         }
         return model
 

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -169,7 +169,12 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
 
 
 class StatefulTerminalManager(TerminalManager):
-    # patch execution_state into terminal
+    """
+    ***Experimental***
+    Patch execution_state into terminal
+    The method of setting the state is not necessarily reliable, the terminal of bus y state will still be culled
+    """
+
     def pty_read(self, fd, events=None):
         """Called by the event loop when there is pty data ready to read."""
         # prevent blocking on fd

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -14,9 +14,9 @@ from tornado.ioloop import PeriodicCallback
 from traitlets import Integer
 from traitlets.config import LoggingConfigurable
 
+from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 from jupyter_server._tz import isoformat
 from jupyter_server._tz import utcnow
-from ..prometheus.metrics import TERMINAL_CURRENTLY_RUNNING_TOTAL
 
 
 class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
@@ -103,7 +103,7 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
     def _check_terminal(self, name):
         """Check a that terminal 'name' exists and raise 404 if not."""
         if name not in self.terminals:
-            raise web.HTTPError(404, u"Terminal not found: %s" % name)
+            raise web.HTTPError(404, "Terminal not found: %s" % name)
 
     def _initialize_culler(self):
         """Start culler if 'cull_inactive_timeout' is greater than zero.
@@ -195,22 +195,22 @@ class StatefulTerminalManager(TerminalManager):
                 client.on_pty_died()
 
     def set_state_idle_if_return(self, ptywclients, s):
-        first_stdout = getattr(ptywclients, 'first_stdout', '')
+        first_stdout = getattr(ptywclients, "first_stdout", "")
 
         if not first_stdout:
             # Record the first output to identify the terminal return
             # It works well for jupyterhub-singleuser and should also work for other debian-based mirrors
             # fixme: May fail if terminal is not properly separated with ':' or change user after connect
             #        (Any change to the user, hostname or environment may render it invalid)
-            first_stdout = s.split(':')[0].lstrip()
+            first_stdout = s.split(":")[0].lstrip()
             ptywclients.first_stdout = first_stdout
             self.log.debug(f'take "{first_stdout}" as terminal returned')
         if s.lstrip().startswith(first_stdout):
             self._set_state_idle(ptywclients)
 
     def _set_state_idle(self, ptywclients):
-        self.log.debug('set terminal execution_state as idle')
-        ptywclients.execution_state = 'idle'
+        self.log.debug("set terminal execution_state as idle")
+        ptywclients.execution_state = "idle"
 
     def get_terminal_model(self, name):
         """Return a JSON-safe dict representing a terminal.
@@ -218,5 +218,5 @@ class StatefulTerminalManager(TerminalManager):
         """
         model = super(StatefulTerminalManager, self).get_terminal_model(name)
         term = self.terminals[name]
-        model.setdefault('execution_state', getattr(term, 'execution_state', 'not connected yet'))
+        model.setdefault("execution_state", getattr(term, "execution_state", "not connected yet"))
         return model

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -82,48 +82,6 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
         # because a terminal has been shutdown
         TERMINAL_CURRENTLY_RUNNING_TOTAL.dec()
 
-    def pty_read(self, fd, events=None):
-        """Called by the event loop when there is pty data ready to read."""
-        # prevent blocking on fd
-        if not _poll(fd, timeout=0.1):  # 100ms
-            self.log.debug(f"Spurious pty_read() on fd {fd}")
-            return
-        ptywclients = self.ptys_by_fd[fd]
-        try:
-            s = ptywclients.ptyproc.read(65536)
-            client_list = ptywclients.clients
-            ptywclients.read_buffer.append(s)
-            # hook for set terminal status
-            self._set_state_idle_if_return(ptywclients, s)
-            if not client_list:
-                # No one to consume our output: buffer it.
-                ptywclients.preopen_buffer.append(s)
-                return
-            for client in ptywclients.clients:
-                client.on_pty_read(s)
-        except EOFError:
-            self.on_eof(ptywclients)
-            for client in ptywclients.clients:
-                client.on_pty_died()
-
-    def _set_state_idle_if_return(self, ptywclients, s):
-        first_stdout = getattr(ptywclients, 'first_stdout', '')
-
-        if not first_stdout:
-            # Record the first output to identify the terminal return
-            # It works well for jupyterhub-singleuser and should also work for other debian-based mirrors
-            # fixme: May fail if terminal is not properly separated with ':' or change user after connect
-            #        (Any change to the user, hostname or environment may render it invalid)
-            first_stdout = s.split(':')[0].lstrip()
-            ptywclients.first_stdout = first_stdout
-            self.log.debug(f'take "{first_stdout}" as terminal returned')
-        if s.lstrip().startswith(first_stdout):
-            self._set_state_idle(ptywclients)
-
-    def _set_state_idle(self, ptywclients):
-        self.log.debug('set terminal execution_state as idle')
-        ptywclients.execution_state = 'idle'
-
     async def terminate_all(self):
         """Terminate all terminals."""
         terms = [name for name in self.terminals]
@@ -209,3 +167,48 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
                     "Culling terminal '%s' due to %s seconds of inactivity.", name, inactivity
                 )
                 await self.terminate(name, force=True)
+
+
+class StatefulTerminalManager(TerminalManager):
+    # patch execution_state into terminal
+    def pty_read(self, fd, events=None):
+        """Called by the event loop when there is pty data ready to read."""
+        # prevent blocking on fd
+        if not _poll(fd, timeout=0.1):  # 100ms
+            self.log.debug(f"Spurious pty_read() on fd {fd}")
+            return
+        ptywclients = self.ptys_by_fd[fd]
+        try:
+            s = ptywclients.ptyproc.read(65536)
+            client_list = ptywclients.clients
+            ptywclients.read_buffer.append(s)
+            # hook for set terminal status
+            self.set_state_idle_if_return(ptywclients, s)
+            if not client_list:
+                # No one to consume our output: buffer it.
+                ptywclients.preopen_buffer.append(s)
+                return
+            for client in ptywclients.clients:
+                client.on_pty_read(s)
+        except EOFError:
+            self.on_eof(ptywclients)
+            for client in ptywclients.clients:
+                client.on_pty_died()
+
+    def set_state_idle_if_return(self, ptywclients, s):
+        first_stdout = getattr(ptywclients, 'first_stdout', '')
+
+        if not first_stdout:
+            # Record the first output to identify the terminal return
+            # It works well for jupyterhub-singleuser and should also work for other debian-based mirrors
+            # fixme: May fail if terminal is not properly separated with ':' or change user after connect
+            #        (Any change to the user, hostname or environment may render it invalid)
+            first_stdout = s.split(':')[0].lstrip()
+            ptywclients.first_stdout = first_stdout
+            self.log.debug(f'take "{first_stdout}" as terminal returned')
+        if s.lstrip().startswith(first_stdout):
+            self._set_state_idle(ptywclients)
+
+    def _set_state_idle(self, ptywclients):
+        self.log.debug('set terminal execution_state as idle')
+        ptywclients.execution_state = 'idle'

--- a/jupyter_server/terminal/terminalmanager.py
+++ b/jupyter_server/terminal/terminalmanager.py
@@ -97,7 +97,6 @@ class TerminalManager(LoggingConfigurable, terminado.NamedTermManager):
         model = {
             "name": name,
             "last_activity": isoformat(term.last_activity),
-            'execution_state': getattr(term, 'execution_state', 'not connected yet')
         }
         return model
 
@@ -212,3 +211,12 @@ class StatefulTerminalManager(TerminalManager):
     def _set_state_idle(self, ptywclients):
         self.log.debug('set terminal execution_state as idle')
         ptywclients.execution_state = 'idle'
+
+    def get_terminal_model(self, name):
+        """Return a JSON-safe dict representing a terminal.
+        For use in representing terminals in the JSON APIs.
+        """
+        model = super(StatefulTerminalManager, self).get_terminal_model(name)
+        term = self.terminals[name]
+        model.setdefault('execution_state', getattr(term, 'execution_state', 'not connected yet'))
+        return model

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -76,12 +76,11 @@ async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesse
     setup = ["set_size", 0, 0, 80, 32]
     await ws.write_message(json.dumps(setup))
     await ws.read_message()
-    sleep_3_msg = ['stdin', "python -c 'import time;time.sleep(3)'\r\n"]
-    await ws.write_message(json.dumps(sleep_3_msg))
+    sleep_1_msg = ['stdin', "python -c 'import time;time.sleep(1)'\r\n"]
+    await ws.write_message(json.dumps(sleep_1_msg))
     ws.close()
-    await asyncio.sleep(1)
-    assert not jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].clients
     assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
-    await asyncio.sleep(3)
+    await asyncio.sleep(2)
+    assert not jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].clients
     assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
     await jp_cleanup_subprocesses()

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -35,7 +35,7 @@ def jp_server_config():
 
 async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
     if os.name == "nt":
-        return
+        pytest.skip("Feature not supported on Windows")
 
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -27,7 +27,7 @@ def jp_server_config():
     return Config(
         {
             "ServerApp": {
-                "stateful_terminals_enabled": True,
+                "terminal_manager_class": "jupyter_server.terminal.StatefulTerminalManager",
             }
         }
     )

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -50,8 +50,9 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
     setup = ["set_size", 0, 0, 80, 32]
     await ws.write_message(json.dumps(setup))
     await ws.read_message()
-    sleep_1_msg = ['stdin', "python -c 'import time;time.sleep(1)'\r\n"]
-    await ws.write_message(json.dumps(sleep_1_msg))
+    sleep_2_msg = ['stdin', "python -c 'import time;time.sleep(2)'\r\n"]
+    await ws.write_message(json.dumps(sleep_2_msg))
+    await asyncio.sleep(1)
     assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
     await asyncio.sleep(2)
     assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
@@ -76,9 +77,10 @@ async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesse
     setup = ["set_size", 0, 0, 80, 32]
     await ws.write_message(json.dumps(setup))
     await ws.read_message()
-    sleep_1_msg = ['stdin', "python -c 'import time;time.sleep(1)'\r\n"]
-    await ws.write_message(json.dumps(sleep_1_msg))
+    sleep_2_msg = ['stdin', "python -c 'import time;time.sleep(2)'\r\n"]
+    await ws.write_message(json.dumps(sleep_2_msg))
     ws.close()
+    await asyncio.sleep(1)
     assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
     await asyncio.sleep(2)
     assert not jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].clients

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+import os
+import shutil
+
+import pytest
+from traitlets.config import Config
+
+
+@pytest.fixture
+def terminal_path(tmp_path):
+    subdir = tmp_path.joinpath("terminal_path")
+    subdir.mkdir()
+
+    yield subdir
+
+    shutil.rmtree(str(subdir), ignore_errors=True)
+
+
+CULL_TIMEOUT = 10
+CULL_INTERVAL = 3
+
+
+@pytest.fixture
+def jp_server_config():
+    return Config(
+        {
+            "ServerApp": {
+                "stateful_terminals_enabled": True,
+            }
+        }
+    )
+
+
+async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
+    # disable man sudo_root
+    os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
+
+    resp = await jp_fetch(
+        "api",
+        "terminals",
+        method="POST",
+        allow_nonstandard_methods=True,
+    )
+    term = json.loads(resp.body.decode())
+    term_1 = term["name"]
+    ws = await jp_ws_fetch(
+        'terminals', 'websocket', term_1
+    )
+    setup = ["set_size", 0, 0, 80, 32]
+    await ws.write_message(json.dumps(setup))
+    await ws.read_message()
+    sleep_1_msg = ['stdin', "python -c 'import time;time.sleep(1)'\r\n"]
+    await ws.write_message(json.dumps(sleep_1_msg))
+    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
+    await asyncio.sleep(2)
+    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
+    await jp_cleanup_subprocesses()
+
+
+async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
+    # disable man sudo_root
+    os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
+
+    resp = await jp_fetch(
+        "api",
+        "terminals",
+        method="POST",
+        allow_nonstandard_methods=True,
+    )
+    term = json.loads(resp.body.decode())
+    term_1 = term["name"]
+    ws = await jp_ws_fetch(
+        'terminals', 'websocket', term_1
+    )
+    setup = ["set_size", 0, 0, 80, 32]
+    await ws.write_message(json.dumps(setup))
+    await ws.read_message()
+    sleep_3_msg = ['stdin', "python -c 'import time;time.sleep(3)'\r\n"]
+    await ws.write_message(json.dumps(sleep_3_msg))
+    ws.close()
+    await asyncio.sleep(1)
+    assert not jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].clients
+    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
+    await asyncio.sleep(3)
+    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
+    await jp_cleanup_subprocesses()

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -34,7 +34,7 @@ def jp_server_config():
 
 
 async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if platform.system().lower() != "linux":
+    if os.name == "nt":
         return
 
     # disable man sudo_root

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -85,7 +85,7 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
     if os.name == "nt":
-        pytest.skip('Feature not supported on Windows')
+        pytest.skip("Feature not supported on Windows")
 
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -84,7 +84,7 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
 
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if platform.system().lower() != "linux":
+    if os.name != "nt":
         return
 
     # disable man sudo_root

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -84,7 +84,7 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
 
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if os.name != "nt":
+    if os.name == "nt":
         pytest.skip('Feature not supported on Windows')
 
     # disable man sudo_root

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -34,7 +34,7 @@ def jp_server_config():
 
 
 async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if platform.system().lower() != 'linux':
+    if platform.system().lower() != "linux":
         return
 
     # disable man sudo_root
@@ -48,9 +48,7 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
     )
     term = json.loads(resp.body.decode())
     term_1 = term["name"]
-    ws = await jp_ws_fetch(
-        'terminals', 'websocket', term_1
-    )
+    ws = await jp_ws_fetch("terminals", "websocket", term_1)
     setup = ["set_size", 0, 0, 80, 32]
     await ws.write_message(json.dumps(setup))
     while True:
@@ -58,10 +56,13 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
             await asyncio.wait_for(ws.read_message(), timeout=1)
         except asyncio.TimeoutError:
             break
-    sleep_2_msg = ['stdin', "python -c 'import time;time.sleep(2)'\r\n"]
+    sleep_2_msg = ["stdin", "python -c 'import time;time.sleep(2)'\r\n"]
     await ws.write_message(json.dumps(sleep_2_msg))
     await asyncio.sleep(1)
-    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
+    assert (
+        jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state
+        == "busy"
+    )
     await asyncio.sleep(2)
     message_stdout = ""
     while True:
@@ -75,12 +76,15 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
         if message[0] == "stdout":
             message_stdout += message[1]
     print(message_stdout)
-    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
+    assert (
+        jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state
+        == "idle"
+    )
     await jp_cleanup_subprocesses()
 
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if platform.system().lower() != 'linux':
+    if platform.system().lower() != "linux":
         return
 
     # disable man sudo_root
@@ -94,9 +98,7 @@ async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesse
     )
     term = json.loads(resp.body.decode())
     term_1 = term["name"]
-    ws = await jp_ws_fetch(
-        'terminals', 'websocket', term_1
-    )
+    ws = await jp_ws_fetch("terminals", "websocket", term_1)
     setup = ["set_size", 0, 0, 80, 32]
     await ws.write_message(json.dumps(setup))
     while True:
@@ -104,12 +106,18 @@ async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesse
             await asyncio.wait_for(ws.read_message(), timeout=1)
         except asyncio.TimeoutError:
             break
-    sleep_2_msg = ['stdin', "python -c 'import time;time.sleep(2)'\r\n"]
+    sleep_2_msg = ["stdin", "python -c 'import time;time.sleep(2)'\r\n"]
     await ws.write_message(json.dumps(sleep_2_msg))
     ws.close()
     await asyncio.sleep(1)
-    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'busy'
+    assert (
+        jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state
+        == "busy"
+    )
     await asyncio.sleep(2)
     assert not jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].clients
-    assert jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state == 'idle'
+    assert (
+        jp_serverapp.web_app.settings["terminal_manager"].terminals[term_1].execution_state
+        == "idle"
+    )
     await jp_cleanup_subprocesses()

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -33,10 +33,8 @@ def jp_server_config():
     )
 
 
+@pytest.mark.skipif(platform.system().lower() != "linux", reason="Only available on Linux")
 async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if os.name == "nt":
-        pytest.skip("Feature not supported on Windows")
-
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
 
@@ -83,10 +81,8 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
     await jp_cleanup_subprocesses()
 
 
+@pytest.mark.skipif(platform.system().lower() != "linux", reason="Only available on Linux")
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
-    if os.name == "nt":
-        pytest.skip("Feature not supported on Windows")
-
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
 

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -85,7 +85,7 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
     if os.name != "nt":
-        return
+        pytest.skip('Feature not supported on Windows')
 
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")

--- a/jupyter_server/tests/test_stateful_terminal.py
+++ b/jupyter_server/tests/test_stateful_terminal.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import platform
 import shutil
 
 import pytest
@@ -33,6 +34,9 @@ def jp_server_config():
 
 
 async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
+    if platform.system().lower() != 'linux':
+        return
+
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
 
@@ -76,6 +80,9 @@ async def test_set_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serve
 
 
 async def test_set_idle_disconnect(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp):
+    if platform.system().lower() != 'linux':
+        return
+
     # disable man sudo_root
     os.system(f"touch {os.path.expanduser('~/.sudo_as_admin_successful')}")
 


### PR DESCRIPTION
https://github.com/jupyter-server/jupyter_server/issues/625

This is a temporary solution
In Jupyterhub, each input will trigger a record, which may have performance issues