### PR TITLE
Validate notebooks once per fetch or save

### DIFF
--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -265,7 +265,9 @@ class FileManagerMixin(Configurable):
         """Read a notebook from an os path."""
         with self.open(os_path, "r", encoding="utf-8") as f:
             try:
-                return nbformat.read(f, as_version=as_version, capture_validation_error=capture_validation_error)
+                return nbformat.read(
+                    f, as_version=as_version, capture_validation_error=capture_validation_error
+                )
             except Exception as e:
                 e_orig = e
 
@@ -284,12 +286,19 @@ class FileManagerMixin(Configurable):
             invalid_file = path_to_invalid(os_path)
             replace_file(os_path, invalid_file)
             replace_file(tmp_path, os_path)
-            return self._read_notebook(os_path, as_version, capture_validation_error=capture_validation_error)
+            return self._read_notebook(
+                os_path, as_version, capture_validation_error=capture_validation_error
+            )
 
     def _save_notebook(self, os_path, nb, capture_validation_error=None):
         """Save a notebook to an os_path."""
         with self.atomic_writing(os_path, encoding="utf-8") as f:
-            nbformat.write(nb, f, version=nbformat.NO_CONVERT, capture_validation_error=capture_validation_error)
+            nbformat.write(
+                nb,
+                f,
+                version=nbformat.NO_CONVERT,
+                capture_validation_error=capture_validation_error,
+            )
 
     def _read_file(self, os_path, format):
         """Read a non-notebook file.
@@ -356,8 +365,14 @@ class AsyncFileManagerMixin(FileManagerMixin):
         """Read a notebook from an os path."""
         with self.open(os_path, "r", encoding="utf-8") as f:
             try:
-                return await run_sync(partial(nbformat.read, as_version=as_version,
-                                              capture_validation_error=capture_validation_error), f)
+                return await run_sync(
+                    partial(
+                        nbformat.read,
+                        as_version=as_version,
+                        capture_validation_error=capture_validation_error,
+                    ),
+                    f,
+                )
             except Exception as e:
                 e_orig = e
 
@@ -376,13 +391,22 @@ class AsyncFileManagerMixin(FileManagerMixin):
             invalid_file = path_to_invalid(os_path)
             await async_replace_file(os_path, invalid_file)
             await async_replace_file(tmp_path, os_path)
-            return await self._read_notebook(os_path, as_version, capture_validation_error=capture_validation_error)
+            return await self._read_notebook(
+                os_path, as_version, capture_validation_error=capture_validation_error
+            )
 
     async def _save_notebook(self, os_path, nb, capture_validation_error=None):
         """Save a notebook to an os_path."""
         with self.atomic_writing(os_path, encoding="utf-8") as f:
-            await run_sync(partial(nbformat.write, version=nbformat.NO_CONVERT,
-                                   capture_validation_error=capture_validation_error), nb, f)
+            await run_sync(
+                partial(
+                    nbformat.write,
+                    version=nbformat.NO_CONVERT,
+                    capture_validation_error=capture_validation_error,
+                ),
+                nb,
+                f,
+            )
 
     async def _read_file(self, os_path, format):
         """Read a non-notebook file.

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -383,11 +383,12 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
 
         if content:
-            nb = self._read_notebook(os_path, as_version=4)
+            validation_error = {}
+            nb = self._read_notebook(os_path, as_version=4, capture_validation_error=validation_error)
             self.mark_trusted_cells(nb, path)
             model["content"] = nb
             model["format"] = "json"
-            self.validate_notebook_model(model)
+            self.validate_notebook_model(model, validation_error)
 
         return model
 
@@ -461,11 +462,12 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
         self.log.debug("Saving %s", os_path)
 
+        validation_error = {}
         try:
             if model["type"] == "notebook":
                 nb = nbformat.from_dict(model["content"])
                 self.check_and_sign(nb, path)
-                self._save_notebook(os_path, nb)
+                self._save_notebook(os_path, nb, capture_validation_error=validation_error)
                 # One checkpoint should always exist for notebooks.
                 if not self.checkpoints.list_checkpoints(path):
                     self.create_checkpoint(path)
@@ -484,7 +486,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         validation_message = None
         if model["type"] == "notebook":
-            self.validate_notebook_model(model)
+            self.validate_notebook_model(model, validation_error=validation_error)
             validation_message = model.get("message", None)
 
         model = self.get(path, content=False)
@@ -707,11 +709,12 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         os_path = self._get_os_path(path)
 
         if content:
-            nb = await self._read_notebook(os_path, as_version=4)
+            validation_error = {}
+            nb = await self._read_notebook(os_path, as_version=4, capture_validation_error=validation_error)
             self.mark_trusted_cells(nb, path)
             model["content"] = nb
             model["format"] = "json"
-            self.validate_notebook_model(model)
+            self.validate_notebook_model(model, validation_error)
 
         return model
 
@@ -784,11 +787,12 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         if "content" not in model and model["type"] != "directory":
             raise web.HTTPError(400, "No file content provided")
 
+        validation_error = {}
         try:
             if model["type"] == "notebook":
                 nb = nbformat.from_dict(model["content"])
                 self.check_and_sign(nb, path)
-                await self._save_notebook(os_path, nb)
+                await self._save_notebook(os_path, nb, capture_validation_error=validation_error)
                 # One checkpoint should always exist for notebooks.
                 if not (await self.checkpoints.list_checkpoints(path)):
                     await self.create_checkpoint(path)
@@ -807,7 +811,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
 
         validation_message = None
         if model["type"] == "notebook":
-            self.validate_notebook_model(model)
+            self.validate_notebook_model(model, validation_error=validation_error)
             validation_message = model.get("message", None)
 
         model = await self.get(path, content=False)

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -384,7 +384,9 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         if content:
             validation_error = {}
-            nb = self._read_notebook(os_path, as_version=4, capture_validation_error=validation_error)
+            nb = self._read_notebook(
+                os_path, as_version=4, capture_validation_error=validation_error
+            )
             self.mark_trusted_cells(nb, path)
             model["content"] = nb
             model["format"] = "json"
@@ -710,7 +712,9 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
 
         if content:
             validation_error = {}
-            nb = await self._read_notebook(os_path, as_version=4, capture_validation_error=validation_error)
+            nb = await self._read_notebook(
+                os_path, as_version=4, capture_validation_error=validation_error
+            )
             self.mark_trusted_cells(nb, path)
             model["content"] = nb
             model["format"] = "json"

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -388,9 +388,9 @@ class ContentsManager(LoggingConfigurable):
                 validate_nb(model["content"])
         except ValidationError as e:
             model["message"] = "Notebook validation failed: {}:\n{}".format(
-                    e.message,
-                    json.dumps(e.instance, indent=1, default=lambda obj: "<UNKNOWN>"),
-                )
+                e.message,
+                json.dumps(e.instance, indent=1, default=lambda obj: "<UNKNOWN>"),
+            )
         return model
 
     def new_untitled(self, path="", type="", ext=""):

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     traitlets>=5
     jupyter_core>=4.6.0
     jupyter_client>=6.1.1
-    nbformat
+    nbformat>=5.2.0
     nbconvert
     Send2Trash
     terminado>=0.8.3

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,14 +1,12 @@
 import os
 import sys
 import time
+from itertools import combinations
 from typing import Dict
 from typing import Optional
 from typing import Tuple
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
-from itertools import combinations
-
-import jsonschema
 import pytest
 from nbformat import v4 as nbformat
 from nbformat import ValidationError
@@ -77,7 +75,9 @@ def add_invalid_cell(notebook):
     notebook.cells.append(cell)
 
 
-async def prepare_notebook(jp_contents_manager, make_invalid: Optional[bool] = False) -> Tuple[Dict, str]:
+async def prepare_notebook(
+    jp_contents_manager, make_invalid: Optional[bool] = False
+) -> Tuple[Dict, str]:
     cm = jp_contents_manager
     model = await ensure_async(cm.new_untitled(type="notebook"))
     name = model["name"]
@@ -704,8 +704,9 @@ async def test_nb_validation(jp_contents_manager):
     # successful methods and ensure that calls to the aliased "validate_nb" are
     # zero.  Note that since patching side-effects the validation error case, we'll
     # skip call-count assertions for that portion of the test.
-    with patch("nbformat.validate") as mock_validate, \
-         patch("jupyter_server.services.contents.manager.validate_nb") as mock_validate_nb:
+    with patch("nbformat.validate") as mock_validate, patch(
+        "jupyter_server.services.contents.manager.validate_nb"
+    ) as mock_validate_nb:
         # Valid notebook, save, then get
         model = await ensure_async(cm.save(model, path))
         assert "message" not in model

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,10 +1,17 @@
 import os
 import sys
 import time
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from unittest.mock import Mock, patch
+
 from itertools import combinations
 
+import jsonschema
 import pytest
 from nbformat import v4 as nbformat
+from nbformat import ValidationError
 from tornado.web import HTTPError
 from traitlets import TraitError
 
@@ -63,7 +70,14 @@ def add_code_cell(notebook):
     notebook.cells.append(cell)
 
 
-async def new_notebook(jp_contents_manager):
+def add_invalid_cell(notebook):
+    output = nbformat.new_output("display_data", {"application/javascript": "alert('hi');"})
+    cell = nbformat.new_code_cell("print('hi')", outputs=[output])
+    cell.pop("source")  # Remove source to invaliate
+    notebook.cells.append(cell)
+
+
+async def prepare_notebook(jp_contents_manager, make_invalid: Optional[bool] = False) -> Tuple[Dict, str]:
     cm = jp_contents_manager
     model = await ensure_async(cm.new_untitled(type="notebook"))
     name = model["name"]
@@ -72,8 +86,19 @@ async def new_notebook(jp_contents_manager):
     full_model = await ensure_async(cm.get(path))
     nb = full_model["content"]
     nb["metadata"]["counter"] = int(1e6 * time.time())
-    add_code_cell(nb)
+    if make_invalid:
+        add_invalid_cell(nb)
+    else:
+        add_code_cell(nb)
+    return full_model, path
 
+
+async def new_notebook(jp_contents_manager):
+    full_model, path = await prepare_notebook(jp_contents_manager)
+    cm = jp_contents_manager
+    name = full_model["name"]
+    path = full_model["path"]
+    nb = full_model["content"]
     await ensure_async(cm.save(full_model, path))
     return nb, name, path
 
@@ -667,3 +692,82 @@ async def test_check_and_sign(jp_contents_manager):
     cm.mark_trusted_cells(nb, path)
     cm.check_and_sign(nb, path)
     assert cm.notary.check_signature(nb)
+
+
+async def test_nb_validation(jp_contents_manager):
+    # Test that validation is performed once when a notebook is read or written
+
+    model, path = await prepare_notebook(jp_contents_manager, make_invalid=False)
+    cm = jp_contents_manager
+
+    # We'll use a patch to capture the call count on "nbformat.validate" for the
+    # successful methods and ensure that calls to the aliased "validate_nb" are
+    # zero.  Note that since patching side-effects the validation error case, we'll
+    # skip call-count assertions for that portion of the test.
+    with patch("nbformat.validate") as mock_validate, \
+         patch("jupyter_server.services.contents.manager.validate_nb") as mock_validate_nb:
+        # Valid notebook, save, then get
+        model = await ensure_async(cm.save(model, path))
+        assert "message" not in model
+        assert mock_validate.call_count == 1
+        assert mock_validate_nb.call_count == 0
+        mock_validate.reset_mock()
+        mock_validate_nb.reset_mock()
+
+        # Get the notebook and ensure there are no messages
+        model = await ensure_async(cm.get(path))
+        assert "message" not in model
+        assert mock_validate.call_count == 1
+        assert mock_validate_nb.call_count == 0
+        mock_validate.reset_mock()
+        mock_validate_nb.reset_mock()
+
+    # Add invalid cell, save, then get
+    add_invalid_cell(model["content"])
+
+    model = await ensure_async(cm.save(model, path))
+    assert "message" in model
+    assert "Notebook validation failed:" in model["message"]
+
+    model = await ensure_async(cm.get(path))
+    assert "message" in model
+    assert "Notebook validation failed:" in model["message"]
+
+
+async def test_validate_notebook_model(jp_contents_manager):
+    # Test the validation_notebook_model method to ensure that validation is not
+    # performed when a validation_error dictionary is provided and is performed
+    # when that parameter is None.
+
+    model, path = await prepare_notebook(jp_contents_manager, make_invalid=False)
+    cm = jp_contents_manager
+
+    with patch("jupyter_server.services.contents.manager.validate_nb") as mock_validate_nb:
+        # Valid notebook and a non-None dictionary, no validate call expected
+
+        validation_error = {}
+        cm.validate_notebook_model(model, validation_error)
+        assert mock_validate_nb.call_count == 0
+        mock_validate_nb.reset_mock()
+
+        # And without the extra parameter, validate call expected
+        cm.validate_notebook_model(model)
+        assert mock_validate_nb.call_count == 1
+        mock_validate_nb.reset_mock()
+
+        # Now do the same with an invalid model
+        # invalidate the model...
+        add_invalid_cell(model["content"])
+
+        validation_error["ValidationError"] = ValidationError("not a real validation error")
+        cm.validate_notebook_model(model, validation_error)
+        assert "Notebook validation failed" in model["message"]
+        assert mock_validate_nb.call_count == 0
+        mock_validate_nb.reset_mock()
+        model.pop("message")
+
+        # And without the extra parameter, validate call expected.  Since patch side-effects
+        # the patched method, we won't attempt to access the message field.
+        cm.validate_notebook_model(model)
+        assert mock_validate_nb.call_count == 1
+        mock_validate_nb.reset_mock()


### PR DESCRIPTION
Some [prior network analyses](https://github.com/jupyter-server/jupyter_server/issues/312) found that each fetch and save of a notebook file resulted in [double validation](https://github.com/jupyter-server/jupyter_server/issues/312#issuecomment-697095810), presumably so the server could set a helpful message on the notebook model returned to the user since the validation performed within `nbformat`'s read or write methods did not return any indication of a validation error.

`nbformat` was [recently updated](https://github.com/jupyter/nbformat/pull/249) to enable applications to _ask_ for validation error status on the initial read/write calls, thereby enabling notebook to skip its second call to validate the notebook.  This pull request leverages those updated signatures now available in `nbformat 5.2.0`.

The existing `validate_notebook_model()`, however, will still call `nbformat.validate()` if a `None` `validation_error` parameter is provided.  This was done in order to preserve existing functionality from potential calls by server extensions.  The message generation code is shared by both by raising the exception present in the `validation_error` dictionary.

(The CI failures do not appear to be related to these changes.)