### PR TITLE
Fix error handler in simple extension examples

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/jupyter/jupyter_server && \
   pip install -e .[test]
 ```
 
-**OPTIONAL** If you want to build the Typescript code, you need [npm](https://www.npmjs.com) on your local environement. Compiled javascript is provided as artifact in this repository, so this Typescript build step is optional. The Typescript source and configuration have been taken from https://github.com/markellekelly/jupyter-server-example.
+**OPTIONAL** If you want to build the Typescript code, you need [npm](https://www.npmjs.com) on your local environment. Compiled javascript is provided as artifact in this repository, so this Typescript build step is optional. The Typescript source and configuration have been taken from https://github.com/markellekelly/jupyter-server-example.
 
 ```bash
 npm install && \
@@ -88,7 +88,7 @@ The following command starts both the `simple_ext1` and `simple_ext2` extensions
 jupyter server --ServerApp.jpserver_extensions="{'simple_ext1': True, 'simple_ext2': True}"
 ```
 
-Check that the previous `Extension 1` content is still available ant that you can also render `Extension 2` Server content in your browser.
+Check that the previous `Extension 1` content is still available and that you can also render `Extension 2` Server content in your browser.
 
 ```bash
 # HTML static page.

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -46,7 +46,7 @@ class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
                 (r"/{}/template1/(.*)$".format(self.name), TemplateHandler),
                 (r"/{}/redirect".format(self.name), RedirectHandler),
                 (r"/{}/typescript/?".format(self.name), TypescriptHandler),
-                (r"/{}/(.*)", ErrorHandler),
+                (r"/{}/(.*)".format(self.name), ErrorHandler),
             ]
         )
 

--- a/examples/simple/simple_ext1/handlers.py
+++ b/examples/simple/simple_ext1/handlers.py
@@ -42,10 +42,11 @@ class TypescriptHandler(BaseTemplateHandler):
 
 class TemplateHandler(BaseTemplateHandler):
     def get(self, path):
-        """Optionaly, you can print(self.get_template('simple1.html'))"""
+        """Optionally, you can print(self.get_template('simple1.html'))"""
         self.write(self.render_template("simple1.html", path=path))
 
 
 class ErrorHandler(BaseTemplateHandler):
     def get(self, path):
-        self.write(self.render_template("error.html", path=path))
+        # write_error renders template from error.html file.
+        self.write_error(400)

--- a/examples/simple/simple_ext2/handlers.py
+++ b/examples/simple/simple_ext2/handlers.py
@@ -31,4 +31,4 @@ class TemplateHandler(BaseTemplateHandler):
 
 class ErrorHandler(BaseTemplateHandler):
     def get(self, path):
-        self.write(self.render_template("error.html"))
+        self.write_error(400)

--- a/examples/simple/tests/test_handlers.py
+++ b/examples/simple/tests/test_handlers.py
@@ -11,10 +11,21 @@ def jp_server_config(jp_template_dir):
 async def test_handler_default(jp_fetch):
     r = await jp_fetch("simple_ext1/default", method="GET")
     assert r.code == 200
-    print(r.body.decode())
     assert r.body.decode().index("Hello Simple 1 - I am the default...") > -1
 
 
 async def test_handler_template(jp_fetch):
-    r = await jp_fetch("simple_ext1/template1/test", method="GET")
+    path = "/custom/path"
+    r = await jp_fetch("simple_ext1/template1/{}".format(path), method="GET")
     assert r.code == 200
+    assert r.body.decode().index("Path: {}".format(path)) > -1
+
+
+async def test_handler_typescript(jp_fetch):
+    r = await jp_fetch("simple_ext1/typescript", method="GET")
+    assert r.code == 200
+
+
+async def test_handler_error(jp_fetch):
+    r = await jp_fetch("simple_ext1/nope", method="GET")
+    assert r.body.decode().index("400 : Bad Request") > -1


### PR DESCRIPTION
I fixed problem with error handler in simple extension.
We can use `write_error` instead of `write`, so [`status_code` and `status_message`](https://github.com/jupyter-server/jupyter_server/blob/main/examples/simple/simple_ext1/templates/error.html#L8) will be populated.
Also, I added few unit tests for simple_ext1.

cc @Zsailer 