### PR TITLE
Use new post-version-spec from jupyter_releaser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ filterwarnings = [
 [tool.jupyter-releaser]
 skip = ["check-links"]
 
+[tool.jupyter-releaser.options]
+post-version-spec = "dev"
+
 [tool.tbump.version]
 current = "1.16.1.dev0"
 regex = '''


### PR DESCRIPTION
Take advantage of https://github.com/jupyter-server/jupyter_releaser/pull/287

This means that we don't have to set `post-version-spec` when releasing, it will bump to the next minor `.dev0` automatically.  When we run `next`, it will use the previous version from the changelog.  When we use `minor`, it will just drop the `.dev` suffix.