### PR TITLE
Updates To Contribution Documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,6 +37,18 @@ from any directory in your system with::
 
     jupyter server
 
+For connecting the frontend app with the server, you need to run the following command::
+
+    pip install nbclassic
+
+Once it is completed, you can connect the server with the frontend app with the following command::
+
+    jupyter nbclassic --ServerApp.log_level="CRITICAL"
+
+The following log levels are supported:
+1. CRITICAL
+2. INFO
+3. DEBUG
 
 Code Styling
 -----------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,6 +46,7 @@ Once it is completed, you can connect the server with the frontend app with the 
     jupyter nbclassic --ServerApp.log_level="CRITICAL"
 
 The following log levels are supported:
+
 1. CRITICAL
 2. INFO
 3. DEBUG


### PR DESCRIPTION
## Description

When setting up the local server setup, there is no documentation for connecting the front-end app to the server.

## Type of change
CONTRIBUTING.rst has been modified as this contains the server setup instructions for running the server locally. Instructions have been added on the Jupyter extension (nbclassic) required for connecting the server and the front-end app. No information has been removed.

- This change requires a documentation update

## How Has This Been Tested?

Emulation of the entire local sever setup has been done a few times in order record any missing steps and no further issue was found.
