### PR TITLE
Notify ChannelQueue that the response router thread is finishing

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -602,7 +602,7 @@ class GatewayKernelClient(AsyncKernelClient):
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin = False
     _channels_stopped: bool
-    _channel_queues: Optional[dict[str, ChannelQueue]]
+    _channel_queues: Optional[dict[str, Type[ChannelQueue]]]
     _control_channel: Optional[ChannelQueue]
     _hb_channel: Optional[ChannelQueue]
     _stdin_channel: Optional[ChannelQueue]

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -609,9 +609,9 @@ class GatewayKernelClient(AsyncKernelClient):
     _iopub_channel: Optional[ChannelQueue]
     _shell_channel: Optional[ChannelQueue]
 
-    def __init__(self, **kwargs):
+    def __init__(self, kernel_id, **kwargs):
         super().__init__(**kwargs)
-        self.kernel_id = kwargs["kernel_id"]
+        self.kernel_id = kernel_id
         self.channel_socket: Optional[websocket.WebSocket] = None
         self.response_router: Optional[Thread] = None
         self._channels_stopped = False

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -602,7 +602,7 @@ class GatewayKernelClient(AsyncKernelClient):
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin = False
     _channels_stopped: bool
-    _channel_queues: Optional[dict[str, Type[ChannelQueue]]]
+    _channel_queues: Optional[Dict[str, ChannelQueue]]
     _control_channel: Optional[ChannelQueue]
     _hb_channel: Optional[ChannelQueue]
     _stdin_channel: Optional[ChannelQueue]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -335,7 +335,7 @@ async def test_gateway_shutdown(init_gateway, jp_serverapp, jp_fetch, missing_ke
 
 
 @patch("websocket.create_connection", mock_websocket_create_connection(recv_side_effect=Exception))
-async def test_kernel_client_response_router_notifies_when_finished(
+async def test_kernel_client_response_router_notifies_channel_queue_when_finished(
     init_gateway, jp_serverapp, jp_fetch
 ):
     # create

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -352,6 +352,14 @@ async def test_channel_queue_get_msg_with_existing_item():
     assert received_message == sent_message
 
 
+async def test_channel_queue_get_msg_when_response_router_had_finished():
+    queue = ChannelQueue("iopub", MagicMock(), logging.getLogger())
+    queue.response_router_finished = True
+
+    with pytest.raises(RuntimeError):
+        await queue.get_msg()
+
+
 #
 # Test methods below...
 #

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -170,10 +170,8 @@ mock_http_user = "alice"
 
 def mock_websocket_create_connection(recv_side_effect=None):
     def helper(*args, **kwargs):
-        mock_class = MagicMock()
-        mock = mock_class.return_value
+        mock = MagicMock()
         mock.recv = MagicMock(side_effect=recv_side_effect)
-        mock.close = MagicMock()
         return mock
 
     return helper


### PR DESCRIPTION
In case the `response_router` encounters an error, the thread will exit and there is no code to check if it's still alive. This would mean waiting for messages that never arrives.

Added a simple flag based notification mechanism where the route_responses will notify channels that the thread is exiting.

Also because the route_responses thread depends on channels to be created, it is important to make sure we don't start this thread before starting channels.