### PR TITLE
Handle importstring pre/post save hooks

### DIFF
--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -127,7 +127,7 @@ class ContentsManager(LoggingConfigurable):
             value = import_item(self.pre_save_hook)
         if not callable(value):
             raise TraitError("pre_save_hook must be callable")
-        if self.pre_save_hook is not None:
+        if callable(self.pre_save_hook):
             warnings.warn(
                 f"Overriding existing pre_save_hook ({self.pre_save_hook.__name__}) with a new one ({value.__name__}).",
                 stacklevel=2,
@@ -162,7 +162,7 @@ class ContentsManager(LoggingConfigurable):
             value = import_item(value)
         if not callable(value):
             raise TraitError("post_save_hook must be callable")
-        if self.post_save_hook is not None:
+        if callable(self.post_save_hook):
             warnings.warn(
                 f"Overriding existing post_save_hook ({self.post_save_hook.__name__}) with a new one ({value.__name__}).",
                 stacklevel=2,

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -18,6 +18,30 @@ def test_config_did_something(jp_server_config, jp_serverapp):
     )
 
 
+def example_pre_save_hook():
+    pass
+
+
+def example_post_save_hook():
+    pass
+
+
+@pytest.mark.parametrize(
+    "jp_server_config",
+    [
+        {
+            "ContentsManager": {
+                "pre_save_hook": "tests.services.contents.test_config.example_pre_save_hook",
+                "post_save_hook": "tests.services.contents.test_config.example_post_save_hook",
+            },
+        }
+    ],
+)
+def test_pre_post_save_hook_config(jp_serverapp, jp_server_config):
+    assert jp_serverapp.contents_manager.pre_save_hook.__name__ == "example_pre_save_hook"
+    assert jp_serverapp.contents_manager.post_save_hook.__name__ == "example_post_save_hook"
+
+
 async def test_async_contents_manager(jp_configurable_serverapp):
     config = {"ContentsManager": {"checkpoints_class": AsyncCheckpoints}}
     argv = [


### PR DESCRIPTION
Try access the __name__ attribute on the function form of the hook, and
if it doesn't exist then use the string as the name.

Closes #753