### PR TITLE
More updates to unit tests for pending kernels work

### DIFF
--- a/jupyter_server/tests/services/sessions/test_api.py
+++ b/jupyter_server/tests/services/sessions/test_api.py
@@ -114,6 +114,24 @@ class SessionClient:
 
 
 @pytest.fixture
+def session_is_ready(jp_serverapp):
+    """Wait for the kernel started by a session to be ready.
+
+    This is useful when working with pending kernels.
+    """
+
+    async def _(session_id):
+        sm = jp_serverapp.session_manager
+        mkm = jp_serverapp.kernel_manager
+        session = await sm.get_session(session_id=session_id)
+        kernel_id = session["kernel"]["id"]
+        kernel = mkm.get_kernel(kernel_id)
+        await kernel.ready
+
+    return _
+
+
+@pytest.fixture
 def session_client(jp_root_dir, jp_fetch):
     subdir = jp_root_dir.joinpath("foo")
     subdir.mkdir()
@@ -156,7 +174,9 @@ def assert_session_equality(actual, expected):
     assert_kernel_equality(actual["kernel"], expected["kernel"])
 
 
-async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses, jp_serverapp):
+async def test_create(
+    session_client, jp_base_url, jp_cleanup_subprocesses, jp_serverapp, session_is_ready
+):
     # Make sure no sessions exist.
     resp = await session_client.list()
     sessions = j(resp)
@@ -197,7 +217,6 @@ async def test_create(session_client, jp_base_url, jp_cleanup_subprocesses, jp_s
     assert_session_equality(got, new_session)
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -218,7 +237,6 @@ async def test_create_bad(
         await session_client.create("foo/nb1.ipynb")
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -251,7 +269,6 @@ async def test_create_bad_pending(
         assert "non_existent_path" in session["kernel"]["reason"]
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -261,7 +278,6 @@ async def test_create_file_session(session_client, jp_cleanup_subprocesses, jp_s
     newsession = j(resp)
     assert newsession["path"] == "foo/nb1.py"
     assert newsession["type"] == "file"
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -272,7 +288,6 @@ async def test_create_console_session(session_client, jp_cleanup_subprocesses, j
     assert newsession["path"] == "foo/abc123"
     assert newsession["type"] == "console"
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -284,7 +299,6 @@ async def test_create_deprecated(session_client, jp_cleanup_subprocesses, jp_ser
     assert newsession["type"] == "notebook"
     assert newsession["notebook"]["path"] == "foo/nb1.ipynb"
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -316,7 +330,6 @@ async def test_create_with_kernel_id(
     got = j(resp)
     assert_session_equality(got, new_session)
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -327,14 +340,15 @@ async def test_create_with_bad_kernel_id(session_client, jp_cleanup_subprocesses
     # TODO
     assert newsession["path"] == "foo/nb1.py"
     assert newsession["type"] == "file"
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
-async def test_delete(session_client, jp_cleanup_subprocesses, jp_serverapp):
+async def test_delete(session_client, jp_cleanup_subprocesses, jp_serverapp, session_is_ready):
     resp = await session_client.create("foo/nb1.ipynb")
+
     newsession = j(resp)
     sid = newsession["id"]
+    await session_is_ready(sid)
 
     resp = await session_client.delete(sid)
     assert resp.code == 204
@@ -347,7 +361,6 @@ async def test_delete(session_client, jp_cleanup_subprocesses, jp_serverapp):
         await session_client.get(sid)
     assert expected_http_error(e, 404)
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -361,7 +374,6 @@ async def test_modify_path(session_client, jp_cleanup_subprocesses, jp_serverapp
     assert changed["id"] == sid
     assert changed["path"] == "nb2.ipynb"
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -375,7 +387,6 @@ async def test_modify_path_deprecated(session_client, jp_cleanup_subprocesses, j
     assert changed["id"] == sid
     assert changed["notebook"]["path"] == "nb2.ipynb"
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -389,7 +400,6 @@ async def test_modify_type(session_client, jp_cleanup_subprocesses, jp_serverapp
     assert changed["id"] == sid
     assert changed["type"] == "console"
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -414,7 +424,6 @@ async def test_modify_kernel_name(session_client, jp_fetch, jp_cleanup_subproces
         assert kernel_list == [after["kernel"]]
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -446,7 +455,6 @@ async def test_modify_kernel_id(session_client, jp_fetch, jp_cleanup_subprocesse
         assert kernel_list == [kernel]
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()
 
 
@@ -509,5 +517,4 @@ async def test_restart_kernel(
     assert model["connections"] == 1
 
     # Need to find a better solution to this.
-    await session_client.cleanup()
     await jp_cleanup_subprocesses()


### PR DESCRIPTION
This is a follow-up PR to #654. The session unit tests also need to changes for the [work landing in Jupyter Client around pending kernels.](https://github.com/jupyter/jupyter_client/pull/732)
