### PR TITLE
Clean up activity recording

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -514,7 +514,7 @@ class MappingKernelManager(MultiKernelManager):
             self.last_kernel_activity = kernel.last_activity = utcnow()
 
             idents, fed_msg_list = session.feed_identities(msg_list)
-            msg = session.deserialize(fed_msg_list)
+            msg = session.deserialize(fed_msg_list, content=False)
 
             msg_type = msg["header"]["msg_type"]
             if msg_type == "status":

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -518,6 +518,7 @@ class MappingKernelManager(MultiKernelManager):
 
             msg_type = msg["header"]["msg_type"]
             if msg_type == "status":
+                msg = session.deserialize(fed_msg_list)
                 kernel.execution_state = msg["content"]["execution_state"]
                 self.log.debug(
                     "activity on %s: %s (%s)",


### PR DESCRIPTION
Avoid deserializing the entire message until we know it is a status message to avoid deserializing large iopub contents.