### PR TITLE
Normalize os_path

### DIFF
--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -111,7 +111,7 @@ def to_os_path(path, root=""):
     parts = path.strip("/").split("/")
     parts = [p for p in parts if p != ""]  # remove duplicate splits
     path = os.path.join(root, *parts)
-    return path
+    return os.path.normpath(path)
 
 
 def to_api_path(os_path, root=""):


### PR DESCRIPTION
This fixes an issue causing access to local files in Voila considered forbidden:

Accessing a file `./jupyter.svg` in Voila (`jupyter.svg` being under the root_dir) results in a:
```
  File "/home/martin/micromamba/envs/voila/lib/python3.10/site-packages/mistune.py", line 661, in _process_link
    return self.renderer.image(link, title, text)
  File "/home/martin/github/voila/voila/exporter.py", line 34, in image
    content = contents_manager.get(src, format='base64')
  File "/home/martin/micromamba/envs/voila/lib/python3.10/site-packages/jupyter_server/services/contents/filemanager.py", line 386, in get
    raise web.HTTPError(404, four_o_four)
tornado.web.HTTPError: HTTP 404: Not Found (file or directory does not exist: './jupyter.svg')
```

This was because the root_dir was set to `/home/martin/github/voila/tests/notebooks` and the path `/home/martin/github/voila/tests/notebooks/./jupyter.svg` was considered "hidden" by jupyter_server, while it's not. Normalizing the path fixes it.