### PR TITLE
NBectomy

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -62,7 +62,6 @@ from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.session import Session
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.paths import jupyter_runtime_dir
-from nbformat.sign import NotebookNotary
 from traitlets import (
     Any,
     Bool,
@@ -769,7 +768,6 @@ class ServerApp(JupyterApp):
         FileContentsManager,
         AsyncContentsManager,
         AsyncFileContentsManager,
-        NotebookNotary,
         GatewayMappingKernelManager,
         GatewayKernelSpecManager,
         GatewaySessionManager,

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -289,6 +289,7 @@ class FileManagerMixin(Configurable):
 
     def _save_file(self, os_path, content, format):
         """Save content of a generic file."""
+        format = format or "text"
         if format not in {"json", "text", "base64"}:
             raise HTTPError(
                 400,
@@ -352,6 +353,7 @@ class AsyncFileManagerMixin(FileManagerMixin):
 
     async def _save_file(self, os_path, content, format):
         """Save content of a generic file."""
+        format = format or "text"
         if format not in {"json", "text", "base64"}:
             raise HTTPError(
                 400,

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -4,13 +4,12 @@ Utilities for file-based Contents/Checkpoints managers.
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import errno
+import json
 import os
 import shutil
 from base64 import decodebytes, encodebytes
 from contextlib import contextmanager
-from functools import partial
 
-import nbformat
 from anyio.to_thread import run_sync
 from tornado.web import HTTPError
 from traitlets import Bool
@@ -259,47 +258,8 @@ class FileManagerMixin(Configurable):
             raise HTTPError(404, "%s is outside root contents directory" % path)
         return os_path
 
-    def _read_notebook(self, os_path, as_version=4, capture_validation_error=None):
-        """Read a notebook from an os path."""
-        with self.open(os_path, "r", encoding="utf-8") as f:
-            try:
-                return nbformat.read(
-                    f, as_version=as_version, capture_validation_error=capture_validation_error
-                )
-            except Exception as e:
-                e_orig = e
-
-            # If use_atomic_writing is enabled, we'll guess that it was also
-            # enabled when this notebook was written and look for a valid
-            # atomic intermediate.
-            tmp_path = path_to_intermediate(os_path)
-
-            if not self.use_atomic_writing or not os.path.exists(tmp_path):
-                raise HTTPError(
-                    400,
-                    f"Unreadable Notebook: {os_path} {e_orig!r}",
-                )
-
-            # Move the bad file aside, restore the intermediate, and try again.
-            invalid_file = path_to_invalid(os_path)
-            replace_file(os_path, invalid_file)
-            replace_file(tmp_path, os_path)
-            return self._read_notebook(
-                os_path, as_version, capture_validation_error=capture_validation_error
-            )
-
-    def _save_notebook(self, os_path, nb, capture_validation_error=None):
-        """Save a notebook to an os_path."""
-        with self.atomic_writing(os_path, encoding="utf-8") as f:
-            nbformat.write(
-                nb,
-                f,
-                version=nbformat.NO_CONVERT,
-                capture_validation_error=capture_validation_error,
-            )
-
     def _read_file(self, os_path, format):
-        """Read a non-notebook file.
+        """Read a file.
 
         os_path: The path to be read.
         format:
@@ -329,13 +289,15 @@ class FileManagerMixin(Configurable):
 
     def _save_file(self, os_path, content, format):
         """Save content of a generic file."""
-        if format not in {"text", "base64"}:
+        if format not in {"json", "text", "base64"}:
             raise HTTPError(
                 400,
-                "Must specify format of file contents as 'text' or 'base64'",
+                "Must specify format of file contents as 'json', 'text' or 'base64'",
             )
         try:
-            if format == "text":
+            if format == "json":
+                bcontent = json.dumps(content).encode("utf8")
+            elif format == "text":
                 bcontent = content.encode("utf8")
             else:
                 b64_bytes = content.encode("ascii")
@@ -359,55 +321,8 @@ class AsyncFileManagerMixin(FileManagerMixin):
         """
         await async_copy2_safe(src, dest, log=self.log)
 
-    async def _read_notebook(self, os_path, as_version=4, capture_validation_error=None):
-        """Read a notebook from an os path."""
-        with self.open(os_path, "r", encoding="utf-8") as f:
-            try:
-                return await run_sync(
-                    partial(
-                        nbformat.read,
-                        as_version=as_version,
-                        capture_validation_error=capture_validation_error,
-                    ),
-                    f,
-                )
-            except Exception as e:
-                e_orig = e
-
-            # If use_atomic_writing is enabled, we'll guess that it was also
-            # enabled when this notebook was written and look for a valid
-            # atomic intermediate.
-            tmp_path = path_to_intermediate(os_path)
-
-            if not self.use_atomic_writing or not os.path.exists(tmp_path):
-                raise HTTPError(
-                    400,
-                    f"Unreadable Notebook: {os_path} {e_orig!r}",
-                )
-
-            # Move the bad file aside, restore the intermediate, and try again.
-            invalid_file = path_to_invalid(os_path)
-            await async_replace_file(os_path, invalid_file)
-            await async_replace_file(tmp_path, os_path)
-            return await self._read_notebook(
-                os_path, as_version, capture_validation_error=capture_validation_error
-            )
-
-    async def _save_notebook(self, os_path, nb, capture_validation_error=None):
-        """Save a notebook to an os_path."""
-        with self.atomic_writing(os_path, encoding="utf-8") as f:
-            await run_sync(
-                partial(
-                    nbformat.write,
-                    version=nbformat.NO_CONVERT,
-                    capture_validation_error=capture_validation_error,
-                ),
-                nb,
-                f,
-            )
-
     async def _read_file(self, os_path, format):
-        """Read a non-notebook file.
+        """Read a file.
 
         os_path: The path to be read.
         format:
@@ -437,13 +352,15 @@ class AsyncFileManagerMixin(FileManagerMixin):
 
     async def _save_file(self, os_path, content, format):
         """Save content of a generic file."""
-        if format not in {"text", "base64"}:
+        if format not in {"json", "text", "base64"}:
             raise HTTPError(
                 400,
-                "Must specify format of file contents as 'text' or 'base64'",
+                "Must specify format of file contents as 'json', 'text' or 'base64'",
             )
         try:
-            if format == "text":
+            if format == "json":
+                bcontent = json.dumps(content).encode("utf8")
+            elif format == "text":
                 bcontent = content.encode("utf8")
             else:
                 b64_bytes = content.encode("ascii")

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -98,7 +98,9 @@ class ContentsHandler(ContentsAPIHandler):
         cm = self.contents_manager
 
         type = self.get_query_argument("type", default=None)
-        if type not in {None, "directory", "file", "notebook"}:
+        if type == "notebook":
+            type = "file"
+        if type not in {None, "directory", "file"}:
             raise web.HTTPError(400, "Type %r is invalid" % type)
 
         format = self.get_query_argument("format", default=None)

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -525,10 +525,7 @@ class ContentsManager(LoggingConfigurable):
         if model is None:
             model = {}
 
-        if path.endswith(".ipynb"):
-            model.setdefault("type", "notebook")
-        else:
-            model.setdefault("type", "file")
+        model.setdefault("type", "file")
 
         # no content, not a directory, so fill out new-file model
         if "content" not in model and model["type"] != "directory":


### PR DESCRIPTION
Jupyter Server should not special-case notebook documents. There should only be two models, as far as the contents API is concerned: directories and files. A notebook is a file.