### PR TITLE
Added a debug file, vscode config  to aid debugging in IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/source/other/changelog.md
 .history
 .vscode/*
 !.vscode/*.template
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jupyter Server",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceRoot}/jupyter_server/debug.py"
+    }
+  ]
+}

--- a/jupyter_server/debug.py
+++ b/jupyter_server/debug.py
@@ -1,0 +1,7 @@
+"""Launches Juptyer Server. Use this file for debugging in an IDE."""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+from serverapp import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added a debug file to allow server debugging by adding breakpoints directly within an IDE. Also, added a launch configuration for vscode that allows using the debugger interface within the IDE.

### Notes
I wasn't able to extend this idea to debug the server code within a jupyterlab session. For example, this code did not engage the vscode debugger.
```python
from jupyterlab.labapp import main

if __name__ == "__main__":
    main()
``` 