### PR TITLE
Make ChannelQueue.get_msg true async

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import os
 from logging import Logger
-from queue import Queue, Empty
+from queue import Empty, Queue
 from threading import Thread
 from typing import Any, Dict, Optional
 

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -517,7 +517,7 @@ class ChannelQueue(Queue):
                 return self.get(block=False)
             except Empty:
                 if monotonic() > end_time:
-                    raise Empty
+                    raise
                 await asyncio.sleep(0)
 
     async def get_msg(self, *args: Any, **kwargs: Any) -> dict:

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -7,8 +7,8 @@ import os
 from logging import Logger
 from queue import Empty, Queue
 from threading import Thread
-from typing import Any, Dict, Optional
 from time import monotonic
+from typing import Any, Dict, Optional
 
 import websocket
 from jupyter_client.asynchronous.client import AsyncKernelClient

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -1,10 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import asyncio
 import datetime
 import json
 import os
 from logging import Logger
-from queue import Queue
+from queue import Queue, Empty
 from threading import Thread
 from typing import Any, Dict, Optional
 
@@ -503,9 +504,22 @@ class ChannelQueue(Queue):
         self.channel_socket = channel_socket
         self.log = log
 
+    async def _async_get(self):
+        while True:
+            try:
+                return self.get(block=False)
+            except Empty:
+                await asyncio.sleep(0)
+
+    async def _async_get_with_timeout(self, timeout=None):
+        try:
+            return await asyncio.wait_for(self._async_get(), timeout)
+        except asyncio.TimeoutError:
+            raise Empty
+
     async def get_msg(self, *args: Any, **kwargs: Any) -> dict:
         timeout = kwargs.get("timeout", 1)
-        msg = self.get(timeout=timeout)
+        msg = await self._async_get_with_timeout(timeout=timeout)
         self.log.debug(
             "Received message on channel: {}, msg_id: {}, msg_type: {}".format(
                 self.channel_name, msg["msg_id"], msg["msg_type"] if msg else "null"


### PR DESCRIPTION
ChannelQueue.get_msg is marked as async, however it's a blocking call.

Looking at https://github.com/jupyter/nbclient/blob/main/nbclient/client.py#L806, there is a call to `get_msg` which may block infinite. Now that code is fine, because the coroutine is being run as a background task and timeout being handled with asyncio.

However, thinking about a little bit, get_msg will block the entire thread, not giving a chance to other tasks to run.

We can easily make this method true async. I also considered asyncio.Queue, but that is not thread safe and we need it for recv_thread.