### PR TITLE
Run pre_save_hook before model check

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -433,15 +433,14 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         """Save the file model and return the model with no content."""
         path = path.strip("/")
 
+        os_path = self._get_os_path(path)
+        self.log.debug("Saving %s", os_path)
+        self.run_pre_save_hook(model=model, path=path)
+
         if "type" not in model:
             raise web.HTTPError(400, u"No file type provided")
         if "content" not in model and model["type"] != "directory":
             raise web.HTTPError(400, u"No file content provided")
-
-        os_path = self._get_os_path(path)
-        self.log.debug("Saving %s", os_path)
-
-        self.run_pre_save_hook(model=model, path=path)
 
         try:
             if model["type"] == "notebook":
@@ -757,15 +756,14 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         """Save the file model and return the model with no content."""
         path = path.strip("/")
 
+        os_path = self._get_os_path(path)
+        self.log.debug("Saving %s", os_path)
+        self.run_pre_save_hook(model=model, path=path)
+
         if "type" not in model:
             raise web.HTTPError(400, u"No file type provided")
         if "content" not in model and model["type"] != "directory":
             raise web.HTTPError(400, u"No file content provided")
-
-        os_path = self._get_os_path(path)
-        self.log.debug("Saving %s", os_path)
-
-        self.run_pre_save_hook(model=model, path=path)
 
         try:
             if model["type"] == "notebook":

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -433,14 +433,15 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         """Save the file model and return the model with no content."""
         path = path.strip("/")
 
-        os_path = self._get_os_path(path)
-        self.log.debug("Saving %s", os_path)
         self.run_pre_save_hook(model=model, path=path)
 
         if "type" not in model:
             raise web.HTTPError(400, u"No file type provided")
         if "content" not in model and model["type"] != "directory":
             raise web.HTTPError(400, u"No file content provided")
+
+        os_path = self._get_os_path(path)
+        self.log.debug("Saving %s", os_path)
 
         try:
             if model["type"] == "notebook":

--- a/jupyter_server/services/contents/largefilemanager.py
+++ b/jupyter_server/services/contents/largefilemanager.py
@@ -18,6 +18,10 @@ class LargeFileManager(FileContentsManager):
         if chunk is not None:
             path = path.strip("/")
 
+            os_path = self._get_os_path(path)
+            self.log.debug("Saving %s", os_path)
+            self.run_pre_save_hook(model=model, path=path)
+
             if "type" not in model:
                 raise web.HTTPError(400, u"No file type provided")
             if model["type"] != "file":
@@ -30,12 +34,8 @@ class LargeFileManager(FileContentsManager):
             if "content" not in model and model["type"] != "directory":
                 raise web.HTTPError(400, u"No file content provided")
 
-            os_path = self._get_os_path(path)
-
             try:
                 if chunk == 1:
-                    self.log.debug("Saving %s", os_path)
-                    self.run_pre_save_hook(model=model, path=path)
                     super(LargeFileManager, self)._save_file(
                         os_path, model["content"], model.get("format")
                     )
@@ -90,6 +90,10 @@ class AsyncLargeFileManager(AsyncFileContentsManager):
         if chunk is not None:
             path = path.strip("/")
 
+            os_path = self._get_os_path(path)
+            self.log.debug("Saving %s", os_path)
+            self.run_pre_save_hook(model=model, path=path)
+
             if "type" not in model:
                 raise web.HTTPError(400, u"No file type provided")
             if model["type"] != "file":
@@ -102,12 +106,8 @@ class AsyncLargeFileManager(AsyncFileContentsManager):
             if "content" not in model and model["type"] != "directory":
                 raise web.HTTPError(400, u"No file content provided")
 
-            os_path = self._get_os_path(path)
-
             try:
                 if chunk == 1:
-                    self.log.debug("Saving %s", os_path)
-                    self.run_pre_save_hook(model=model, path=path)
                     await super(AsyncLargeFileManager, self)._save_file(
                         os_path, model["content"], model.get("format")
                     )

--- a/jupyter_server/services/contents/largefilemanager.py
+++ b/jupyter_server/services/contents/largefilemanager.py
@@ -18,8 +18,6 @@ class LargeFileManager(FileContentsManager):
         if chunk is not None:
             path = path.strip("/")
 
-            os_path = self._get_os_path(path)
-            self.log.debug("Saving %s", os_path)
             self.run_pre_save_hook(model=model, path=path)
 
             if "type" not in model:
@@ -33,6 +31,9 @@ class LargeFileManager(FileContentsManager):
                 )
             if "content" not in model and model["type"] != "directory":
                 raise web.HTTPError(400, u"No file content provided")
+
+            os_path = self._get_os_path(path)
+            self.log.debug("Saving %s", os_path)
 
             try:
                 if chunk == 1:


### PR DESCRIPTION
The `pre_save_hook` can potentially change the model, so checking for the `type` and `content` should be done after the call to the hook.
This will be needed in JupyterLab when we save documents from the back-end. In this case, the content won't be sent through the HTTP endpoint, but the hook will populate the model's content from the RTC server.

See https://github.com/jupyterlab/jupyterlab/pull/11599.