### PR TITLE
Ensure minimal nbconvert support jinja2 v2 & v3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     argon2-cffi
     traitlets>=5.1.0
     jupyter_core>=4.7.0
-    jupyter_client>=6.1.5
+    jupyter_client>=6.1.12
     nbformat>=5.2.0
     nbconvert>=6.2.0
     Send2Trash

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     jupyter_core>=4.6.0
     jupyter_client>=6.1.1
     nbformat>=5.2.0
-    nbconvert
+    nbconvert>=6.2.0
     Send2Trash
     terminado>=0.8.3
     prometheus_client

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pyzmq>=17
     argon2-cffi
     traitlets>=5.1.0
-    jupyter_core>=4.6.0
+    jupyter_core>=4.7.0
     jupyter_client>=6.1.5
     nbformat>=5.2.0
     nbconvert>=6.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     tornado>=6.1.0
     pyzmq>=17
     argon2-cffi
-    traitlets>=5
+    traitlets>=5.1.0
     jupyter_core>=4.6.0
     jupyter_client>=6.1.1
     nbformat>=5.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     argon2-cffi
     traitlets>=5.1.0
     jupyter_core>=4.6.0
-    jupyter_client>=6.1.1
+    jupyter_client>=6.1.5
     nbformat>=5.2.0
     nbconvert>=6.2.0
     Send2Trash

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     jupyter_core>=4.7.0
     jupyter_client>=6.1.12
     nbformat>=5.2.0
-    nbconvert>=6.2.0
+    nbconvert>=6.4.4
     Send2Trash
     terminado>=0.8.3
     prometheus_client


### PR DESCRIPTION
Fix https://github.com/jupyter-server/jupyter_server/runs/5681044426?check_suite_focus=true where nbconvert 5.6.1 is used. But jinja2 3.1 was just release and drop some deprecated functions from v2. So requires at least nbconvert 6.2 that handle both jinja2 v2 and v3.