### PR TITLE
Identity API at /api/me

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,6 +73,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxcontrib_github_alt",
     "sphinxcontrib.openapi",
@@ -131,7 +132,7 @@ language = None
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-# default_role = None
+default_role = "literal"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True
@@ -360,6 +361,7 @@ intersphinx_mapping = {
     "nbconvert": ("https://nbconvert.readthedocs.io/en/latest/", None),
     "nbformat": ("https://nbformat.readthedocs.io/en/latest/", None),
     "jupyter": ("https://jupyter.readthedocs.io/en/latest/", None),
+    "tornado": ("https://www.tornadoweb.org/en/stable/", None),
 }
 
 spelling_lang = "en_US"

--- a/jupyter_server/auth/__init__.py
+++ b/jupyter_server/auth/__init__.py
@@ -1,3 +1,4 @@
 from .authorizer import *  # noqa
 from .decorator import authorized  # noqa
+from .identity import *  # noqa
 from .security import passwd  # noqa

--- a/jupyter_server/auth/authorizer.py
+++ b/jupyter_server/auth/authorizer.py
@@ -11,6 +11,8 @@ from traitlets.config import LoggingConfigurable
 
 from jupyter_server.base.handlers import JupyterHandler
 
+from .identity import User
+
 
 class Authorizer(LoggingConfigurable):
     """Base class for authorizing access to resources
@@ -32,23 +34,28 @@ class Authorizer(LoggingConfigurable):
     .. versionadded:: 2.0
     """
 
-    def is_authorized(self, handler: JupyterHandler, user: str, action: str, resource: str) -> bool:
+    def is_authorized(
+        self, handler: JupyterHandler, user: User, action: str, resource: str
+    ) -> bool:
         """A method to determine if `user` is authorized to perform `action`
         (read, write, or execute) on the `resource` type.
 
         Parameters
         ----------
-        user : usually a dict or string
-            A truthy model representing the authenticated user.
-            A username string by default,
-            but usually a dict when integrating with an auth provider.
+        user : jupyter_server.auth.User
+            An object representing the authenticated user,
+            as returned by :meth:`.IdentityProvider.get_user`.
+
         action : str
             the category of action for the current request: read, write, or execute.
 
         resource : str
             the type of resource (i.e. contents, kernels, files, etc.) the user is requesting.
 
-        Returns True if user authorized to make request; otherwise, returns False.
+        Returns
+        -------
+        bool
+            True if user authorized to make request; False, otherwise
         """
         raise NotImplementedError()
 
@@ -61,7 +68,9 @@ class AllowAllAuthorizer(Authorizer):
     .. versionadded:: 2.0
     """
 
-    def is_authorized(self, handler: JupyterHandler, user: str, action: str, resource: str) -> bool:
+    def is_authorized(
+        self, handler: JupyterHandler, user: User, action: str, resource: str
+    ) -> bool:
         """This method always returns True.
 
         All authenticated users are allowed to do anything in the Jupyter Server.

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union
 from tornado.log import app_log
 from tornado.web import HTTPError
 
-from .utils import HTTP_METHOD_TO_AUTH_ACTION, warn_disabled_authorization
+from .utils import HTTP_METHOD_TO_AUTH_ACTION
 
 
 def authorized(
@@ -57,18 +57,13 @@ def authorized(
             if not user:
                 app_log.warning("Attempting to authorize request without authentication!")
                 raise HTTPError(status_code=403, log_message=message)
-
-            # Handle the case where an authorizer wasn't attached to the handler.
-            if not self.authorizer:
-                warn_disabled_authorization()
-                return method(self, *args, **kwargs)
-
-            # Only return the method if the action is authorized.
+            # If the user is allowed to do this action,
+            # call the method.
             if self.authorizer.is_authorized(self, user, action, resource):
                 return method(self, *args, **kwargs)
-
-            # Raise an exception if the method wasn't returned (i.e. not authorized)
-            raise HTTPError(status_code=403, log_message=message)
+            # else raise an exception.
+            else:
+                raise HTTPError(status_code=403, log_message=message)
 
         return inner
 

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -95,6 +95,8 @@ class IdentityProvider(LoggingConfigurable):
     """
     Interface for providing identity
 
+    _may_ be a coroutine.
+
     Two principle methods:
 
     - :meth:`~.IdentityProvider.get_user` returns a :class:`~.User` object

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -1,0 +1,139 @@
+"""Identity Provider interface
+
+This defines the _authentication_ layer of Jupyter Server,
+to be used in combination with Authorizer for _authorization_.
+
+.. versionadded:: 2.0
+"""
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from tornado.web import RequestHandler
+from traitlets.config import LoggingConfigurable
+
+# from dataclasses import field
+
+
+@dataclass
+class User:
+    """Object representing a User
+
+    This or a subclass should be returned from IdentityProvider.get_user
+    """
+
+    username: str  # the only truly required field
+
+    # these fields are filled from username if not specified
+    # name is the 'real' name of the user
+    name: str = ""
+    # display_name is a shorter name for us in UI,
+    # if different from name. e.g. a nickname
+    display_name: str = ""
+
+    # these fields are left as None if undefined
+    initials: Optional[str] = None
+    avatar_url: Optional[str] = None
+    color: Optional[str] = None
+
+    # TODO: extension fields?
+    # ext: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.fill_defaults()
+
+    def fill_defaults(self):
+        """Fill out default fields in the identity model
+
+        - Ensures all values are defined
+        - Fills out derivative values for name fields fields
+        - Fills out null values for optional fields
+        """
+
+        # username is the only truly required field
+        if not self.username:
+            raise ValueError(f"user.username must not be empty: {self}")
+
+        # derive name fields from username -> name -> display name
+        if not self.name:
+            self.name = self.username
+        if not self.display_name:
+            self.display_name = self.name
+
+    def to_dict(self):
+        pass
+
+
+def _backward_compat_user(got_user: Any) -> User:
+    """Backward-compatibility for LoginHandler.get_user
+
+    Prior to 2.0, LoginHandler.get_user could return anything truthy.
+
+    Typically, this was either a simple string username,
+    or a simple dict.
+
+    Make some effort to allow common patterns to keep working.
+    """
+    if isinstance(got_user, str):
+        return User(username=got_user)
+    elif isinstance(got_user, dict):
+        kwargs = {}
+        if "username" not in got_user:
+            if "name" in got_user:
+                kwargs["username"] = got_user["name"]
+        for field in User.__dataclass_fields__:
+            if field in got_user:
+                kwargs[field] = got_user[field]
+        try:
+            return User(**kwargs)
+        except TypeError:
+            raise ValueError(f"Unrecognized user: {got_user}")
+    else:
+        raise ValueError(f"Unrecognized user: {got_user}")
+
+
+class IdentityProvider(LoggingConfigurable):
+    """
+    Interface for providing identity
+
+    Two principle methods:
+
+    - :meth:`~.IdentityProvider.get_user` returns a :class:`~.User` object
+      for successful authentication, or None for no-identity-found.
+    - :meth:`~.IdentityProvider.identity_model` turns a :class:`~.User` into a JSONable dict.
+      The default is to use :py:meth:`dataclasses.asdict`,
+      and usually shouldn't need override.
+
+    .. versionadded:: 2.0
+    """
+
+    def get_user(self, handler: RequestHandler) -> User:
+        """Get the authenticated user for a request
+
+        Must return a :class:`.jupyter_server.auth.User`,
+        though it may be a subclass.
+
+        Return None if the request is not authenticated.
+        """
+
+        if handler.login_handler is None:
+            return User("anonymous")
+
+        # The default: call LoginHandler.get_user for backward-compatibility
+        # TODO: move default implementation to this class,
+        # deprecate `LoginHandler.get_user`
+        user = handler.login_handler.get_user(handler)
+        if user and not isinstance(user, User):
+            return _backward_compat_user(user)
+        return user
+
+    def identity_model(self, user: User) -> dict:
+        """Return a User as an Identity model"""
+        # TODO: validate?
+        return asdict(user)
+
+    def get_handlers(self) -> list:
+        """Return list of additional handlers for this identity provider
+
+        For example, an OAuth callback handler.
+        """
+        return []

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -165,17 +165,20 @@ class LoginHandler(JupyterHandler):
         # called on LoginHandler itself.
         if getattr(handler, "_user_id", None):
             return handler._user_id
-        user_id = cls.get_user_token(handler)
-        if user_id is None:
-            get_secure_cookie_kwargs = handler.settings.get("get_secure_cookie_kwargs", {})
-            user_id = handler.get_secure_cookie(handler.cookie_name, **get_secure_cookie_kwargs)
-            if user_id:
-                user_id = user_id.decode()
-        else:
-            cls.set_login_cookie(handler, user_id)
+        token_user_id = cls.get_user_token(handler)
+        cookie_user_id = cls.get_user_cookie(handler)
+        # prefer token to cookie if both given,
+        # because token is always explicit
+        user_id = token_user_id or cookie_user_id
+        if token_user_id:
+            # if token-authenticated, persist user_id in cookie
+            # if it hasn't already been stored there
+            if user_id != cookie_user_id:
+                cls.set_login_cookie(handler, user_id)
             # Record that the current request has been authenticated with a token.
             # Used in is_token_authenticated above.
             handler._token_authenticated = True
+
         if user_id is None:
             # If an invalid cookie was sent, clear it to prevent unnecessary
             # extra warnings. But don't do this on a request with *no* cookie,
@@ -190,6 +193,15 @@ class LoginHandler(JupyterHandler):
 
         # cache value for future retrievals on the same request
         handler._user_id = user_id
+        return user_id
+
+    @classmethod
+    def get_user_cookie(cls, handler):
+        """Get user-id from a cookie"""
+        get_secure_cookie_kwargs = handler.settings.get("get_secure_cookie_kwargs", {})
+        user_id = handler.get_secure_cookie(handler.cookie_name, **get_secure_cookie_kwargs)
+        if user_id:
+            user_id = user_id.decode()
         return user_id
 
     @classmethod
@@ -215,7 +227,17 @@ class LoginHandler(JupyterHandler):
             authenticated = True
 
         if authenticated:
-            return uuid.uuid4().hex
+            # token does not correspond to user-id,
+            # which is stored in a cookie.
+            # still check the cookie for the user id
+            user_id = cls.get_user_cookie(handler)
+            if user_id is None:
+                # no cookie, generate new random user_id
+                user_id = uuid.uuid4().hex
+                handler.log.info(
+                    f"Generating new user_id for token-authenticated request: {user_id}"
+                )
+            return user_id
         else:
             return None
 

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -152,7 +152,7 @@ class LoginHandler(JupyterHandler):
         """
         if getattr(handler, "_user_id", None) is None:
             # ensure get_user has been called, so we know if we're token-authenticated
-            handler.get_current_user()
+            handler.current_user
         return getattr(handler, "_token_authenticated", False)
 
     @classmethod

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -8,16 +8,11 @@ import warnings
 
 
 def warn_disabled_authorization():
+    """DEPRECATED, does nothing"""
     warnings.warn(
-        "The Tornado web application does not have an 'authorizer' defined "
-        "in its settings. In future releases of jupyter_server, this will "
-        "be a required key for all subclasses of `JupyterHandler`. For an "
-        "example, see the jupyter_server source code for how to "
-        "add an authorizer to the tornado settings: "
-        "https://github.com/jupyter-server/jupyter_server/blob/"
-        "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
-        "#L234-L256",
-        FutureWarning,
+        "jupyter_server.auth.utils.warn_disabled_authorization is deprecated",
+        DeprecationWarning,
+        stacklevel=2,
     )
 
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -134,9 +134,7 @@ class AuthenticatedHandler(web.RequestHandler):
             self.force_clear_cookie(self.cookie_name)
 
     def get_current_user(self):
-        if self.login_handler is None:
-            return "anonymous"
-        return self.login_handler.get_user(self)
+        return self.identity_provider.get_user(self)
 
     def skip_check_origin(self):
         """Ask my login_handler if I should skip the origin_check
@@ -193,7 +191,45 @@ class AuthenticatedHandler(web.RequestHandler):
 
     @property
     def authorizer(self):
+        if "authorizer" not in self.settings:
+            warnings.warn(
+                "The Tornado web application does not have an 'authorizer' defined "
+                "in its settings. In future releases of jupyter_server, this will "
+                "be a required key for all subclasses of `JupyterHandler`. For an "
+                "example, see the jupyter_server source code for how to "
+                "add an authorizer to the tornado settings: "
+                "https://github.com/jupyter-server/jupyter_server/blob/"
+                "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
+                "#L234-L256",
+            )
+            from jupyter_server.auth import AllowAllAuthorizer
+
+            self.settings["authorizer"] = AllowAllAuthorizer(
+                config=self.settings.get("config", None)
+            )
+
         return self.settings.get("authorizer")
+
+    @property
+    def identity_provider(self):
+        if "identity_provider" not in self.settings:
+            warnings.warn(
+                "The Tornado web application does not have an 'identity_provider' defined "
+                "in its settings. In future releases of jupyter_server, this will "
+                "be a required key for all subclasses of `JupyterHandler`. For an "
+                "example, see the jupyter_server source code for how to "
+                "add an identity provider to the tornado settings: "
+                "https://github.com/jupyter-server/jupyter_server/blob/"
+                "aa8fd8b3faf37466eeb99689d5555314c5bf6640/jupyter_server/serverapp.py"
+                "#L253",
+            )
+            from jupyter_server.auth import IdentityProvider
+
+            # no identity provider set, load default
+            self.settings["identity_provider"] = IdentityProvider(
+                config=self.settings.get("config", None)
+            )
+        return self.settings["identity_provider"]
 
 
 class JupyterHandler(AuthenticatedHandler):

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -313,7 +313,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):
         the websocket finishes completing.
         """
         # authenticate the request before opening the websocket
-        user = self.get_current_user()
+        user = self.current_user
         if user is None:
             self.log.warning("Couldn't authenticate WebSocket connection")
             raise web.HTTPError(403)

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -19,8 +19,6 @@ from jupyter_client.session import Session
 from tornado import ioloop, web
 from tornado.websocket import WebSocketHandler
 
-from jupyter_server.auth.utils import warn_disabled_authorization
-
 from .handlers import JupyterHandler
 
 
@@ -321,10 +319,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer:
-            # Warn if there is not authorizer.
-            warn_disabled_authorization()
-        elif not self.authorizer.is_authorized(self, user, "execute", "kernels"):
+        if not self.authorizer.is_authorized(self, user, "execute", "kernels"):
             raise web.HTTPError(403)
 
         if self.get_argument("session_id", False):

--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -48,7 +48,7 @@ class WebSocketChannelsHandler(WebSocketHandler, JupyterHandler):
         the websocket finishes completing.
         """
         # authenticate the request before opening the websocket
-        if self.get_current_user() is None:
+        if self.current_user is None:
             self.log.warning("Couldn't authenticate WebSocket connection")
             raise web.HTTPError(403)
 

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -33,6 +33,16 @@ parameters:
     in: path
     description: file path
     type: string
+  permissions:
+    name: permissions
+    type: string
+    required: false
+    in: query
+    description: |
+      JSON-serialized dictionary of `{"resource": ["action",]}`
+      (dict of lists of strings) to check.
+      The same dictionary structure will be returned,
+      containing only the actions for which the user is authorized.
   checkpoint_id:
     name: checkpoint_id
     required: true
@@ -616,7 +626,42 @@ paths:
           description: Forbidden to access
         404:
           description: Not found
-
+  /api/me:
+    get:
+      summary: |
+        Get the identity of the currently authenticated user.
+        If present, a `permissions` argument may be specified
+        to check what actions the user currently is authorized to take.
+      tags:
+        - identity
+      parameters:
+        - $ref: "#/parameters/permissions"
+      responses:
+        200:
+          description: The user's identity and permissions
+          schema:
+            type: object
+            properties:
+              identity:
+                $ref: "#/definitions/Identity"
+              permissions:
+                $ref: "#/definitions/Permissions"
+            example:
+              identity:
+                username: minrk
+                name: Min Ragan-Kelley
+                display_name: Min RK
+                initials: MRK
+                avatar_url: null
+                color: null
+              permissions:
+                contents:
+                  - read
+                  - write
+                kernels:
+                  - read
+                  - write
+                  - execute
   /api/status:
     get:
       summary: Get the current status/activity of the server.
@@ -663,6 +708,53 @@ definitions:
         type: number
         description: |
           The total number of running kernels.
+  Identity:
+    description: The identity of the currently authenticated user
+    properties:
+      username:
+        type: string
+        description: |
+          Unique string identifying the user
+      name:
+        type: string
+        description: |
+          For-humans name of the user.
+          May be the same as `username` in systems where
+          only usernames are available.
+      display_name:
+        type: string
+        description: |
+          Alternate rendering of name for display.
+          Often the same as `name`.
+      initials:
+        type: string
+        description: |
+          Short string of initials.
+          Initials should not be derived automatically due to localization issues.
+          May be `null` if unavailable.
+      avatar_url:
+        type: string
+        description: |
+          URL of an avatar to be used for the user.
+          May be `null` if unavailable.
+      color:
+        type: string
+        description: |
+          A CSS color string to use as a preferred color,
+          such as for collaboration cursors.
+          May be `null` if unavailable.
+  Permissions:
+    type: object
+    description: |
+      A dict of the form: `{"resource": ["action",]}`
+      containing only the AUTHORIZED subset of resource+actions
+      from the permissions specified in the request.
+      If no permission checks were made in the request,
+      this will be empty.
+    additionalProperties:
+      type: array
+      items:
+        type: string
   KernelSpec:
     description: Kernel spec (contents of kernel.json)
     properties:

--- a/tests/auth/test_identity.py
+++ b/tests/auth/test_identity.py
@@ -1,0 +1,107 @@
+import pytest
+
+from jupyter_server.auth import IdentityProvider, User
+from jupyter_server.auth.identity import _backward_compat_user
+
+
+class CustomUser:
+    def __init__(self, name):
+        self.name = name
+
+
+@pytest.mark.parametrize(
+    "old_user, expected",
+    [
+        (
+            "str-name",
+            {"username": "str-name", "name": "str-name", "display_name": "str-name"},
+        ),
+        (
+            {"username": "user.username", "name": "user.name"},
+            {
+                "username": "user.username",
+                "name": "user.name",
+                "display_name": "user.name",
+            },
+        ),
+        (
+            {"username": "user.username", "display_name": "display"},
+            {
+                "username": "user.username",
+                "name": "user.username",
+                "display_name": "display",
+            },
+        ),
+        ({"name": "user.name"}, {"username": "user.name", "name": "user.name"}),
+        ({"unknown": "value"}, ValueError),
+        (CustomUser("custom_name"), ValueError),
+    ],
+)
+def test_identity_model(old_user, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            user = _backward_compat_user(old_user)
+        return
+    user = _backward_compat_user(old_user)
+    idp = IdentityProvider()
+    identity = idp.identity_model(user)
+    print(identity)
+    identity_subset = {key: identity[key] for key in expected}
+    print(type(identity), type(identity_subset), type(expected))
+    assert identity_subset == expected
+
+
+@pytest.mark.parametrize(
+    "fields, expected",
+    [
+        ({"name": "user"}, TypeError),
+        (
+            {"username": "user.username"},
+            {
+                "username": "user.username",
+                "name": "user.username",
+                "initials": None,
+                "avatar_url": None,
+                "color": None,
+            },
+        ),
+        (
+            {"username": "user.username", "name": "user.name", "color": "#abcdef"},
+            {
+                "username": "user.username",
+                "name": "user.name",
+                "display_name": "user.name",
+                "color": "#abcdef",
+            },
+        ),
+        (
+            {"username": "user.username", "display_name": "display"},
+            {
+                "username": "user.username",
+                "name": "user.username",
+                "display_name": "display",
+            },
+        ),
+    ],
+)
+def test_user_defaults(fields, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            user = User(**fields)
+        return
+    user = User(**fields)
+
+    # check expected fields
+    for key in expected:
+        assert getattr(user, key) == expected[key]
+
+    # check types
+    for key in ("username", "name", "display_name"):
+        value = getattr(user, key)
+        assert isinstance(value, str)
+        # don't allow empty strings
+        assert value
+
+    for key in ("initials", "avatar_url", "color"):
+        value = getattr(user, key)
+        assert value is None or isinstance(value, str)

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -1,4 +1,5 @@
 """Tests for login redirects"""
+import json
 from functools import partial
 from urllib.parse import urlencode
 
@@ -92,3 +93,26 @@ async def test_next_ok(login, jp_base_url, next_path):
     expected = jp_base_url + next_path
     actual = await login(next=expected)
     assert actual == expected
+
+
+async def test_token_cookie_user_id(jp_serverapp, jp_fetch):
+    token = jp_serverapp.token
+
+    # first request with token, sets cookie with user-id
+    resp = await jp_fetch("/")
+    assert resp.code == 200
+    set_cookie = resp.headers["set-cookie"]
+    headers = {"Cookie": set_cookie}
+
+    # subsequent requests with cookie and no token
+    # receive same user-id
+    resp = await jp_fetch("/api/me", headers=headers)
+    user_id = json.loads(resp.body.decode("utf8"))
+    resp = await jp_fetch("/api/me", headers=headers)
+    user_id2 = json.loads(resp.body.decode("utf8"))
+    assert user_id["identity"] == user_id2["identity"]
+
+    # new request, just token -> new user_id
+    resp = await jp_fetch("/api/me")
+    user_id3 = json.loads(resp.body.decode("utf8"))
+    assert user_id["identity"] != user_id3["identity"]

--- a/tests/services/api/test_api.py
+++ b/tests/services/api/test_api.py
@@ -1,4 +1,11 @@
 import json
+from typing import Dict, List
+from unittest import mock
+
+import pytest
+from tornado.httpclient import HTTPError
+
+from jupyter_server.auth import Authorizer, IdentityProvider, User
 
 
 async def test_get_spec(jp_fetch):
@@ -21,3 +28,151 @@ async def test_get_status(jp_fetch):
     assert status["kernels"] == 0
     assert status["last_activity"].endswith("Z")
     assert status["started"].endswith("Z")
+
+
+class MockUser(User):
+    permissions: Dict[str, List[str]]
+
+
+class MockIdentityProvider(IdentityProvider):
+    mock_user: MockUser
+
+    def get_user(self, handler):
+        # super returns a UUID
+        # return our mock user instead, as long as the request is authorized
+        authenticated = super().get_user(handler)
+        if isinstance(self.mock_user, dict):
+            self.mock_user = MockUser(**self.mock_user)
+        if authenticated:
+            return self.mock_user
+
+
+class MockAuthorizer(Authorizer):
+    def is_authorized(self, handler, user, action, resource):
+        permissions = user.permissions
+        if permissions == "*":
+            return True
+        actions = permissions.get(resource, [])
+        return action in actions
+
+
+@pytest.fixture
+def identity_provider(jp_serverapp):
+    idp = MockIdentityProvider(parent=jp_serverapp)
+    authorizer = MockAuthorizer(parent=jp_serverapp)
+    with mock.patch.dict(
+        jp_serverapp.web_app.settings,
+        {"identity_provider": idp, "authorizer": authorizer},
+    ):
+        yield idp
+
+
+@pytest.mark.parametrize(
+    "identity, expected",
+    [
+        (
+            {"username": "user.username"},
+            {
+                "username": "user.username",
+                "name": "user.username",
+                "display_name": "user.username",
+            },
+        ),
+        (
+            {"username": "user", "name": "name", "display_name": "display"},
+            {"username": "user", "name": "name", "display_name": "display"},
+        ),
+        (
+            None,
+            403,
+        ),
+    ],
+)
+async def test_identity(jp_fetch, identity, expected, identity_provider):
+    if identity:
+        identity_provider.mock_user = MockUser(**identity)
+    else:
+        identity_provider.mock_user = None
+
+    if isinstance(expected, int):
+        with pytest.raises(HTTPError) as exc:
+            await jp_fetch("api/me")
+        print(exc)
+        assert exc.value.code == expected
+        return
+
+    r = await jp_fetch("api/me")
+
+    assert r.code == 200
+    response = json.loads(r.body.decode())
+    assert set(response.keys()) == {"identity", "permissions"}
+    identity_model = response["identity"]
+    print(identity_model)
+    for key, value in expected.items():
+        assert identity_model[key] == value
+
+    assert set(identity_model.keys()) == set(User.__dataclass_fields__)
+
+
+@pytest.mark.parametrize(
+    "have_permissions, check_permissions, expected",
+    [
+        ("*", None, {}),
+        (
+            {
+                "contents": ["read"],
+                "kernels": ["read", "write"],
+                "sessions": ["write"],
+            },
+            {
+                "contents": ["read", "write"],
+                "kernels": ["read", "write", "execute"],
+                "terminals": ["execute"],
+            },
+            {
+                "contents": ["read"],
+                "kernels": ["read", "write"],
+                "terminals": [],
+            },
+        ),
+        ("*", {"contents": ["write"]}, {"contents": ["write"]}),
+    ],
+)
+async def test_identity_permissions(
+    jp_fetch, have_permissions, check_permissions, expected, identity_provider
+):
+    user = MockUser("username")
+    user.permissions = have_permissions
+    identity_provider.mock_user = user
+
+    if check_permissions is not None:
+        params = {"permissions": json.dumps(check_permissions)}
+    else:
+        params = None
+
+    r = await jp_fetch("api/me", params=params)
+    assert r.code == 200
+    response = json.loads(r.body.decode())
+    assert set(response.keys()) == {"identity", "permissions"}
+    assert response["permissions"] == expected
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        "",
+        "[]",
+        '"abc"',
+        json.dumps({"resource": "action"}),
+        json.dumps({"resource": [5]}),
+        json.dumps({"resource": {}}),
+    ],
+)
+async def test_identity_bad_permissions(jp_fetch, permissions):
+    with pytest.raises(HTTPError) as exc:
+        await jp_fetch("api/me", params={"permissions": json.dumps(permissions)})
+
+    r = exc.value.response
+    assert r.code == 400
+    reply = json.loads(r.body.decode())
+    assert "permissions should be a JSON dict" in reply["message"]


### PR DESCRIPTION
Draft implement of identity API (closes #638). Includes #165.

Key issues:

- Jupyter Server has never put any requirements on the return of `get_user` other than truthiness - this poses a challenge in coercing to a user model. I'm aware of two patterns:
  1. current_user is a string username (the default), and
  2. current_user is a dict with 'username' field or 'name' field (JupyterHub uses 'name')
  
  so these are supported, and others result in `username: "unknown"`.
  We could take this opportunity to _enforce_ a structure on .current_user, or we could require custom User objects to use a corresponding Authorizer class to define the new Authorizer.user_model method to adapt to the dict format.
- checking permissions - the design in #165 doesn't allow _a priori_ listing of available resource+action combinations, so permissions to check are inputs to the API request. Currently, permissions input is two lists - resources and actions, but it could be a JSON dict of `resource: [action,]` (matching output).

TODO:

- [x] merge #165
- [x] implement /api/me
- [x] test /api/me
- [x] decide how to enforce/coerce current_user to user model
- [x] decide on required, optional fields
- [x] decide on permission checking
