### PR TITLE
Add Auto Pre-Commit

### DIFF
--- a/.github/workflows/trigger_precommit.yml
+++ b/.github/workflows/trigger_precommit.yml
@@ -1,0 +1,24 @@
+name: Trigger Pre-Commit on a PR
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pr-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@1.0.0
+        id: check
+        with:
+          trigger: "auto run pre-commit"
+      - if: steps.check.outputs.triggered == 'true'
+        uses: jupyterlab/maintainer-tools/.github/actions/pr-script@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pre_commit: true
+          commit_message: "auto run pre-commit"
+          target: ${{ github.event.issue.html_url }}
+          association: ${{ github.event.comment.author_association }}


### PR DESCRIPTION
Experimental support for running `pre-commit` on a [PR](https://github.com/jupyterlab/maintainer-tools#pr-script-1).

With this configuration, any member, owner, or collaborator can comment `auto run pre-commit`, and it will run `pre-commit` against the PR and push the change.

For now, we use the `GITHUB_TOKEN` provided to the workflow.
The result is that the workflows are not automatically re-run for the commit: we have to close and re-open the PR.

We can later decide to use an access token from `@jupyterlab-bot`, which would re-run the workflows.

The end state is that we will ideally use [jupyterlab-probot](https://github.com/jupyterlab/jupyterlab-probot/issues/14) for this feature once it is available there.

This gives us a chance to kick the tires on the concept with minimal risk.