### PR TITLE
Remove unused pytest-mock dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,6 @@ test =
     pre-commit
     pytest-console-scripts
     pytest-cov
-    pytest-mock
     pytest-timeout
     pytest-tornasync
     pytest>=6.0


### PR DESCRIPTION
Remove the dependency on pytest-mock, as the `mocker` fixture is not
used anywhere in the source code, and all tests pass without it.