### PR TITLE
add hook to observe pending sessions

### DIFF
--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -14,8 +14,33 @@ from tornado import web
 from traitlets import Instance, TraitError, Unicode, validate
 from traitlets.config.configurable import LoggingConfigurable
 
+from typing import Union
+
+from jupyter_server.utils import ensure_async
 from jupyter_server.traittypes import InstanceFromClasses
 from jupyter_server.utils import ensure_async
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SessionRecord:
+    session_id: Union[None, str] = None
+    kernel_id: Union[None, str] = None
+    recorded: Union[None, bool] = None
+
+    def __eq__(self, other: "SessionRecord") -> bool:
+        if isinstance(other, SessionRecord):
+            if any(
+                [
+                    # Check if the session_id matches
+                    self.session_id and other.session_id and self.session_id == other.session_id,
+                    # Check if the kernel_id matches.
+                    self.kernel_id and other.kernel_id and self.kernel_id == other.kernel_id,
+                ]
+            ):
+                return True
+        return False
 
 
 class SessionManager(LoggingConfigurable):
@@ -57,6 +82,8 @@ class SessionManager(LoggingConfigurable):
             "notebook.services.contents.manager.ContentsManager",
         ]
     )
+
+    _pending_session = []
 
     # Session database initialized below
     _cursor = None

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -10,21 +10,22 @@ except ImportError:
     # fallback on pysqlite2 if Python was build without sqlite
     from pysqlite2 import dbapi2 as sqlite3
 
+from dataclasses import dataclass, fields
+from typing import Union
+
 from tornado import web
 from traitlets import Instance, TraitError, Unicode, validate
 from traitlets.config.configurable import LoggingConfigurable
 
-from typing import Union
-
-from jupyter_server.utils import ensure_async
 from jupyter_server.traittypes import InstanceFromClasses
 from jupyter_server.utils import ensure_async
 
-from dataclasses import dataclass
-from dataclasses import fields
-
 
 class KernelSessionRecordConflict(Exception):
+    """Exception class to use when two KernelSessionRecords cannot
+    merge because of conflicting data.
+    """
+
     pass
 
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -25,8 +25,6 @@ from dataclasses import fields
 
 
 class KernelSessionRecordConflict(Exception):
-    """An exception raised when"""
-
     pass
 
 
@@ -34,7 +32,9 @@ class KernelSessionRecordConflict(Exception):
 class KernelSessionRecord:
     """A record object for tracking a Jupyter Server Kernel Session.
 
-    Two records are equal if they share the
+    Two records that share a session_id must also share a kernel_id, while
+    kernels can have multiple session (and thereby) session_ids
+    associated with them.
     """
 
     session_id: Union[None, str] = None
@@ -86,11 +86,12 @@ class KernelSessionRecord:
 
 
 class KernelSessionRecordList:
-    """Handy object for storing and managing a list of KernelSessionRecords.
+    """An object for storing and managing a list of KernelSessionRecords.
 
-    When adding a record to the list, first checks if the record
-    already exists. If it does, the record will be updated with
-    the new information.
+    When adding a record to the list, the KernelSessionRecordList
+    first checks if the record already exists in the list. If it does,
+    the record will be updated with the new information; otherwise,
+    it will be appended.
     """
 
     def __init__(self, *records):
@@ -116,6 +117,9 @@ class KernelSessionRecordList:
         return len(self._records)
 
     def get(self, record: Union[KernelSessionRecord, str]) -> KernelSessionRecord:
+        """Return a full KernelSessionRecord from a session_id, kernel_id, or
+        incomplete KernelSessionRecord.
+        """
         if isinstance(record, str):
             for r in self._records:
                 if record == r.kernel_id or record == r.session_id:

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -7,10 +7,12 @@ from traitlets import TraitError
 from jupyter_server._tz import isoformat, utcnow
 from jupyter_server.services.contents.manager import ContentsManager
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
-from jupyter_server.services.sessions.sessionmanager import KernelSessionRecord
-from jupyter_server.services.sessions.sessionmanager import KernelSessionRecordConflict
-from jupyter_server.services.sessions.sessionmanager import KernelSessionRecordList
-from jupyter_server.services.sessions.sessionmanager import SessionManager
+from jupyter_server.services.sessions.sessionmanager import (
+    KernelSessionRecord,
+    KernelSessionRecordConflict,
+    KernelSessionRecordList,
+    SessionManager,
+)
 
 
 class DummyKernel(object):

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from tornado import web
 from traitlets import TraitError
@@ -5,6 +7,9 @@ from traitlets import TraitError
 from jupyter_server._tz import isoformat, utcnow
 from jupyter_server.services.contents.manager import ContentsManager
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+from jupyter_server.services.sessions.sessionmanager import KernelRecord
+from jupyter_server.services.sessions.sessionmanager import KernelRecordConflict
+from jupyter_server.services.sessions.sessionmanager import KernelRecordList
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 
 
@@ -39,9 +44,111 @@ class DummyMKM(MappingKernelManager):
         del self._kernels[kernel_id]
 
 
+class SlowDummyMKM(DummyMKM):
+    async def start_kernel(self, kernel_id=None, path=None, kernel_name="python", **kwargs):
+        await asyncio.sleep(1.0)
+        return await super().start_kernel(
+            kernel_id=kernel_id, path=path, kernel_name=kernel_name, **kwargs
+        )
+
+    async def shutdown_kernel(self, kernel_id, now=False):
+        await asyncio.sleep(1.0)
+        await super().shutdown_kernel(kernel_id, now=now)
+
+
 @pytest.fixture
 def session_manager():
     return SessionManager(kernel_manager=DummyMKM(), contents_manager=ContentsManager())
+
+
+def test_kernel_record_equals():
+    record1 = KernelRecord(session_id="session1")
+    record2 = KernelRecord(session_id="session1", kernel_id="kernel1")
+    record3 = KernelRecord(session_id="session2", kernel_id="kernel1")
+    record4 = KernelRecord(session_id="session1", kernel_id="kernel2")
+
+    assert record1 == record2
+    assert record2 == record3
+    assert record3 != record4
+    assert record1 != record3
+    assert record3 != record4
+
+    with pytest.raises(KernelRecordConflict):
+        assert record2 == record4
+
+
+def test_kernel_record_update():
+    record1 = KernelRecord(session_id="session1")
+    record2 = KernelRecord(session_id="session1", kernel_id="kernel1")
+    record1.update(record2)
+    assert record1.kernel_id == "kernel1"
+
+    record1 = KernelRecord(session_id="session1")
+    record2 = KernelRecord(kernel_id="kernel1")
+    record1.update(record2)
+    assert record1.kernel_id == "kernel1"
+
+    record1 = KernelRecord(kernel_id="kernel1")
+    record2 = KernelRecord(session_id="session1")
+    record1.update(record2)
+    assert record1.session_id == "session1"
+
+    record1 = KernelRecord(kernel_id="kernel1")
+    record2 = KernelRecord(session_id="session1", kernel_id="kernel1")
+    record1.update(record2)
+    assert record1.session_id == "session1"
+
+    record1 = KernelRecord(kernel_id="kernel1")
+    record2 = KernelRecord(session_id="session1", kernel_id="kernel2")
+    with pytest.raises(KernelRecordConflict):
+        record1.update(record2)
+
+    record1 = KernelRecord(kernel_id="kernel1", session_id="session1")
+    record2 = KernelRecord(kernel_id="kernel2")
+    with pytest.raises(KernelRecordConflict):
+        record1.update(record2)
+
+    record1 = KernelRecord(kernel_id="kernel1", session_id="session1")
+    record2 = KernelRecord(kernel_id="kernel2", session_id="session1")
+    with pytest.raises(KernelRecordConflict):
+        record1.update(record2)
+
+    record1 = KernelRecord(session_id="session1", kernel_id="kernel1")
+    record2 = KernelRecord(session_id="session2", kernel_id="kernel1")
+    record1.update(record2)
+    assert record1.session_id == "session2"
+
+
+def test_kernel_record_list():
+    records = KernelRecordList()
+    r = KernelRecord(kernel_id="kernel1")
+    records.update(r)
+    assert r in records
+    assert "kernel1" in records
+    assert len(records) == 1
+
+    # Test .get()
+    r_ = records.get(r)
+    assert r == r_
+    r_ = records.get(r.kernel_id)
+    assert r == r_
+
+    with pytest.raises(ValueError):
+        records.get("badkernel")
+
+    r_update = KernelRecord(kernel_id="kernel1", session_id="session1")
+    records.update(r_update)
+    assert len(records) == 1
+    assert "session1" in records
+
+    r2 = KernelRecord(kernel_id="kernel2")
+    records.update(r2)
+    assert r2 in records
+    assert len(records) == 2
+
+    records.remove(r2)
+    assert r2 not in records
+    assert len(records) == 1
 
 
 async def create_multiple_sessions(session_manager, *kwargs_list):
@@ -362,3 +469,50 @@ async def test_session_persistence(jp_runtime_dir):
 
     # Assert that the session database persists.
     session = await session_manager.get_session(session_id=session["id"])
+
+
+async def test_pending_kernel():
+    session_manager = SessionManager(
+        kernel_manager=SlowDummyMKM(), contents_manager=ContentsManager()
+    )
+    # Create a session with a slow starting kernel
+    fut = session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="python", type="notebook"
+    )
+    task = asyncio.create_task(fut)
+    await asyncio.sleep(0.1)
+    assert len(session_manager._pending_kernels) == 1
+    # Get a handle on the record
+    record = session_manager._pending_kernels._records[0]
+    session = await task
+    # Check that record is cleared after the task has completed.
+    assert record not in session_manager._pending_kernels
+
+    # Check pending kernel list when sessions are
+    fut = session_manager.delete_session(session_id=session["id"])
+    task = asyncio.create_task(fut)
+    await asyncio.sleep(0.1)
+    assert len(session_manager._pending_kernels) == 1
+    # Get a handle on the record
+    record = session_manager._pending_kernels._records[0]
+    session = await task
+    # Check that record is cleared after the task has completed.
+    assert record not in session_manager._pending_kernels
+
+    # Test multiple, parallel pending kernels
+    fut1 = session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="python", type="notebook"
+    )
+    fut2 = session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="python", type="notebook"
+    )
+    task1 = asyncio.create_task(fut1)
+    await asyncio.sleep(0.1)
+    task2 = asyncio.create_task(fut2)
+    await asyncio.sleep(0.1)
+    assert len(session_manager._pending_kernels) == 2
+
+    await task1
+    await task2
+    session1, session2 = await asyncio.gather(task1, task2)
+    assert len(session_manager._pending_kernels) == 0


### PR DESCRIPTION
In the case where a (new) session has been created and a new kernel is launched, there can be time gap between when a kernel is actually started and its session is actually saved—specifically, if [`._finish_kernel_start()`](https://github.com/jupyter-server/jupyter_server/blob/cd1b1b886db08c6480329c3f0832d05f15d49a19/jupyter_server/services/kernels/kernelmanager.py#L219) takes any time at all. The same is true for deleting sessions; `shutdown_kernel` can take some time. I call this a "pending session".

I've been working on some tooling to synchronize sessions and kernels (more on that coming in a future PR). To achieve this, I need to be "aware" of pending sessions. Unfortunately, this isn't easily achievable without adding the plumbing directly to source code, hence this pull request.

Here, I've added a "KernelSessionRecordList". This is a thread-safe list of kernels started by the SessionManager. The items in this list can be searched by their `kernel_id` or `session_id`. Two records are equal if either of these two keys match each other. When updating this list, we check if the record already exists. If so, we update the value, rather than append.

When `create_session` is first called, a temporary `KernelSessionRecord` is added to the `_pending_sessions` attribute. Once the session is saved, the KernelSessionRecord is removed from the list. The same is true for `delete_session`. 

The unit tests I've added are a good demonstration of how the `._pending_sessions` attribute works.

I've opened this PR in draft state for discussion at our next meeting. I'm hoping to open another PR to show my use-case and justify merging. This is an additive feature that won't affect most users, so the risk of merging is fairly low.

