### PR TITLE
Regression in connection URL calcuation in ServerApp

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1976,8 +1976,10 @@ class ServerApp(JupyterApp):
             scheme = "http+unix"
             netloc = urlencode_unix_socket_path(self.sock)
         else:
+            if not self.ip:
+                ip = "localhost"
             # Handle nonexplicit hostname.
-            if self.ip in ("", "0.0.0.0", "::"):
+            elif self.ip in ("0.0.0.0", "::"):
                 ip = "%s" % socket.gethostname()
             else:
                 ip = "[{}]".format(self.ip) if ":" in self.ip else self.ip

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -229,6 +229,12 @@ def test_resolve_file_to_run_and_root_dir(prefix_path, root_dir, file_to_run, ex
             "http+unix://%2Ftmp%2Fjp-test.sock/test/?token=<generated>",
             "http+unix://%2Ftmp%2Fjp-test.sock/",
         ),
+        (
+            {"ip": ""},
+            "http://localhost:8888/?token=<generated>",
+            "http://127.0.0.1:8888/?token=<generated>",
+            "http://localhost:8888/",
+        )
     ],
 )
 def test_urls(config, public_url, local_url, connection_url):

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -234,7 +234,7 @@ def test_resolve_file_to_run_and_root_dir(prefix_path, root_dir, file_to_run, ex
             "http://localhost:8888/?token=<generated>",
             "http://127.0.0.1:8888/?token=<generated>",
             "http://localhost:8888/",
-        )
+        ),
     ],
 )
 def test_urls(config, public_url, local_url, connection_url):


### PR DESCRIPTION
Addresses an unintentional regression in the calculation of the `connection_url` property of the `ServerApp` detailed in issue: #743 
