### PR TITLE
Allow new file types

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -99,7 +99,8 @@ class ContentsHandler(ContentsAPIHandler):
 
         type = self.get_query_argument("type", default=None)
         if type not in {None, "directory", "file", "notebook"}:
-            raise web.HTTPError(400, "Type %r is invalid" % type)
+            # fall back to file if unknown type
+            type = "file"
 
         format = self.get_query_argument("format", default=None)
         if format not in {None, "text", "base64"}:
@@ -222,6 +223,9 @@ class ContentsHandler(ContentsAPIHandler):
             copy_from = model.get("copy_from")
             ext = model.get("ext", "")
             type = model.get("type", "")
+            if type not in {None, "", "directory", "file", "notebook"}:
+                # fall back to file if unknown type
+                type = "file"
             if copy_from:
                 await self._copy(copy_from, path)
             else:


### PR DESCRIPTION
In #884 we talked about the possibility to register new file types. It could be needed in the future, and maybe a `notebook` file type should be such a registered type (through a jupyter-server extension).
But for now an easier path would be to not throw an error when we get an unknown file type, and treat it as a generic `file`.

Closes https://github.com/jupyterlab/jupyterlab/pull/12719.