### PR TITLE
move isort, black config to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,12 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: ["--line-length", "100"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
         files: \.py$
-        args: [--profile=black]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,12 @@ factory = "jupyter_packaging.npm_builder"
 [tool.check-manifest]
 ignore = ["tbump.toml", ".*", "*.yml", "package-lock.json", "bootstrap*", "conftest.py"]
 
+[tool.black]
+line_length = 100
+
+[tool.isort]
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = "-raXs --durations 10 --color=yes --doctest-modules"
 testpaths = [


### PR DESCRIPTION
this way, the formatters produce the same output whether run via pre-commit or not