### PR TITLE
Do not use pre-releases for build dependencies

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -111,7 +111,8 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-          pip install --pre -e ".[test]"
+          pip install --no-deps -e .
+          pip install --pre --upgrade "jupyter_server[test]"
       - name: List installed packages
         run: |
           pip freeze


### PR DESCRIPTION
Workaround for https://github.com/pypa/pip/issues/10222