### PR TITLE
Use hatch backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["hatchling >=0.25"]
+build-backend = "hatchling.build"
 
 [project]
 name = "jupyter_server"
@@ -96,9 +96,6 @@ filterwarnings = [
   "ignore:unclosed event loop:ResourceWarning",
   "ignore:run_pre_save_hook is deprecated:DeprecationWarning"
 ]
-
-[tool.flit.sdist]
-include = ["tests/"]
 
 [tool.jupyter-releaser]
 skip = ["check-links"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ test = [
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
 
+[tool.hatch.build]
+artifacts = ["jupyter_server/static/style/*.*"]
+
 [tool.black]
 line_length = 100
 


### PR DESCRIPTION
Simplified version of #845 until we decided whether to adopt `hatch_jupyter_builder`, to get editable mode working again.  cf https://github.com/pypa/pip/issues/11110