### PR TITLE
give authorizer handle on identity provider

### DIFF
--- a/jupyter_server/auth/authorizer.py
+++ b/jupyter_server/auth/authorizer.py
@@ -7,11 +7,12 @@ allows all authenticated requests
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from traitlets import Instance
 from traitlets.config import LoggingConfigurable
 
 from jupyter_server.base.handlers import JupyterHandler
 
-from .identity import User
+from .identity import IdentityProvider, User
 
 
 class Authorizer(LoggingConfigurable):
@@ -33,6 +34,8 @@ class Authorizer(LoggingConfigurable):
 
     .. versionadded:: 2.0
     """
+
+    identity_provider = Instance(IdentityProvider)
 
     def is_authorized(
         self, handler: JupyterHandler, user: User, action: str, resource: str

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -220,7 +220,8 @@ class AuthenticatedHandler(web.RequestHandler):
             from jupyter_server.auth import AllowAllAuthorizer
 
             self.settings["authorizer"] = AllowAllAuthorizer(
-                config=self.settings.get("config", None)
+                config=self.settings.get("config", None),
+                identity_provider=self.identity_provider,
             )
 
         return self.settings.get("authorizer")

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -217,15 +217,6 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
     ):
-        if authorizer is None:
-            warnings.warn(
-                "authorizer unspecified. Using permissive AllowAllAuthorizer."
-                " Specify an authorizer to avoid this message.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            authorizer = AllowAllAuthorizer(parent=jupyter_app)
-
         if identity_provider is None:
             warnings.warn(
                 "identity_provider unspecified. Using default IdentityProvider."
@@ -234,6 +225,15 @@ class ServerWebApplication(web.Application):
                 stacklevel=2,
             )
             identity_provider = IdentityProvider(parent=jupyter_app)
+
+        if authorizer is None:
+            warnings.warn(
+                "authorizer unspecified. Using permissive AllowAllAuthorizer."
+                " Specify an authorizer to avoid this message.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            authorizer = AllowAllAuthorizer(parent=jupyter_app, identity_provider=identity_provider)
 
         settings = self.init_settings(
             jupyter_app,
@@ -1861,8 +1861,10 @@ class ServerApp(JupyterApp):
             parent=self,
             log=self.log,
         )
-        self.authorizer = self.authorizer_class(parent=self, log=self.log)
         self.identity_provider = self.identity_provider_class(parent=self, log=self.log)
+        self.authorizer = self.authorizer_class(
+            parent=self, log=self.log, identity_provider=self.identity_provider
+        )
 
     def init_logging(self):
         # This prevents double log messages because tornado use a root logger that


### PR DESCRIPTION
In many cases of custom implementations, these two will have some coupling. So it makes sense for the Authorizer to have access to the identity provider for shared info.

e.g. the HubAuth object, when working with JupyterHub.