### PR TITLE
Print IPv6 url as hostname or enclosed in brackets

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1900,10 +1900,10 @@ class ServerApp(JupyterApp):
             netloc = urlencode_unix_socket_path(self.sock)
         else:
             # Handle nonexplicit hostname.
-            if self.ip in ("", "0.0.0.0"):
+            if self.ip in ("", "0.0.0.0", "::"):
                 ip = "%s" % socket.gethostname()
             else:
-                ip = self.ip
+                ip = "[{}]".format(self.ip) if ":" in self.ip else self.ip
             netloc = "{ip}:{port}".format(ip=ip, port=self.port)
             if self.certfile:
                 scheme = "https"


### PR DESCRIPTION
This pull request addresses the display of IPv6 URLs:

* Just like `0.0.0.0`, `::` is replaced with the hostname.

* Literal IPv6 addresses are enclosed in square brackets, e.g. `::1` is turned into `[::1]`, to separate the address from the port number.