### PR TITLE
default to system node version in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0


### PR DESCRIPTION
Fixes #905. Basically just prefer Node version available in system path instead of installing the latest stable version of Node upstream. Fixes pre-commit for some systems like AL2.