### PR TITLE
Adds anonymous users

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -292,19 +292,28 @@ class IdentityProvider(LoggingConfigurable):
         Default is just the user's username.
         """
         # default: username is enough
-        cookie = json.dumps({
-            'username': user.username,
-            'name': user.name,
-            'display_name': user.display_name,
-            'initials': user.initials,
-            'color': user.color
-        })
+        cookie = json.dumps(
+            {
+                "username": user.username,
+                "name": user.name,
+                "display_name": user.display_name,
+                "initials": user.initials,
+                "color": user.color,
+            }
+        )
         return cookie
 
     def user_from_cookie(self, cookie_value: str) -> User | None:
         """Inverse of user_to_cookie"""
         user = json.loads(cookie_value)
-        return User(user['username'], user['name'], user['display_name'], user['initials'], None, user['color'])
+        return User(
+            user["username"],
+            user["name"],
+            user["display_name"],
+            user["initials"],
+            None,
+            user["color"],
+        )
 
     def get_cookie_name(self, handler: JupyterHandler) -> str:
         """Return the login cookie name
@@ -457,8 +466,8 @@ class IdentityProvider(LoggingConfigurable):
         """
         user_id = uuid.uuid4().hex
         moon = get_anonymous_username()
-        name = display_name = "Anonymous {}".format(moon)
-        initials = "A{}".format(moon[0])
+        name = display_name = f"Anonymous {moon}"
+        initials = f"A{moon[0]}"
         color = get_random_color()
         handler.log.info(f"Generating new user for token-authenticated request: {user_id}")
         return User(user_id, name, display_name, initials, None, color)

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -25,7 +25,7 @@ from traitlets.config import LoggingConfigurable
 from jupyter_server.transutils import _i18n
 
 from .security import passwd_check, set_password
-from .utils import get_anonymous_username, get_random_color
+from .utils import get_anonymous_username
 
 # circular imports for type checking
 if TYPE_CHECKING:
@@ -468,7 +468,7 @@ class IdentityProvider(LoggingConfigurable):
         moon = get_anonymous_username()
         name = display_name = f"Anonymous {moon}"
         initials = f"A{moon[0]}"
-        color = get_random_color()
+        color = None
         handler.log.info(f"Generating new user for token-authenticated request: {user_id}")
         return User(user_id, name, display_name, initials, None, color)
 

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import binascii
 import datetime
+import json
 import os
 import re
 import sys
@@ -24,6 +25,7 @@ from traitlets.config import LoggingConfigurable
 from jupyter_server.transutils import _i18n
 
 from .security import passwd_check, set_password
+from .utils import get_anonymous_username, get_random_color
 
 # circular imports for type checking
 if TYPE_CHECKING:
@@ -290,11 +292,19 @@ class IdentityProvider(LoggingConfigurable):
         Default is just the user's username.
         """
         # default: username is enough
-        return user.username
+        cookie = json.dumps({
+            'username': user.username,
+            'name': user.name,
+            'display_name': user.display_name,
+            'initials': user.initials,
+            'color': user.color
+        })
+        return cookie
 
     def user_from_cookie(self, cookie_value: str) -> User | None:
         """Inverse of user_to_cookie"""
-        return User(username=cookie_value)
+        user = json.loads(cookie_value)
+        return User(user['username'], user['name'], user['display_name'], user['initials'], None, user['color'])
 
     def get_cookie_name(self, handler: JupyterHandler) -> str:
         """Return the login cookie name
@@ -396,7 +406,6 @@ class IdentityProvider(LoggingConfigurable):
         - in URL parameters: ?token=<token>
         - in header: Authorization: token <token>
         """
-
         user_token = handler.get_argument("token", "")
         if not user_token:
             # get it from Authorization header
@@ -447,8 +456,12 @@ class IdentityProvider(LoggingConfigurable):
         but does not identify a user.
         """
         user_id = uuid.uuid4().hex
+        moon = get_anonymous_username()
+        name = display_name = "Anonymous {}".format(moon)
+        initials = "A{}".format(moon[0])
+        color = get_random_color()
         handler.log.info(f"Generating new user for token-authenticated request: {user_id}")
-        return User(user_id)
+        return User(user_id, name, display_name, initials, None, color)
 
     def should_check_origin(self, handler: JupyterHandler) -> bool:
         """Should the Handler check for CORS origin validation?

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -167,20 +167,3 @@ def get_anonymous_username() -> str:
     This function returns names like "Anonymous Io" or "Anonymous Metis".
     """
     return moons_of_jupyter[random.randint(0, len(moons_of_jupyter) - 1)]
-
-
-# Using JupyterLab CSS variable because the colors may change with the theme
-user_colors = [
-    "var(--jp-collaborator-color1)",
-    "var(--jp-collaborator-color2)",
-    "var(--jp-collaborator-color3)",
-    "var(--jp-collaborator-color4)",
-    "var(--jp-collaborator-color5)",
-    "var(--jp-collaborator-color6)",
-    "var(--jp-collaborator-color7)",
-]
-
-
-def get_random_color() -> str:
-    """Get a random color from the list of colors."""
-    return user_colors[random.randint(0, len(user_colors) - 1)]

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -3,9 +3,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import importlib
-import re
 import math
 import random
+import re
 import warnings
 
 
@@ -77,107 +77,111 @@ def match_url_to_resource(url, regex_mapping=None):
         if pattern.fullmatch(url):
             return auth_resource
 
+
 # From https://en.wikipedia.org/wiki/Moons_of_Jupiter
 moons_of_jupyter = [
-    'Metis',
-    'Adrastea',
-    'Amalthea',
-    'Thebe',
-    'Io',
-    'Europa',
-    'Ganymede',
-    'Callisto',
-    'Themisto',
-    'Leda',
-    'Ersa',
-    'Pandia',
-    'Himalia',
-    'Lysithea',
-    'Elara',
-    'Dia',
-    'Carpo',
-    'Valetudo',
-    'Euporie',
-    'Eupheme',
+    "Metis",
+    "Adrastea",
+    "Amalthea",
+    "Thebe",
+    "Io",
+    "Europa",
+    "Ganymede",
+    "Callisto",
+    "Themisto",
+    "Leda",
+    "Ersa",
+    "Pandia",
+    "Himalia",
+    "Lysithea",
+    "Elara",
+    "Dia",
+    "Carpo",
+    "Valetudo",
+    "Euporie",
+    "Eupheme",
     # 'S/2003 J 18',
     # 'S/2010 J 2',
-    'Helike',
+    "Helike",
     # 'S/2003 J 16',
     # 'S/2003 J 2',
-    'Euanthe',
+    "Euanthe",
     # 'S/2017 J 7',
-    'Hermippe',
-    'Praxidike',
-    'Thyone',
-    'Thelxinoe',
+    "Hermippe",
+    "Praxidike",
+    "Thyone",
+    "Thelxinoe",
     # 'S/2017 J 3',
-    'Ananke',
-    'Mneme',
+    "Ananke",
+    "Mneme",
     # 'S/2016 J 1',
-    'Orthosie',
-    'Harpalyke',
-    'Iocaste',
+    "Orthosie",
+    "Harpalyke",
+    "Iocaste",
     # 'S/2017 J 9',
     # 'S/2003 J 12',
     # 'S/2003 J 4',
-    'Erinome',
-    'Aitne',
-    'Herse',
-    'Taygete',
+    "Erinome",
+    "Aitne",
+    "Herse",
+    "Taygete",
     # 'S/2017 J 2',
     # 'S/2017 J 6',
-    'Eukelade',
-    'Carme',
+    "Eukelade",
+    "Carme",
     # 'S/2003 J 19',
-    'Isonoe',
+    "Isonoe",
     # 'S/2003 J 10',
-    'Autonoe',
-    'Philophrosyne',
-    'Cyllene',
-    'Pasithee',
+    "Autonoe",
+    "Philophrosyne",
+    "Cyllene",
+    "Pasithee",
     # 'S/2010 J 1',
-    'Pasiphae',
-    'Sponde',
+    "Pasiphae",
+    "Sponde",
     # 'S/2017 J 8',
-    'Eurydome',
+    "Eurydome",
     # 'S/2017 J 5',
-    'Kalyke',
-    'Hegemone',
-    'Kale',
-    'Kallichore',
+    "Kalyke",
+    "Hegemone",
+    "Kale",
+    "Kallichore",
     # 'S/2011 J 1',
     # 'S/2017 J 1',
-    'Chaldene',
-    'Arche',
-    'Eirene',
-    'Kore',
+    "Chaldene",
+    "Arche",
+    "Eirene",
+    "Kore",
     # 'S/2011 J 2',
     # 'S/2003 J 9',
-    'Megaclite',
-    'Aoede',
+    "Megaclite",
+    "Aoede",
     # 'S/2003 J 23',
-    'Callirrhoe',
-    'Sinope'
+    "Callirrhoe",
+    "Sinope",
 ]
+
 
 def get_anonymous_username() -> str:
     """
     Get a random user-name based on the moons of Jupyter.
     This function returns names like "Anonymous Io" or "Anonymous Metis".
     """
-    return moons_of_jupyter[random.randint(0, len(moons_of_jupyter)-1)]
+    return moons_of_jupyter[random.randint(0, len(moons_of_jupyter) - 1)]
+
 
 # Using JupyterLab CSS variable because the colors may change with the theme
 user_colors = [
-    'var(--jp-collaborator-color1)',
-    'var(--jp-collaborator-color2)',
-    'var(--jp-collaborator-color3)',
-    'var(--jp-collaborator-color4)',
-    'var(--jp-collaborator-color5)',
-    'var(--jp-collaborator-color6)',
-    'var(--jp-collaborator-color7)'
+    "var(--jp-collaborator-color1)",
+    "var(--jp-collaborator-color2)",
+    "var(--jp-collaborator-color3)",
+    "var(--jp-collaborator-color4)",
+    "var(--jp-collaborator-color5)",
+    "var(--jp-collaborator-color6)",
+    "var(--jp-collaborator-color7)",
 ]
 
+
 def get_random_color() -> str:
-    """ Get a random color from the list of colors. """
-    return user_colors[random.randint(0, len(user_colors)-1)];
+    """Get a random color from the list of colors."""
+    return user_colors[random.randint(0, len(user_colors) - 1)]

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import importlib
-import math
 import random
 import re
 import warnings

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -4,6 +4,8 @@
 # Distributed under the terms of the Modified BSD License.
 import importlib
 import re
+import math
+import random
 import warnings
 
 
@@ -74,3 +76,108 @@ def match_url_to_resource(url, regex_mapping=None):
         pattern = re.compile(regex)
         if pattern.fullmatch(url):
             return auth_resource
+
+# From https://en.wikipedia.org/wiki/Moons_of_Jupiter
+moons_of_jupyter = [
+    'Metis',
+    'Adrastea',
+    'Amalthea',
+    'Thebe',
+    'Io',
+    'Europa',
+    'Ganymede',
+    'Callisto',
+    'Themisto',
+    'Leda',
+    'Ersa',
+    'Pandia',
+    'Himalia',
+    'Lysithea',
+    'Elara',
+    'Dia',
+    'Carpo',
+    'Valetudo',
+    'Euporie',
+    'Eupheme',
+    # 'S/2003 J 18',
+    # 'S/2010 J 2',
+    'Helike',
+    # 'S/2003 J 16',
+    # 'S/2003 J 2',
+    'Euanthe',
+    # 'S/2017 J 7',
+    'Hermippe',
+    'Praxidike',
+    'Thyone',
+    'Thelxinoe',
+    # 'S/2017 J 3',
+    'Ananke',
+    'Mneme',
+    # 'S/2016 J 1',
+    'Orthosie',
+    'Harpalyke',
+    'Iocaste',
+    # 'S/2017 J 9',
+    # 'S/2003 J 12',
+    # 'S/2003 J 4',
+    'Erinome',
+    'Aitne',
+    'Herse',
+    'Taygete',
+    # 'S/2017 J 2',
+    # 'S/2017 J 6',
+    'Eukelade',
+    'Carme',
+    # 'S/2003 J 19',
+    'Isonoe',
+    # 'S/2003 J 10',
+    'Autonoe',
+    'Philophrosyne',
+    'Cyllene',
+    'Pasithee',
+    # 'S/2010 J 1',
+    'Pasiphae',
+    'Sponde',
+    # 'S/2017 J 8',
+    'Eurydome',
+    # 'S/2017 J 5',
+    'Kalyke',
+    'Hegemone',
+    'Kale',
+    'Kallichore',
+    # 'S/2011 J 1',
+    # 'S/2017 J 1',
+    'Chaldene',
+    'Arche',
+    'Eirene',
+    'Kore',
+    # 'S/2011 J 2',
+    # 'S/2003 J 9',
+    'Megaclite',
+    'Aoede',
+    # 'S/2003 J 23',
+    'Callirrhoe',
+    'Sinope'
+]
+
+def get_anonymous_username() -> str:
+    """
+    Get a random user-name based on the moons of Jupyter.
+    This function returns names like "Anonymous Io" or "Anonymous Metis".
+    """
+    return moons_of_jupyter[random.randint(0, len(moons_of_jupyter)-1)]
+
+# Using JupyterLab CSS variable because the colors may change with the theme
+user_colors = [
+    'var(--jp-collaborator-color1)',
+    'var(--jp-collaborator-color2)',
+    'var(--jp-collaborator-color3)',
+    'var(--jp-collaborator-color4)',
+    'var(--jp-collaborator-color5)',
+    'var(--jp-collaborator-color6)',
+    'var(--jp-collaborator-color7)'
+]
+
+def get_random_color() -> str:
+    """ Get a random color from the list of colors. """
+    return user_colors[random.randint(0, len(user_colors)-1)];


### PR DESCRIPTION
I created the PR starting from #825.

Adds the anonymous users logic used in JupyterLab. It stores the user info in the cookie to persist between sessions as was done with the user id.