### PR TITLE
Protocol alignment

### DIFF
--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -94,14 +94,24 @@ def serialize_msg_to_ws_v1(msg_or_list, channel, pack=None):
         msg_list = msg_or_list
     channel = channel.encode("utf-8")
     offsets = []
-    offsets.append(4 * (1 + 1 + len(msg_list) + 1))
+    offsets.append(8 * (1 + 1 + len(msg_list) + 1))
     offsets.append(len(channel) + offsets[-1])
     for msg in msg_list:
         offsets.append(len(msg) + offsets[-1])
-    offset_number = len(offsets).to_bytes(4, byteorder="little")
-    offsets = [offset.to_bytes(4, byteorder="little") for offset in offsets]
+    offset_number = len(offsets).to_bytes(8, byteorder="little")
+    offsets = [offset.to_bytes(8, byteorder="little") for offset in offsets]
     bin_msg = b"".join([offset_number] + offsets + [channel] + msg_list)
     return bin_msg
+
+
+def deserialize_msg_from_ws_v1(ws_msg):
+    offset_number = int.from_bytes(ws_msg[:8], "little")
+    offsets = [
+        int.from_bytes(ws_msg[8 * (i + 1) : 8 * (i + 2)], "little") for i in range(offset_number)
+    ]
+    channel = ws_msg[offsets[0] : offsets[1]].decode("utf-8")
+    msg_list = [ws_msg[offsets[i] : offsets[i + 1]] for i in range(1, offset_number - 1)]
+    return channel, msg_list
 
 
 # ping interval for keeping websockets alive (30 seconds)

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -162,9 +162,16 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             self.log.warning("zmq message arrived on closed channel")
             self.close()
             return
+        channel = getattr(stream, "channel", None)
+        offsets = []
+        curr_sum = 0
+        for msg in msg_list:
+            length = len(msg)
+            offsets.append(length + curr_sum)
+            curr_sum += length
         layout = json.dumps({
-            "channel": getattr(stream, "channel", None),
-            "offsets": [0] + [len(msg) for msg in msg_list] + [0],
+            "channel": channel,
+            "offsets": offsets,
         }).encode("utf-8")
         layout_length = len(layout).to_bytes(2, byteorder="little")
         bin_msg = b"".join([layout_length, layout] + msg_list)

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -272,11 +272,12 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             return cast_unicode(smsg)
 
     def select_subprotocol(self, subprotocols):
-        selected_subprotocol = (
-            "v1.kernel.websocket.jupyter.org"
-            if "v1.kernel.websocket.jupyter.org" in subprotocols
-            else None
-        )
+        preferred_protocol = self.settings.get("kernel_ws_protocol")
+        if preferred_protocol is None:
+            preferred_protocol = "v1.kernel.websocket.jupyter.org"
+        elif preferred_protocol == "":
+            preferred_protocol = None
+        selected_subprotocol = preferred_protocol if preferred_protocol in subprotocols else None
         # None is the default, "legacy" protocol
         return selected_subprotocol
 

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -24,64 +24,6 @@ from tornado.websocket import WebSocketHandler
 from .handlers import JupyterHandler
 
 
-def serialize_binary_message(msg):
-    """serialize a message as a binary blob
-
-    Header:
-
-    4 bytes: number of msg parts (nbufs) as 32b int
-    4 * nbufs bytes: offset for each buffer as integer as 32b int
-
-    Offsets are from the start of the buffer, including the header.
-
-    Returns
-    -------
-    The message serialized to bytes.
-
-    """
-    # don't modify msg or buffer list in-place
-    msg = msg.copy()
-    buffers = list(msg.pop("buffers"))
-    if sys.version_info < (3, 4):
-        buffers = [x.tobytes() for x in buffers]
-    bmsg = json.dumps(msg, default=json_default).encode("utf8")
-    buffers.insert(0, bmsg)
-    nbufs = len(buffers)
-    offsets = [4 * (nbufs + 1)]
-    for buf in buffers[:-1]:
-        offsets.append(offsets[-1] + len(buf))
-    offsets_buf = struct.pack("!" + "I" * (nbufs + 1), nbufs, *offsets)
-    buffers.insert(0, offsets_buf)
-    return b"".join(buffers)
-
-
-def deserialize_binary_message(bmsg):
-    """deserialize a message from a binary blog
-
-    Header:
-
-    4 bytes: number of msg parts (nbufs) as 32b int
-    4 * nbufs bytes: offset for each buffer as integer as 32b int
-
-    Offsets are from the start of the buffer, including the header.
-
-    Returns
-    -------
-    message dictionary
-    """
-    nbufs = struct.unpack("!i", bmsg[:4])[0]
-    offsets = list(struct.unpack("!" + "I" * nbufs, bmsg[4 : 4 * (nbufs + 1)]))
-    offsets.append(None)
-    bufs = []
-    for start, stop in zip(offsets[:-1], offsets[1:]):
-        bufs.append(bmsg[start:stop])
-    msg = json.loads(bufs[0].decode("utf8"))
-    msg["header"] = extract_dates(msg["header"])
-    msg["parent_header"] = extract_dates(msg["parent_header"])
-    msg["buffers"] = bufs[1:]
-    return msg
-
-
 # ping interval for keeping websockets alive (30 seconds)
 WS_PING_INTERVAL = 30000
 
@@ -213,32 +155,6 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
                 # we can close the connection more gracefully.
                 self.stream.close()
 
-    def _reserialize_reply(self, msg_or_list, channel=None):
-        """Reserialize a reply message using JSON.
-
-        msg_or_list can be an already-deserialized msg dict or the zmq buffer list.
-        If it is the zmq list, it will be deserialized with self.session.
-
-        This takes the msg list from the ZMQ socket and serializes the result for the websocket.
-        This method should be used by self._on_zmq_reply to build messages that can
-        be sent back to the browser.
-
-        """
-        if isinstance(msg_or_list, dict):
-            # already unpacked
-            msg = msg_or_list
-        else:
-            idents, msg_list = self.session.feed_identities(msg_or_list)
-            msg = self.session.deserialize(msg_list)
-        if channel:
-            msg["channel"] = channel
-        if msg["buffers"]:
-            buf = serialize_binary_message(msg)
-            return buf
-        else:
-            smsg = json.dumps(msg, default=json_default)
-            return cast_unicode(smsg)
-
     def _on_zmq_reply(self, stream, msg_list):
         # Sometimes this gets triggered when the on_close method is scheduled in the
         # eventloop but hasn't been called.
@@ -246,13 +162,13 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             self.log.warning("zmq message arrived on closed channel")
             self.close()
             return
-        channel = getattr(stream, "channel", None)
-        try:
-            msg = self._reserialize_reply(msg_list, channel=channel)
-        except Exception:
-            self.log.critical("Malformed message: %r" % msg_list, exc_info=True)
-        else:
-            self.write_message(msg, binary=isinstance(msg, bytes))
+        layout = json.dumps({
+            "channel": getattr(stream, "channel", None),
+            "offsets": [0] + [len(msg) for msg in msg_list] + [0],
+        }).encode("utf-8")
+        layout_length = len(layout).to_bytes(2, byteorder="little")
+        bin_msg = b"".join([layout_length, layout] + msg_list)
+        self.write_message(bin_msg, binary=True)
 
 
 class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -240,7 +240,7 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             return cast_unicode(smsg)
 
     def select_subprotocol(self, subprotocols):
-        selected_subprotocol = "0.0.1" if "0.0.1" in subprotocols else None
+        selected_subprotocol = "v1.websocket.jupyter.org" if "v1.websocket.jupyter.org" in subprotocols else None
         # None is the default, "legacy" protocol
         return selected_subprotocol
 
@@ -252,7 +252,7 @@ class ZMQStreamHandler(WebSocketMixin, WebSocketHandler):
             self.close()
             return
         channel = getattr(stream, "channel", None)
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             offsets = []
             curr_sum = 0
             for msg in msg_list:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1612,6 +1612,14 @@ class ServerApp(JupyterApp):
         help=_i18n("Reraise exceptions encountered loading server extensions?"),
     )
 
+    limit_rate = Bool(
+        False,
+        config=True,
+        help=_i18n("Whether to limit the rate of IOPub messages (default: False). "
+                   "If True, use iopub_msg_rate_limit, iopub_data_rate_limit and/or rate_limit_window "
+                   "to tune the rate."),
+    )
+
     iopub_msg_rate_limit = Float(
         1000,
         config=True,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -314,6 +314,8 @@ class ServerWebApplication(web.Application):
                 "no_cache_paths": [url_path_join(base_url, "static", "custom")],
             },
             version_hash=version_hash,
+            # kernel message protocol over websoclet
+            kernel_ws_protocol=jupyter_app.kernel_ws_protocol,
             # rate limits
             limit_rate=jupyter_app.limit_rate,
             iopub_msg_rate_limit=jupyter_app.iopub_msg_rate_limit,
@@ -1611,6 +1613,19 @@ class ServerApp(JupyterApp):
         False,
         config=True,
         help=_i18n("Reraise exceptions encountered loading server extensions?"),
+    )
+
+    kernel_ws_protocol = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help=_i18n(
+            "Preferred kernel message protocol over websocket to use (default: None). "
+            "If an empty string is passed, select the legacy protocol. If None, "
+            "the selected protocol will depend on what the front-end supports "
+            "(usually the most recent protocol supported by the back-end and the "
+            "front-end)."
+        ),
     )
 
     limit_rate = Bool(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1629,10 +1629,10 @@ class ServerApp(JupyterApp):
     )
 
     limit_rate = Bool(
-        False,
+        True,
         config=True,
         help=_i18n(
-            "Whether to limit the rate of IOPub messages (default: False). "
+            "Whether to limit the rate of IOPub messages (default: True). "
             "If True, use iopub_msg_rate_limit, iopub_data_rate_limit and/or rate_limit_window "
             "to tune the rate."
         ),

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -315,6 +315,7 @@ class ServerWebApplication(web.Application):
             },
             version_hash=version_hash,
             # rate limits
+            limit_rate=jupyter_app.limit_rate,
             iopub_msg_rate_limit=jupyter_app.iopub_msg_rate_limit,
             iopub_data_rate_limit=jupyter_app.iopub_data_rate_limit,
             rate_limit_window=jupyter_app.rate_limit_window,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1615,9 +1615,11 @@ class ServerApp(JupyterApp):
     limit_rate = Bool(
         False,
         config=True,
-        help=_i18n("Whether to limit the rate of IOPub messages (default: False). "
-                   "If True, use iopub_msg_rate_limit, iopub_data_rate_limit and/or rate_limit_window "
-                   "to tune the rate."),
+        help=_i18n(
+            "Whether to limit the rate of IOPub messages (default: False). "
+            "If True, use iopub_msg_rate_limit, iopub_data_rate_limit and/or rate_limit_window "
+            "to tune the rate."
+        ),
     )
 
     iopub_msg_rate_limit = Float(

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -22,6 +22,7 @@ from tornado.ioloop import IOLoop
 
 from ...base.handlers import APIHandler
 from ...base.zmqhandlers import AuthenticatedZMQStreamHandler
+from ...base.zmqhandlers import deserialize_binary_message
 from jupyter_server.utils import ensure_async
 from jupyter_server.utils import url_escape
 from jupyter_server.utils import url_path_join
@@ -457,9 +458,33 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             # already closed, ignore the message
             self.log.debug("Received message on closed websocket %r", msg)
             return
+
+        if self.selected_subprotocol == "0.0.1":
+            return self.on_message_0_0_1(msg)
+
+        if isinstance(msg, bytes):
+            msg = deserialize_binary_message(msg)
+        else:
+            msg = json.loads(msg)
+        channel = msg.pop("channel", None)
+        if channel is None:
+            self.log.warning("No channel specified, assuming shell: %s", msg)
+            channel = "shell"
+        if channel not in self.channels:
+            self.log.warning("No such channel: %r", channel)
+            return
+        am = self.kernel_manager.allowed_message_types
+        mt = msg["header"]["msg_type"]
+        if am and mt not in am:
+            self.log.warning('Received message of type "%s", which is not allowed. Ignoring.' % mt)
+        else:
+            stream = self.channels[channel]
+            self.session.send(stream, msg)
+
+    def on_message_0_0_1(self, msg):
         layout_len = int.from_bytes(msg[:2], "little")
-        layout = json.loads(msg[2:2 + layout_len])
-        msg_list = list(get_msg_list(msg[2 + layout_len:], layout["offsets"]))
+        layout = json.loads(msg[2 : 2 + layout_len])
+        msg_list = list(get_msg_list_from_zmq(msg[2 + layout_len :], layout["offsets"]))
         channel = layout["channel"]
         if channel not in self.channels:
             self.log.warning("No such channel: %r", channel)
@@ -471,7 +496,9 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             header = self.get_msg_field("header", header, msg_list)
             mt = header["msg_type"]
             if mt not in am:
-                self.log.warning('Received message of type "%s", which is not allowed. Ignoring.' % mt)
+                self.log.warning(
+                    'Received message of type "%s", which is not allowed. Ignoring.' % mt
+                )
                 ignore_msg = True
         if not ignore_msg:
             stream = self.channels[channel]
@@ -487,46 +514,34 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             value = self.session.unpack(msg_list[field2idx[field]])
         return value
 
-    
     def _on_zmq_reply(self, stream, msg_list):
-        idents, fed_msg_list = self.session.feed_identities(msg_list)
+        if self.selected_subprotocol == "0.0.1":
+            return self._on_zmq_reply_0_0_1(stream, msg_list)
 
-        # parse only what is needed for now
-        # we will parse more later if needed
-        msg = None
-        header = None
-        content = None
-        parent_header = None
+        idents, fed_msg_list = self.session.feed_identities(msg_list)
+        msg = self.session.deserialize(fed_msg_list)
+
+        parent = msg["parent_header"]
 
         def write_stderr(error_message):
             self.log.warning(error_message)
-            # parent_header = self.get_msg_field("parent_header", fed_msg_list)
-            # msg = self.session.msg(
-            #     "stream", content={"text": error_message + "\n", "name": "stderr"}, parent=parent_header
-            # )
-            # msg["channel"] = "iopub"
-            # self.write_message(json.dumps(msg, default=json_default))
-            # FIXME: write this message
+            msg = self.session.msg(
+                "stream", content={"text": error_message + "\n", "name": "stderr"}, parent=parent
+            )
+            msg["channel"] = "iopub"
+            self.write_message(json.dumps(msg, default=json_default))
 
         channel = getattr(stream, "channel", None)
+        msg_type = msg["header"]["msg_type"]
 
-        if not self.kernel_manager.allow_tracebacks:
-            header = self.get_msg_field("header", header, fed_msg_list)
-            if channel == "iopub" and header["msg_type"] == "error":
-                content = self.get_msg_field("content", content, fed_msg_list)
-                content["ename"] = "ExecutionError"
-                content["evalue"] = "Execution error"
-                content["traceback"] = [self.kernel_manager.traceback_replacement_message]
-                fed_msg_list[4] = self.session.pack(content)
+        if channel == "iopub" and msg_type == "error":
+            self._on_error(msg)
 
         if self.limit_rate:
-            header = self.get_msg_field("header", header, fed_msg_list)
-            content = self.get_msg_field("content", content, fed_msg_list)
-            msg_type = header["msg_type"]
             if (
                 channel == "iopub"
                 and msg_type == "status"
-                and content.get("execution_state") == "idle"
+                and msg["content"].get("execution_state") == "idle"
             ):
                 # reset rate limit counter on status=idle,
                 # to avoid 'Run All' hitting limits prematurely.
@@ -631,7 +646,160 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                     self._iopub_window_byte_count -= byte_count
                     self._iopub_window_byte_queue.pop(-1)
                     return
-        super(ZMQChannelsHandler, self)._on_zmq_reply(stream, fed_msg_list[1:])
+        super(ZMQChannelsHandler, self)._on_zmq_reply(stream, msg)
+
+    def _on_zmq_reply_0_0_1(self, stream, msg_list):
+        idents, fed_msg_list = self.session.feed_identities(msg_list)
+
+        # parse only what is needed for now
+        # we will parse more later if needed
+        msg = None
+        header = None
+        content = None
+        parent_header = None
+
+        def write_stderr(error_message, parent_header):
+            self.log.warning(error_message)
+            msg = self.session.msg(
+                "stream",
+                content={"text": error_message + "\n", "name": "stderr"},
+                parent=parent_header,
+            )
+            bin_msg = serialize_msg_to_ws(msg, "iopub", self.session.pack)
+            self.write_message(bin_msg, binary=True)
+
+        channel = getattr(stream, "channel", None)
+
+        if not self.kernel_manager.allow_tracebacks:
+            header = self.get_msg_field("header", header, fed_msg_list)
+            if channel == "iopub" and header["msg_type"] == "error":
+                content = self.get_msg_field("content", content, fed_msg_list)
+                content["ename"] = "ExecutionError"
+                content["evalue"] = "Execution error"
+                content["traceback"] = [self.kernel_manager.traceback_replacement_message]
+                fed_msg_list[4] = self.session.pack(content)
+
+        if self.limit_rate:
+            header = self.get_msg_field("header", header, fed_msg_list)
+            content = self.get_msg_field("content", content, fed_msg_list)
+            msg_type = header["msg_type"]
+            if (
+                channel == "iopub"
+                and msg_type == "status"
+                and content.get("execution_state") == "idle"
+            ):
+                # reset rate limit counter on status=idle,
+                # to avoid 'Run All' hitting limits prematurely.
+                self._iopub_window_byte_queue = []
+                self._iopub_window_msg_count = 0
+                self._iopub_window_byte_count = 0
+                self._iopub_msgs_exceeded = False
+                self._iopub_data_exceeded = False
+
+            if channel == "iopub" and msg_type not in {"status", "comm_open", "execute_input"}:
+
+                # Remove the counts queued for removal.
+                now = IOLoop.current().time()
+                while len(self._iopub_window_byte_queue) > 0:
+                    queued = self._iopub_window_byte_queue[0]
+                    if now >= queued[0]:
+                        self._iopub_window_byte_count -= queued[1]
+                        self._iopub_window_msg_count -= 1
+                        del self._iopub_window_byte_queue[0]
+                    else:
+                        # This part of the queue hasn't be reached yet, so we can
+                        # abort the loop.
+                        break
+
+                # Increment the bytes and message count
+                self._iopub_window_msg_count += 1
+                if msg_type == "stream":
+                    byte_count = sum([len(x) for x in msg_list])
+                else:
+                    byte_count = 0
+                self._iopub_window_byte_count += byte_count
+
+                # Queue a removal of the byte and message count for a time in the
+                # future, when we are no longer interested in it.
+                self._iopub_window_byte_queue.append((now + self.rate_limit_window, byte_count))
+
+                # Check the limits, set the limit flags, and reset the
+                # message and data counts.
+                msg_rate = float(self._iopub_window_msg_count) / self.rate_limit_window
+                data_rate = float(self._iopub_window_byte_count) / self.rate_limit_window
+
+                # Check the msg rate
+                if self.iopub_msg_rate_limit > 0 and msg_rate > self.iopub_msg_rate_limit:
+                    if not self._iopub_msgs_exceeded:
+                        self._iopub_msgs_exceeded = True
+                        parent_header = self.get_msg_field(
+                            "parent_header", parent_header, fed_msg_list
+                        )
+                        write_stderr(
+                            dedent(
+                                """\
+                        IOPub message rate exceeded.
+                        The Jupyter server will temporarily stop sending output
+                        to the client in order to avoid crashing it.
+                        To change this limit, set the config variable
+                        `--ServerApp.iopub_msg_rate_limit`.
+
+                        Current values:
+                        ServerApp.iopub_msg_rate_limit={} (msgs/sec)
+                        ServerApp.rate_limit_window={} (secs)
+                        """.format(
+                                    self.iopub_msg_rate_limit, self.rate_limit_window
+                                )
+                            ),
+                            parent_header,
+                        )
+                else:
+                    # resume once we've got some headroom below the limit
+                    if self._iopub_msgs_exceeded and msg_rate < (0.8 * self.iopub_msg_rate_limit):
+                        self._iopub_msgs_exceeded = False
+                        if not self._iopub_data_exceeded:
+                            self.log.warning("iopub messages resumed")
+
+                # Check the data rate
+                if self.iopub_data_rate_limit > 0 and data_rate > self.iopub_data_rate_limit:
+                    if not self._iopub_data_exceeded:
+                        self._iopub_data_exceeded = True
+                        parent_header = self.get_msg_field(
+                            "parent_header", parent_header, fed_msg_list
+                        )
+                        write_stderr(
+                            dedent(
+                                """\
+                        IOPub data rate exceeded.
+                        The Jupyter server will temporarily stop sending output
+                        to the client in order to avoid crashing it.
+                        To change this limit, set the config variable
+                        `--ServerApp.iopub_data_rate_limit`.
+
+                        Current values:
+                        ServerApp.iopub_data_rate_limit={} (bytes/sec)
+                        ServerApp.rate_limit_window={} (secs)
+                        """.format(
+                                    self.iopub_data_rate_limit, self.rate_limit_window
+                                )
+                            ),
+                            parent_header,
+                        )
+                else:
+                    # resume once we've got some headroom below the limit
+                    if self._iopub_data_exceeded and data_rate < (0.8 * self.iopub_data_rate_limit):
+                        self._iopub_data_exceeded = False
+                        if not self._iopub_msgs_exceeded:
+                            self.log.warning("iopub messages resumed")
+
+                # If either of the limit flags are set, do not send the message.
+                if self._iopub_msgs_exceeded or self._iopub_data_exceeded:
+                    # we didn't send it, remove the current message from the calculus
+                    self._iopub_window_msg_count -= 1
+                    self._iopub_window_byte_count -= byte_count
+                    self._iopub_window_byte_queue.pop(-1)
+                    return
+        super(ZMQChannelsHandler, self)._on_zmq_reply_0_0_1(stream, fed_msg_list[1:])
 
     def close(self):
         super(ZMQChannelsHandler, self).close()
@@ -680,10 +848,13 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             # ensures proper ordering on the IOPub channel
             # that all messages from the stopped kernel have been delivered
             iopub.flush()
-        # msg = self.session.msg("status", {"execution_state": status})
-        # msg["channel"] = "iopub"
-        # self.write_message(json.dumps(msg, default=json_default))
-        # FIXME: write this message
+        msg = self.session.msg("status", {"execution_state": status})
+        if not self.selected_subprotocol:
+            msg["channel"] = "iopub"
+            self.write_message(json.dumps(msg, default=json_default))
+        elif self.selected_subprotocol == "0.0.1":
+            bin_msg = serialize_msg_to_ws(msg, "iopub")
+            self.write_message(bin_msg, binary=True)
 
     def on_kernel_restarted(self):
         self.log.warning("kernel %s restarted", self.kernel_id)
@@ -693,13 +864,44 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         self.log.error("kernel %s restarted failed!", self.kernel_id)
         self._send_status_message("dead")
 
+    def _on_error(self, msg):
+        if self.kernel_manager.allow_tracebacks:
+            return
+        msg["content"]["ename"] = "ExecutionError"
+        msg["content"]["evalue"] = "Execution error"
+        msg["content"]["traceback"] = [self.kernel_manager.traceback_replacement_message]
 
-def get_msg_list(msg, offsets):
+
+def get_msg_list_from_zmq(msg, offsets):
     i0 = 0
     for i1 in offsets:
         yield msg[i0:i1]
         i0 = i1
     yield msg[i0:]
+
+
+def serialize_msg_to_ws(msg, channel, pack):
+    offsets = []
+    curr_sum = 0
+    parts = [
+        pack(msg["header"]),
+        pack(msg["parent_header"]),
+        pack(msg["metadata"]),
+        pack(msg["content"]),
+    ]
+    for part in parts:
+        length = len(part)
+        offsets.append(length + curr_sum)
+        curr_sum += length
+    layout = json.dumps(
+        {
+            "channel": channel,
+            "offsets": offsets,
+        }
+    ).encode("utf-8")
+    layout_length = len(layout).to_bytes(2, byteorder="little")
+    bin_msg = b"".join([layout_length, layout] + parts)
+    return bin_msg
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -694,17 +694,13 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         self._send_status_message("dead")
 
 
-
 def get_msg_list(msg, offsets):
     i0 = 0
-    i = 1
-    while True:
-        i1 = i0 + offsets[i]
-        if i0 == i1:
-            return
+    for i1 in offsets:
         yield msg[i0:i1]
         i0 = i1
-        i += 1
+    yield msg[i0:]
+
 
 # -----------------------------------------------------------------------------
 # URL to handler mappings

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -111,7 +111,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
 
     @property
     def limit_rate(self):
-        return self.settings.get("limit_rate", False)
+        return self.settings.get("limit_rate", True)
 
     @property
     def iopub_msg_rate_limit(self):

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -459,7 +459,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             self.log.debug("Received message on closed websocket %r", ws_msg)
             return
 
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             layout_len = int.from_bytes(ws_msg[:2], "little")
             layout = json.loads(ws_msg[2 : 2 + layout_len])
             msg_list = list(get_parts_from_ws(ws_msg[2 + layout_len :], layout["offsets"]))
@@ -494,7 +494,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                 ignore_msg = True
         if not ignore_msg:
             stream = self.channels[channel]
-            if self.selected_subprotocol == "0.0.1":
+            if self.selected_subprotocol == "v1.websocket.jupyter.org":
                 self.session.send_raw(stream, msg_list)
             else:
                 self.session.send(stream, msg)
@@ -512,7 +512,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
     def _on_zmq_reply(self, stream, msg_list):
         idents, fed_msg_list = self.session.feed_identities(msg_list)
 
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             msg = {"header": None, "parent_header": None, "content": None}
         else:
             msg = self.session.deserialize(fed_msg_list)
@@ -525,7 +525,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         if self._limit_rate(channel, msg, parts):
             return
 
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             super(ZMQChannelsHandler, self)._on_zmq_reply(stream, parts)
         else:
             super(ZMQChannelsHandler, self)._on_zmq_reply(stream, msg)
@@ -537,7 +537,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             content={"text": error_message + "\n", "name": "stderr"},
             parent=msg["parent_header"],
         )
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             bin_msg = serialize_msg_to_ws(err_msg, "iopub", self.session.pack)
             self.write_message(bin_msg, binary=True)
         else:
@@ -715,7 +715,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
             # that all messages from the stopped kernel have been delivered
             iopub.flush()
         msg = self.session.msg("status", {"execution_state": status})
-        if self.selected_subprotocol == "0.0.1":
+        if self.selected_subprotocol == "v1.websocket.jupyter.org":
             bin_msg = serialize_msg_to_ws(msg, "iopub")
             self.write_message(bin_msg, binary=True)
         else:
@@ -741,7 +741,7 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
                 msg["content"]["ename"] = "ExecutionError"
                 msg["content"]["evalue"] = "Execution error"
                 msg["content"]["traceback"] = [self.kernel_manager.traceback_replacement_message]
-                if self.selected_subprotocol == "0.0.1":
+                if self.selected_subprotocol == "v1.websocket.jupyter.org":
                     msg_list[3] = self.session.pack(msg["content"])
 
 


### PR DESCRIPTION
# Towards a better format for the kernel wire protocol over websocket

## Context

Jupyter web clients (e.g. Jupyter Lab) communicate with Jupyter kernels over websockets, but kernels natively use Zero-MQ sockets as their transport layer. The Jupyter server acts as a bridge between kernels and web clients, and is responsible for forwarding messages to/from kernels over Zero-MQ sockets from/to web clients over websocket:

```
kernel <-----> Jupyter server <-----> web client
          ^                      ^
          |                      |
   Zero-MQ sockets           websocket
```

## Current situation

### Kernel wire protocol over Zero-MQ sockets

The kernel wire protocol over Zero-MQ sockets is well specified. It takes advantage of multipart messages, allowing to decompose a message into parts and to send and receive them unmerged. The following table shows the message format (the beginning has been omitted for clarity):

| ... | 0 | 1 | 2 | 3 | 4 | 5 | ... |
| - | - | - | - | - | - | - | - |
| ... | header | parent_header | metadata | content | buffer_0 | buffer_1 | ... |

*Format of a kernel message over Zero-MQ sockets (indices refer to parts, not bytes).*

The message can be deserialized simply by iterating over the parts:

```
{
    "header": header,
    "parent_header": parent_header,
    "metadata": metadata,
    "content": content,
    "buffers": [
        buffer_0,
        buffer_1,
        ...
    ]
}
```

Serializing is equally easy.

### Kernel wire protocol over websocket

A kernel message is serialized over websocket as follows:

| 0 | 4 | 8 | ... | offset_0 | offset_1 | offset_2 | ... |
| - | - | - | - | - | - | - | - |
| offset_0 | offset_1 | offset_2 | ... | msg | buffer_0 | buffer_1 | ... |

*Format of a kernel message over websocket (indices refer to bytes).*

- `offset_0`: position of the kernel message (`msg`) from the beginning of this message, in bytes.
- `offset_1`: position of the first binary buffer (`buffer_0`) from the beginning of this message, in bytes (optional).
- `offset_2`: position of the second binary buffer (`buffer_1`) from the beginning of this message, in bytes (optional).
- `msg`: the kernel message, excluding binary buffers, as a UTF8-encoded stringified JSON.
- `buffer_0`: first binary buffer (optional).
- `buffer_1`: second binary buffer (optional).

The message can be deserialized by parsing `msg` as a JSON object (after decoding it to a string):

```
msg = {
    "channel": channel,
    "header": header,
    "parent_header": parent_header,
    "metadata": metadata,
    "content": content
}
```

Then retrieving the channel name, and updating with the buffers, if any:

```
{
    "buffers": [
        buffer_0,
        buffer_1,
        ...
    ]
}
```

## Problem

The problem is that `msg` is serialized/deserialized using a JSON parser, which is very costly, considering that quite a lot of information could be included e.g. in the `content`. For instance, widgets not using binary buffers might pass data through this field.
Instead, the kernel wire protocol over websocket should remain as close as possible to the kernel wire protocol over Zero-MQ sockets, so that going from one to the other basically consists of moving blocks of raw memory, without any parsing involved whatsoever.

## Proposal

Messages transiting over websockets cannot be decomposed into parts, as it is the case for Zero-MQ sockets. They are received as a whole, so the message must include its own layout description. Unlike the current situation, we propose to use a JSON-encoded layout format, but it is so small and simple that we don't expect any performance loss. The new format of the kernel wire protocol over websocket is the following:

| 0 | 2 | 2 +<br>layout_length | 2+layout_length+<br>layout.offsets[0] | 2+layout_length+<br>layout.offsets[1] | 2+layout_length+<br>layout.offsets[2] | 2+layout_length+<br>layout.offsets[3] | 2+layout_length+<br>layout.offsets[4] | ... |
| - | - | - | - | - | - | - | - | - |
| layout_length | layout | header | parent_header | metadata | content | buffer_0 | buffer_1 | ... |

*Format of a kernel message over websocket (indices refer to bytes).*

Where:

```
layout = {
    "channel": channel,
    "offsets": [offset_0, offset_1, offset_2, ...]
}
```

- `channel` is a string indicating the name of the Zero-MQ socket ("shell", "control" or "iopub").
- `offsets` consists of a list of at least 3 values, corresponding to the offsets of `parent_header`, `metadata` and `content`, respectively (`header` implicitly has offset 0). If more values are provided, they correspond to the offsets of the optional binary buffers.