### PR TITLE
allow handlers to work without an authorizer in the Tornado settings

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -193,7 +193,7 @@ class AuthenticatedHandler(web.RequestHandler):
 
     @property
     def authorizer(self):
-        return self.settings["authorizer"]
+        return self.settings.get("authorizer")
 
 
 class JupyterHandler(AuthenticatedHandler):


### PR DESCRIPTION
Fixes #713.

We worked on this issue during contributing hour.

Allows the handlers in jupyter_server to be used without its tornado web app by setting the `authorizer` to `None` when it's not found in the tornado settings. Adding this to maintain backwards compatibility for now.

It also raises a warning to inform libraries like Voila that they should include an authorizer in the settings in future releases of Jupyter Server.