### PR TITLE
Missing warning when no authorizer in found ZMQ handlers

### DIFF
--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -2,7 +2,6 @@
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-import warnings
 from functools import wraps
 from typing import Callable
 from typing import Optional
@@ -12,6 +11,7 @@ from tornado.log import app_log
 from tornado.web import HTTPError
 
 from .utils import HTTP_METHOD_TO_AUTH_ACTION
+from .utils import warn_disabled_authorization
 
 
 def authorized(
@@ -63,17 +63,7 @@ def authorized(
 
             # Handle the case where an authorizer wasn't attached to the handler.
             if not self.authorizer:
-                warnings.warn(
-                    "The Tornado web application does not have an 'authorizer' defined "
-                    "in its settings. In future releases of jupyter_server, this will "
-                    "be a required key for all subclasses of `JupyterHandler`. For an "
-                    "example, see the jupyter_server source code for how to "
-                    "add an authorizer to the tornado settings: "
-                    "https://github.com/jupyter-server/jupyter_server/blob/"
-                    "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
-                    "#L234-L256",
-                    FutureWarning,
-                )
+                warn_disabled_authorization()
                 return method(self, *args, **kwargs)
 
             # Only return the method if the action is authorized.

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -4,6 +4,21 @@
 # Distributed under the terms of the Modified BSD License.
 import importlib
 import re
+import warnings
+
+
+def warn_disabled_authorization():
+    warnings.warn(
+        "The Tornado web application does not have an 'authorizer' defined "
+        "in its settings. In future releases of jupyter_server, this will "
+        "be a required key for all subclasses of `JupyterHandler`. For an "
+        "example, see the jupyter_server source code for how to "
+        "add an authorizer to the tornado settings: "
+        "https://github.com/jupyter-server/jupyter_server/blob/"
+        "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
+        "#L234-L256",
+        FutureWarning,
+    )
 
 
 HTTP_METHOD_TO_AUTH_ACTION = {

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -21,6 +21,7 @@ from tornado import web
 from tornado.websocket import WebSocketHandler
 
 from .handlers import JupyterHandler
+from jupyter_server.auth.utils import warn_disabled_authorization
 
 
 def serialize_binary_message(msg):
@@ -320,7 +321,10 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer.is_authorized(self, user, "execute", "kernels"):
+        if not self.authorizer:
+            # Warn if there is not authorizer.
+            warn_disabled_authorization()
+        elif not self.authorizer.is_authorized(self, user, "execute", "kernels"):
             raise web.HTTPError(403)
 
         if self.get_argument("session_id", False):

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -8,6 +8,7 @@ from tornado import web
 from ..base.handlers import JupyterHandler
 from ..base.zmqhandlers import WebSocketMixin
 from jupyter_server._tz import utcnow
+from jupyter_server.auth.utils import warn_disabled_authorization
 
 AUTH_RESOURCE = "terminals"
 
@@ -28,7 +29,11 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
         if not user:
             raise web.HTTPError(403)
 
-        if not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
+        # authorize the user.
+        if not self.authorizer:
+            # Warn if there is not authorizer.
+            warn_disabled_authorization()
+        elif not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
             raise web.HTTPError(403)
 
         if not args[0] in self.term_manager.terminals:


### PR DESCRIPTION
Looks like I missed one more place where a warning is needed when no authorizer is set.

Fixes #737 (hopefully completely).