### PR TITLE
wait to cleanup kernels after kernel is finished pending

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -189,15 +189,9 @@ class MappingKernelManager(MultiKernelManager):
         return os_path
 
     async def _remove_kernel_when_ready(self, kernel_id, kernel_awaitable):
-        try:
-            await super()._remove_kernel_when_ready(kernel_id, kernel_awaitable)
-        finally:
-            # Unlike its async sibling method in AsyncMappingKernelManager, removing the kernel_id
-            # from the connections dictionary isn't as problematic before the shutdown since the
-            # method is synchronous.  However, we'll keep the relative call orders the same from
-            # a maintenance perspective.
-            self._kernel_connections.pop(kernel_id, None)
-            self._kernel_ports.pop(kernel_id, None)
+        await super()._remove_kernel_when_ready(kernel_id, kernel_awaitable)
+        self._kernel_connections.pop(kernel_id, None)
+        self._kernel_ports.pop(kernel_id, None)
 
     async def start_kernel(self, kernel_id=None, path=None, **kwargs):
         """Start a kernel for a session and return its kernel_id.


### PR DESCRIPTION
This PR fixes an issue I'm seeing when working with pending kernels. 

There's race condition when shutting a kernel down. The entries in `_kernel_connections` and `_kernel_ports` for a pending shutdown get removed before that pending kernel fully finished terminating. 

This raises the following exception in the kernels handler as a consequence:
```
Uncaught exception GET /api/kernels/0b8f1e20-e8c6-43a2-bb96-8f07dc702636/channels?session_id=61f58256-f8d3-48f3-a12e-0ac6c0f4c856 (127.0.0.1)
    HTTPServerRequest(protocol='http', host='127.0.0.1:8888', method='GET', uri='/api/kernels/0b8f1e20-e8c6-43a2-bb96-8f07dc702636/channels?session_id=61f58256-f8d3-48f3-a12e-0ac6c0f4c856', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/.../python3.8/site-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/.../python3.8/site-packages/jupyter_server/services/kernels/handlers.py", line 409, in get
        await super(ZMQChannelsHandler, self).get(kernel_id=kernel_id)
      File "/.../lib/python3.8/site-packages/jupyter_server/base/zmqhandlers.py", line 341, in get
        await res
      File "/.../python3.8/site-packages/tornado/websocket.py", line 278, in get
        await self.ws_connection.accept_connection(self)
      File "/.../python3.8/site-packages/tornado/websocket.py", line 879, in accept_connection
        await self._accept_connection(handler)
      File "/.../python3.8/site-packages/tornado/websocket.py", line 962, in _accept_connection
        await self._receive_frame_loop()
      File "/.../python3.8/site-packages/tornado/websocket.py", line 1119, in _receive_frame_loop
        self.handler.on_ws_connection_close(self.close_code, self.close_reason)
      File "/.../python3.8/site-packages/tornado/websocket.py", line 576, in on_ws_connection_close
        self.on_connection_close()
      File "/.../python3.8/site-packages/tornado/websocket.py", line 568, in on_connection_close
        self.on_close()
      File "/.../python3.8/site-packages/jupyter_server/services/kernels/handlers.py", line 722, in on_close
        if km._kernel_connections[self.kernel_id] == 0:
    KeyError: '0b8f1e20-e8c6-43a2-bb96-8f07dc702636'
```