### PR TITLE
Implement Required Methods in Async Manner

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -906,3 +906,21 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
             raise
         except Exception as e:
             raise web.HTTPError(500, "Unknown error renaming file: %s %s" % (old_path, e)) from e
+
+    async def dir_exists(self, path):
+        """Does a directory exist at the given path"""
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        return os.path.isdir(os_path)
+
+    async def file_exists(self, path):
+        """Does a file exist at the given path"""
+        path = path.strip("/")
+        os_path = self._get_os_path(path)
+        return os.path.isfile(os_path)
+
+    async def is_hidden(self, path):
+        """Is path a hidden directory or file"""
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        return is_hidden(os_path, self.root_dir)


### PR DESCRIPTION
The `AsyncFileContentsManager` was missing `async` definitions of the a few required methods. Therefore because of the multiple inheritance, the `FileContentsManager` definitions were being used resulting in an unpleasant developer experience when implementing a proxy Contents Manager responsible for delegating to an `AsyncContentsManager` (for our remote storage system at Twitter) or an `AsyncLargeFileManager`.  This feels like undesired behavior to have a few CM methods need to be execute in a synchronous style and some in an async style using `await` requiring additional boilerplate type checking in my case.