### PR TITLE
Re-use ServerApp.config_file_paths for consistency

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -162,6 +162,11 @@ class ExtensionApp(JupyterApp):
     def _default_open_browser(self):
         return self.serverapp.config["ServerApp"].get("open_browser", True)
 
+    @property
+    def config_file_paths(self):
+        """Look on the same path as our parent for config files"""
+        return self.serverapp.config_file_paths
+
     # The extension name used to name the jupyter config
     # file, jupyter_{name}_config.
     # This should also match the jupyter subcommand used to launch

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -104,7 +104,6 @@ from jupyter_core.application import (
     base_flags,
     base_aliases,
 )
-from jupyter_core.paths import jupyter_config_path
 from jupyter_client import KernelManager
 from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.session import Session
@@ -2154,11 +2153,7 @@ class ServerApp(JupyterApp):
         # This enables merging on keys, which we want for extension enabling.
         # Regular config loading only merges at the class level,
         # so each level clobbers the previous.
-        config_paths = jupyter_config_path()
-        if self.config_dir not in config_paths:
-            # add self.config_dir to the front, if set manually
-            config_paths.insert(0, self.config_dir)
-        manager = ExtensionConfigManager(read_config_path=config_paths)
+        manager = ExtensionConfigManager(read_config_path=self.config_file_paths)
         extensions = manager.get_jpserver_extensions()
 
         for modulename, enabled in sorted(extensions.items()):


### PR DESCRIPTION
Rather than duplicating its logic, re-use the value. JupyterHub overrides this in the base ServerApp (https://github.com/jupyterhub/jupyterhub/issues/3804), but the overridden value should be used for both:

1. locating extensions,
2. when extensions look for their own config files
