### PR TITLE
bump traitlets dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pyzmq>=17
     argon2-cffi
     ipython_genutils
-    traitlets>=4.2.1
+    traitlets>=5
     jupyter_core>=4.6.0
     jupyter_client>=6.1.1
     nbformat


### PR DESCRIPTION
Fixes #661. 

We previously had a shim for the `'traitlets.utils.descriptions.describe` function for backwards compatibility with traitlets 4.3.x. We dropped this shim in #650 while dropping Python 3.6 support.

I don't think we need to add this shim back. Since traitlets 5.x has been released for over a year, I think we can bump its dependency.