### PR TITLE
remove redundant pylint check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,3 @@ repos:
     rev: v7.32.0
     hooks:
       - id: eslint
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a3
-    hooks:
-      - id: pylint
-        args: [--disable=all, --enable=unused-import]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -379,7 +379,7 @@ spelling_lang = "en_US"
 spelling_word_list_filename = "spelling_wordlist.txt"
 
 # import before any doc is built, so _ is guaranteed to be injected
-import jupyter_server.transutils  # pylint: disable=unused-import
+import jupyter_server.transutils  # noqa: F401
 
 
 def setup(app):

--- a/examples/simple/conftest.py
+++ b/examples/simple/conftest.py
@@ -1,1 +1,1 @@
-from jupyter_server.conftest import *
+from jupyter_server.conftest import *  # noqa

--- a/jupyter_server/__init__.py
+++ b/jupyter_server/__init__.py
@@ -13,7 +13,7 @@ DEFAULT_JUPYTER_SERVER_PORT = 8888
 
 del os
 
-from ._version import version_info, __version__
+from ._version import version_info, __version__  # noqa
 
 
 def _cleanup():

--- a/jupyter_server/auth/__init__.py
+++ b/jupyter_server/auth/__init__.py
@@ -1,1 +1,1 @@
-from .security import passwd
+from .security import passwd  # noqa

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -9,7 +9,6 @@ try:
     # Jupyter Notebook also defines these metrics.  Re-defining them results in a ValueError.
     # Try to de-duplicate by using the ones in Notebook if available.
     # See https://github.com/jupyter/jupyter_server/issues/209
-    # pylint: disable=unused-import
     from notebook.prometheus.metrics import (
         HTTP_REQUEST_DURATION_SECONDS,
         TERMINAL_CURRENTLY_RUNNING_TOTAL,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -486,7 +486,6 @@ def shutdown_server(server_info, timeout=5, log=None):
     Returns True if the server was stopped by any means, False if stopping it
     failed (on Windows).
     """
-    from tornado.httpclient import HTTPClient, HTTPRequest
 
     url = server_info["url"]
     pid = server_info["pid"]

--- a/jupyter_server/services/config/__init__.py
+++ b/jupyter_server/services/config/__init__.py
@@ -1,1 +1,1 @@
-from .manager import ConfigManager
+from .manager import ConfigManager  # noqa

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -14,11 +14,11 @@ from distutils.version import LooseVersion
 from urllib.parse import quote
 from urllib.parse import SplitResult
 from urllib.parse import unquote
-from urllib.parse import urljoin  # pylint: disable=unused-import
+from urllib.parse import urljoin  # noqa: F401
 from urllib.parse import urlparse
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
-from urllib.request import pathname2url  # pylint: disable=unused-import
+from urllib.request import pathname2url  # noqa: F401
 
 from tornado.httpclient import AsyncHTTPClient
 from tornado.httpclient import HTTPClient

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ console_scripts =
 exclude = ['docs*', 'examples*']
 
 [flake8]
-ignore = E, C, W, F401, F403, F811, F841, E402, I100, I101, D400
+ignore = E, C, W, F403, F811, F841, E402, I100, I101, D400
 builtins = c, get_config
 exclude =
     .cache,


### PR DESCRIPTION
significant time savings in pre-commit

pylint was only checking for one issue, which flake8 supports, but skipped in config

remove the skip in flake8 config, so pylint can be removed