### PR TITLE
Disable write_error logic for the FileFindHandler

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -871,6 +871,10 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
 
         return super(FileFindHandler, self).validate_absolute_path(root, absolute_path)
 
+    def write_error(self, status_code, **kwargs):
+        # This is a no-op, we don't write any HTML error file
+        pass
+
 
 class APIVersionHandler(APIHandler):
     def get(self):


### PR DESCRIPTION
When failing to serve a static file with the `FileFindHandler`, the `FileFindHandler` calls `write_error` (inherited from JupyterHandler, see https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/base/handlers.py#L565-L599) which tries to render the `404.html` or `error.html` template with Jinja. 

My understanding is that this should not happen, and the static file handler should only show an error in the console like the following:
```
WARNING:tornado.access:404 GET /whatever.js (::1) 1.79ms
```

This PR turns the inherited `write_error` method into a no-op.