### PR TITLE
Add resource_dir to KernelSpecHandler model

### DIFF
--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -418,12 +418,13 @@ sample_kernel_json = {
     "argv": ["cat", "{connection_file}"],
     "display_name": "Test kernel",
 }
+sample_script = "cat"
 
 
 @pytest.fixture
 def jp_kernelspecs(jp_data_dir):
     """Configures some sample kernelspecs in the Jupyter data directory."""
-    spec_names = ["sample", "sample2", "bad"]
+    spec_names = ["sample", "sample2", "bad", "resource_dir"]
     for name in spec_names:
         sample_kernel_dir = jp_data_dir.joinpath("kernels", name)
         sample_kernel_dir.mkdir(parents=True)
@@ -432,6 +433,11 @@ def jp_kernelspecs(jp_data_dir):
         kernel_json = sample_kernel_json.copy()
         if name == "bad":
             kernel_json["argv"] = ["non_existent_path"]
+        elif name == "resource_dir":
+            sample_script_file = sample_kernel_dir.joinpath("sample.sh")
+            sample_script_file.write_text(sample_script)
+            sample_script_file.chmod(500)
+            kernel_json["argv"] = ["{resource_dir}/sample.sh"]
         sample_kernel_file.write_text(json.dumps(kernel_json))
         # Create resources text
         sample_kernel_resources = sample_kernel_dir.joinpath("resource.txt")

--- a/jupyter_server/services/kernelspecs/handlers.py
+++ b/jupyter_server/services/kernelspecs/handlers.py
@@ -22,7 +22,7 @@ AUTH_RESOURCE = "kernelspecs"
 
 def kernelspec_model(handler, name, spec_dict, resource_dir):
     """Load a KernelSpec by name and return the REST API model"""
-    d = {"name": name, "spec": spec_dict, "resources": {}}
+    d = {"name": name, "spec": spec_dict, "resources": {}, "resource_dir": resource_dir}
 
     # Add resource files if they exist
     resource_dir = resource_dir
@@ -45,6 +45,7 @@ def is_kernelspec_model(spec_dict):
         and "name" in spec_dict
         and "spec" in spec_dict
         and "resources" in spec_dict
+        and "resource_dir" in spec_dict
     )
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -29,7 +29,7 @@ def generate_kernelspec(name):
             "metadata": {},
         }
     }
-    kernelspec_stanza = {"name": name, "spec": spec_stanza, "resources": {}}
+    kernelspec_stanza = {"name": name, "spec": spec_stanza, "resources": {}, "resource_dir": ""}
     return kernelspec_stanza
 
 


### PR DESCRIPTION
For the case where a user has the template "{resource_dir}" in their kernel.json argv, the server api for api/kernelspecs returns the raw kernel.json spec contents (with the template string in place) but does not also include the resource_dir path that could be used to substitute the template string.

The use case for this PR is locating a script co-located with the kernel.json that is used to launch the kernel and has some custom setup that the user needs that is hard to pack into kernel.json argv directly and wants to be able to request remote tasks that utilize the same script.  Using the same launch script would help to make sure that the task environment can be compatible with (libraries/dependencies, etc) the kernel environment.  You can of course use the resource_dir for any resource co-located with the kernel, but in particular, my use case is a launch script.  Using resource_dir instead of an absolute path is less error-prone for users, it makes the kernel files easier to copy for sharing or just replication, and there are other potential benefits.  It's a nice feature, but unfortunately, when you use it, you do run into the problem of not being able to find that kernel easily on disk from the server api.

The change here (which should be straightforward) is to add a key to the KernelSpecHandler model for resource_dir, and then include that as a required key to validate that a dict represents a kernelspec model.  In practice, this would mean that for a "standard" deployment with no subclassing, the KernelSpecManager would return the specs to the KernelSpecHandler, and then each spec dict would be instantiated as a new model that also includes the resource_dir key and value.  Any KernelSpecManager subclass that already included resource_dir with the model dict would not have this model conversion take place.

The test_gateway sample kernelspec was modified slightly to adopt the added key, and I created a sample kernel that has a launch script colocated with the kernel.json and referred to with "{resource_dir}/" in the kernel.json.

If there are any issues with this PR, happy to discuss and or iterate as needed.