### PR TITLE
[Bug] Change test domain from `*.jupyter.com/*` to `*.jupyter.org/*`

### DIFF
--- a/tests/services/events/mock_event.yaml
+++ b/tests/services/events/mock_event.yaml
@@ -1,4 +1,4 @@
-$id: event.mock.jupyter.com/message
+$id: event.mock.jupyter.org/message
 version: 1
 title: Message
 description: |

--- a/tests/services/events/mockextension/mock_extension.py
+++ b/tests/services/events/mockextension/mock_extension.py
@@ -8,7 +8,7 @@ class MockEventHandler(JupyterHandler):
     def get(self):
         # Emit an event.
         self.event_bus.record_event(
-            schema_name="event.mockextension.jupyter.com/message",
+            schema_name="event.mockextension.jupyter.org/message",
             version=1,
             event={"event_message": "Hello world, from mock extension!"},
         )

--- a/tests/services/events/mockextension/mock_extension_event.yaml
+++ b/tests/services/events/mockextension/mock_extension_event.yaml
@@ -1,4 +1,4 @@
-$id: event.mockextension.jupyter.com/message
+$id: event.mockextension.jupyter.org/message
 version: 1
 title: Message
 description: |

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -11,7 +11,7 @@ def event_bus(jp_serverapp):
     schema_file = pathlib.Path(__file__).parent / "mock_event.yaml"
     event_bus.register_schema_file(schema_file)
     #
-    event_bus.allowed_schemas = ["event.mock.jupyter.com/message"]
+    event_bus.allowed_schemas = ["event.mock.jupyter.org/message"]
     return event_bus
 
 
@@ -20,7 +20,7 @@ async def test_subscribe_websocket(jp_ws_fetch, event_bus):
     ws = await jp_ws_fetch("/api/events/subscribe")
 
     event_bus.record_event(
-        schema_name="event.mock.jupyter.com/message",
+        schema_name="event.mock.jupyter.org/message",
         version=1,
         event={"event_message": "Hello, world!"},
     )

--- a/tests/services/events/test_extension.py
+++ b/tests/services/events/test_extension.py
@@ -9,7 +9,7 @@ def jp_server_config():
         "ServerApp": {
             "jpserver_extensions": {"tests.services.events.mockextension": True},
         },
-        "EventBus": {"allowed_schemas": ["event.mockextension.jupyter.com/message"]},
+        "EventBus": {"allowed_schemas": ["event.mockextension.jupyter.org/message"]},
     }
     return config
 


### PR DESCRIPTION
Closes #852 
Chose to go with `jupyter.org` over `example.com` because `event.mock.jupyter.org/message` felt like it makes more sense.
Let me know if you guys think otherwise and I'll be happy to change. 