### PR TITLE
Give write permissions to enforce label workflow

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   enforce-label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: enforce-triage-label
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1


### PR DESCRIPTION
Take advantage of auto-labeling for dependabot and pre-commit-ci PRs from https://github.com/jupyterlab/maintainer-tools/pull/83/files.