### PR TITLE
Use pytest-github-actions-annotate-failures

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install the Python dependencies
         run: |
           pip install -e ".[test]"
+          pip install pytest-github-actions-annotate-failures
       - name: List installed packages
         run: |
           pip freeze

--- a/.github/workflows/python-linux.yml
+++ b/.github/workflows/python-linux.yml
@@ -100,5 +100,6 @@ jobs:
       - name: Install From SDist
         run: |
           pip install --find-links=./sdist "jupyter_server[test]>=0.0.dev0"
+          pip install pytest-github-actions-annotate-failures
       - name: Run Test
         run: pytest -vv --pyargs --timeout=300 --timeout_method=thread jupyter_server --capture=no

--- a/.github/workflows/python-macos.yml
+++ b/.github/workflows/python-macos.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install the Python dependencies
         run: |
           pip install -e .[test] codecov
+          pip install pytest-github-actions-annotate-failures
       - name: List installed packages
         run: |
           pip freeze

--- a/.github/workflows/python-windows.yml
+++ b/.github/workflows/python-windows.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install the Python dependencies
         run: |
           pip install -e .[test]
+          pip install pytest-github-actions-annotate-failures
       - name: List installed packages
         run: |
           pip freeze


### PR DESCRIPTION
This should make it a bit easier to debug CI failures.