### PR TITLE
Fix path for full config doc

### DIFF
--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -36,9 +36,7 @@ enter::
 
 """
 try:
-    destination = os.path.join(
-        os.path.dirname(__file__), "source/other/full-config.rst"
-    )
+    destination = os.path.join(os.path.dirname(__file__), "source/other/full-config.rst")
 except BaseException:
     destination = os.path.join(os.getcwd(), "other/full-config.rst")
 

--- a/docs/autogen_config.py
+++ b/docs/autogen_config.py
@@ -36,9 +36,11 @@ enter::
 
 """
 try:
-    destination = os.path.join(os.path.dirname(__file__), "source/other/full-config.rst")
+    destination = os.path.join(
+        os.path.dirname(__file__), "source/other/full-config.rst"
+    )
 except BaseException:
-    destination = os.path.join(os.getcwd(), "full-config.rst")
+    destination = os.path.join(os.getcwd(), "other/full-config.rst")
 
 with open(destination, "w") as f:
     f.write(header)


### PR DESCRIPTION
After this PR: https://github.com/jupyter-server/jupyter_server/pull/794, I noticed that full config doc is generated under this path: https://jupyter-server.readthedocs.io/en/latest/full-config.html, but it should be generated under https://jupyter-server.readthedocs.io/en/latest/other/full-config.html.

I guess, we missed `other/` in the destination path, since `autogen_config.py` is executed from  [`/docs/source`](https://github.com/jupyter-server/jupyter_server/tree/main/docs/source).

cc @Zsailer @blink1073 