### PR TITLE
(backport) ensure authorizer is defined

### DIFF
--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union
 from tornado.log import app_log
 from tornado.web import HTTPError
 
-from .utils import HTTP_METHOD_TO_AUTH_ACTION, warn_disabled_authorization
+from .utils import HTTP_METHOD_TO_AUTH_ACTION
 
 
 def authorized(
@@ -57,18 +57,13 @@ def authorized(
             if not user:
                 app_log.warning("Attempting to authorize request without authentication!")
                 raise HTTPError(status_code=403, log_message=message)
-
-            # Handle the case where an authorizer wasn't attached to the handler.
-            if not self.authorizer:
-                warn_disabled_authorization()
-                return method(self, *args, **kwargs)
-
-            # Only return the method if the action is authorized.
+            # If the user is allowed to do this action,
+            # call the method.
             if self.authorizer.is_authorized(self, user, action, resource):
                 return method(self, *args, **kwargs)
-
-            # Raise an exception if the method wasn't returned (i.e. not authorized)
-            raise HTTPError(status_code=403, log_message=message)
+            # else raise an exception.
+            else:
+                raise HTTPError(status_code=403, log_message=message)
 
         return inner
 

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -8,16 +8,11 @@ import warnings
 
 
 def warn_disabled_authorization():
+    """DEPRECATED, does nothing"""
     warnings.warn(
-        "The Tornado web application does not have an 'authorizer' defined "
-        "in its settings. In future releases of jupyter_server, this will "
-        "be a required key for all subclasses of `JupyterHandler`. For an "
-        "example, see the jupyter_server source code for how to "
-        "add an authorizer to the tornado settings: "
-        "https://github.com/jupyter-server/jupyter_server/blob/"
-        "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
-        "#L234-L256",
-        FutureWarning,
+        "jupyter_server.auth.utils.warn_disabled_authorization is deprecated",
+        DeprecationWarning,
+        stacklevel=2,
     )
 
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -193,7 +193,23 @@ class AuthenticatedHandler(web.RequestHandler):
 
     @property
     def authorizer(self):
-        return self.settings.get("authorizer")
+        if "authorizer" not in self.settings:
+            warnings.warn(
+                "The Tornado web application does not have an 'authorizer' defined "
+                "in its settings. In future releases of jupyter_server, this will "
+                "be a required key for all subclasses of `JupyterHandler`. For an "
+                "example, see the jupyter_server source code for how to "
+                "add an authorizer to the tornado settings: "
+                "https://github.com/jupyter-server/jupyter_server/blob/"
+                "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
+                "#L234-L256",
+            )
+            from jupyter_server.auth import AllowAllAuthorizer
+
+            self.settings["authorizer"] = AllowAllAuthorizer(
+                config=self.settings.get("config", None)
+            )
+        return self.settings["authorizer"]
 
 
 class JupyterHandler(AuthenticatedHandler):

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -19,8 +19,6 @@ from jupyter_client.session import Session
 from tornado import ioloop, web
 from tornado.websocket import WebSocketHandler
 
-from jupyter_server.auth.utils import warn_disabled_authorization
-
 from .handlers import JupyterHandler
 
 
@@ -321,10 +319,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer:
-            # Warn if there is not authorizer.
-            warn_disabled_authorization()
-        elif not self.authorizer.is_authorized(self, user, "execute", "kernels"):
+        if not self.authorizer.is_authorized(self, user, "execute", "kernels"):
             raise web.HTTPError(403)
 
         if self.get_argument("session_id", False):

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -5,7 +5,6 @@ import terminado
 from tornado import web
 
 from jupyter_server._tz import utcnow
-from jupyter_server.auth.utils import warn_disabled_authorization
 
 from ..base.handlers import JupyterHandler
 from ..base.zmqhandlers import WebSocketMixin
@@ -30,10 +29,7 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer:
-            # Warn if there is not authorizer.
-            warn_disabled_authorization()
-        elif not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
+        if not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
             raise web.HTTPError(403)
 
         if not args[0] in self.term_manager.terminals:


### PR DESCRIPTION
warn once when populating the default, rather than requiring repeated warnings about its absence everywhere the authorizer might be used.

Left the warning as deprecated rather than removed, due to the fact that it's used in the now-forked jupyter_server_terminals

backported from #671