### PR TITLE
Add back support for kernel launch timeout pad

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -128,7 +128,7 @@ class GatewayClient(SingletonConfigurable):
             os.environ.get("JUPYTER_GATEWAY_CONNECT_TIMEOUT", self.connect_timeout_default_value)
         )
 
-    request_timeout_default_value = 40.0
+    request_timeout_default_value = 42.0
     request_timeout_env = "JUPYTER_GATEWAY_REQUEST_TIMEOUT"
     request_timeout = Float(
         default_value=request_timeout_default_value,
@@ -341,22 +341,22 @@ class GatewayClient(SingletonConfigurable):
             os.environ.get("JUPYTER_GATEWAY_RETRY_MAX", self.gateway_retry_max_default_value)
         )
 
-    kernel_launch_timeout_pad_default_value = 0
-    kernel_launch_timeout_pad_env = "JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD"
-    kernel_launch_timeout_pad = Int(
-        default_value=kernel_launch_timeout_pad_default_value,
+    launch_timeout_pad_default_value = 2
+    launch_timeout_pad_env = "JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD"
+    launch_timeout_pad = Int(
+        default_value=launch_timeout_pad_default_value,
         config=True,
         help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout
         such that request_timeout >= KERNEL_LAUNCH_TIMEOUT + timeout_pad.
-        (JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD env var)""",
+        (JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD env var)""",
     )
 
-    @default("kernel_launch_timeout_pad")
-    def kernel_launch_timeout_pad_default(self):
+    @default("launch_timeout_pad")
+    def launch_timeout_pad_default(self):
         return int(
             os.environ.get(
-                "JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD",
-                self.kernel_launch_timeout_pad_default_value,
+                "JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD",
+                self.launch_timeout_pad_default_value,
             )
         )
 
@@ -376,13 +376,13 @@ class GatewayClient(SingletonConfigurable):
         #  greater value of the two and taking into account the following relation:
         #  request_timeout = KERNEL_LAUNCH_TIME + padding
         minimum_request_timeout = (
-            float(GatewayClient.KERNEL_LAUNCH_TIMEOUT) + self.kernel_launch_timeout_pad
+            float(GatewayClient.KERNEL_LAUNCH_TIMEOUT) + self.launch_timeout_pad
         )
         if self.request_timeout < minimum_request_timeout:
             self.request_timeout = minimum_request_timeout
         elif self.request_timeout > minimum_request_timeout:
             GatewayClient.KERNEL_LAUNCH_TIMEOUT = (
-                int(self.request_timeout) - self.kernel_launch_timeout_pad
+                int(self.request_timeout) - self.launch_timeout_pad
             )
         # Ensure any adjustments are reflected in env.
         os.environ["KERNEL_LAUNCH_TIMEOUT"] = str(GatewayClient.KERNEL_LAUNCH_TIMEOUT)

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -343,7 +343,7 @@ class GatewayClient(SingletonConfigurable):
 
     launch_timeout_pad_default_value = 2
     launch_timeout_pad_env = "JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD"
-    launch_timeout_pad = Int(
+    launch_timeout_pad = Float(
         default_value=launch_timeout_pad_default_value,
         config=True,
         help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout
@@ -353,7 +353,7 @@ class GatewayClient(SingletonConfigurable):
 
     @default("launch_timeout_pad")
     def launch_timeout_pad_default(self):
-        return int(
+        return float(
             os.environ.get(
                 "JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD",
                 self.launch_timeout_pad_default_value,
@@ -382,7 +382,7 @@ class GatewayClient(SingletonConfigurable):
             self.request_timeout = minimum_request_timeout
         elif self.request_timeout > minimum_request_timeout:
             GatewayClient.KERNEL_LAUNCH_TIMEOUT = (
-                int(self.request_timeout) - self.launch_timeout_pad
+                int(self.request_timeout - self.launch_timeout_pad)
             )
         # Ensure any adjustments are reflected in env.
         os.environ["KERNEL_LAUNCH_TIMEOUT"] = str(GatewayClient.KERNEL_LAUNCH_TIMEOUT)

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -341,7 +341,7 @@ class GatewayClient(SingletonConfigurable):
             os.environ.get("JUPYTER_GATEWAY_RETRY_MAX", self.gateway_retry_max_default_value)
         )
 
-    launch_timeout_pad_default_value = 2
+    launch_timeout_pad_default_value = 2.0
     launch_timeout_pad_env = "JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD"
     launch_timeout_pad = Float(
         default_value=launch_timeout_pad_default_value,

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -346,7 +346,8 @@ class GatewayClient(SingletonConfigurable):
     kernel_launch_timeout_pad = Int(
         default_value=kernel_launch_timeout_pad_default_value,
         config=True,
-        help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout.
+        help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout
+        such that request_timeout >= KERNEL_LAUNCH_TIMEOUT + timeout_pad.
         (JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD env var)""",
     )
 

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -353,7 +353,7 @@ class GatewayClient(SingletonConfigurable):
     kernel_launch_timeout_pad = Int(
         default_value=kernel_launch_timeout_pad_default_value,
         config=True,
-        help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout. 
+        help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout.
         (JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD env var)""",
     )
 
@@ -361,7 +361,8 @@ class GatewayClient(SingletonConfigurable):
     def kernel_launch_timeout_pad_default(self):
         return int(
             os.environ.get(
-                "JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD", self.kernel_launch_timeout_pad_default_value
+                "JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD",
+                self.kernel_launch_timeout_pad_default_value,
             )
         )
 

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -347,7 +347,7 @@ class GatewayClient(SingletonConfigurable):
         default_value=launch_timeout_pad_default_value,
         config=True,
         help="""Timeout pad to be ensured between KERNEL_LAUNCH_TIMEOUT and request_timeout
-        such that request_timeout >= KERNEL_LAUNCH_TIMEOUT + timeout_pad.
+        such that request_timeout >= KERNEL_LAUNCH_TIMEOUT + launch_timeout_pad.
         (JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD env var)""",
     )
 

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -341,13 +341,6 @@ class GatewayClient(SingletonConfigurable):
             os.environ.get("JUPYTER_GATEWAY_RETRY_MAX", self.gateway_retry_max_default_value)
         )
 
-    @property
-    def gateway_enabled(self):
-        return bool(self.url is not None and len(self.url) > 0)
-
-    # Ensure KERNEL_LAUNCH_TIMEOUT has a default value.
-    KERNEL_LAUNCH_TIMEOUT = int(os.environ.get("KERNEL_LAUNCH_TIMEOUT", 40))
-
     kernel_launch_timeout_pad_default_value = 0
     kernel_launch_timeout_pad_env = "JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD"
     kernel_launch_timeout_pad = Int(
@@ -365,6 +358,13 @@ class GatewayClient(SingletonConfigurable):
                 self.kernel_launch_timeout_pad_default_value,
             )
         )
+
+    @property
+    def gateway_enabled(self):
+        return bool(self.url is not None and len(self.url) > 0)
+
+    # Ensure KERNEL_LAUNCH_TIMEOUT has a default value.
+    KERNEL_LAUNCH_TIMEOUT = int(os.environ.get("KERNEL_LAUNCH_TIMEOUT", 40))
 
     def init_static_args(self):
         """Initialize arguments used on every request.  Since these are static values, we'll

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -186,7 +186,7 @@ def init_gateway(monkeypatch):
     monkeypatch.setenv("JUPYTER_GATEWAY_HTTP_USER", mock_http_user)
     monkeypatch.setenv("JUPYTER_GATEWAY_REQUEST_TIMEOUT", "44.4")
     monkeypatch.setenv("JUPYTER_GATEWAY_CONNECT_TIMEOUT", "44.4")
-    monkeypatch.setenv("JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD", "1")
+    monkeypatch.setenv("JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD", "1.1")
     yield
     GatewayClient.clear_instance()
 
@@ -199,7 +199,7 @@ async def test_gateway_env_options(init_gateway, jp_serverapp):
         jp_serverapp.gateway_config.connect_timeout == jp_serverapp.gateway_config.request_timeout
     )
     assert jp_serverapp.gateway_config.connect_timeout == 44.4
-    assert jp_serverapp.gateway_config.launch_timeout_pad == 1
+    assert jp_serverapp.gateway_config.launch_timeout_pad == 1.1
 
     GatewayClient.instance().init_static_args()
     assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 43
@@ -211,7 +211,7 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
         "--GatewayClient.http_user=" + mock_http_user,
         "--GatewayClient.connect_timeout=44.4",
         "--GatewayClient.request_timeout=96.0",
-        "--GatewayClient.launch_timeout_pad=6",
+        "--GatewayClient.launch_timeout_pad=5.1",
     ]
 
     GatewayClient.clear_instance()
@@ -222,7 +222,7 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
     assert app.gateway_config.http_user == mock_http_user
     assert app.gateway_config.connect_timeout == 44.4
     assert app.gateway_config.request_timeout == 96.0
-    assert app.gateway_config.launch_timeout_pad == 6
+    assert app.gateway_config.launch_timeout_pad == 5.1
     GatewayClient.instance().init_static_args()
     assert (
         GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 90

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -244,7 +244,7 @@ async def test_gateway_request_timeout_pad_option(
 ):
     argv = [
         f"--GatewayClient.request_timeout={request_timeout}",
-        "--GatewayClient.kernel_launch_timeout_pad=5"
+        "--GatewayClient.kernel_launch_timeout_pad=5",
     ]
 
     GatewayClient.clear_instance()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -186,7 +186,7 @@ def init_gateway(monkeypatch):
     monkeypatch.setenv("JUPYTER_GATEWAY_HTTP_USER", mock_http_user)
     monkeypatch.setenv("JUPYTER_GATEWAY_REQUEST_TIMEOUT", "44.4")
     monkeypatch.setenv("JUPYTER_GATEWAY_CONNECT_TIMEOUT", "44.4")
-    monkeypatch.setenv("JUPYTER_GATEWAY_KERNEL_LAUNCH_TIMEOUT_PAD", "1")
+    monkeypatch.setenv("JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD", "1")
     yield
     GatewayClient.clear_instance()
 
@@ -199,7 +199,7 @@ async def test_gateway_env_options(init_gateway, jp_serverapp):
         jp_serverapp.gateway_config.connect_timeout == jp_serverapp.gateway_config.request_timeout
     )
     assert jp_serverapp.gateway_config.connect_timeout == 44.4
-    assert jp_serverapp.gateway_config.kernel_launch_timeout_pad == 1
+    assert jp_serverapp.gateway_config.launch_timeout_pad == 1
 
     GatewayClient.instance().init_static_args()
     assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 43
@@ -211,7 +211,7 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
         "--GatewayClient.http_user=" + mock_http_user,
         "--GatewayClient.connect_timeout=44.4",
         "--GatewayClient.request_timeout=96.0",
-        "--GatewayClient.kernel_launch_timeout_pad=2",
+        "--GatewayClient.launch_timeout_pad=6",
     ]
 
     GatewayClient.clear_instance()
@@ -222,11 +222,11 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
     assert app.gateway_config.http_user == mock_http_user
     assert app.gateway_config.connect_timeout == 44.4
     assert app.gateway_config.request_timeout == 96.0
-    assert app.gateway_config.kernel_launch_timeout_pad == 2
+    assert app.gateway_config.launch_timeout_pad == 6
     GatewayClient.instance().init_static_args()
     assert (
-        GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 94
-    )  # Ensure KLT gets set from request-timeout - kernel_launch_timeout_pad
+        GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 90
+    )  # Ensure KLT gets set from request-timeout - launch_timeout_pad
     GatewayClient.clear_instance()
 
 
@@ -244,7 +244,7 @@ async def test_gateway_request_timeout_pad_option(
 ):
     argv = [
         f"--GatewayClient.request_timeout={request_timeout}",
-        "--GatewayClient.kernel_launch_timeout_pad=5",
+        "--GatewayClient.launch_timeout_pad=5",
     ]
 
     GatewayClient.clear_instance()


### PR DESCRIPTION
Re-add support removed in https://github.com/jupyter-server/jupyter_server/commit/573adc3de6de26f644afb27b5b7f037f63a1b45a
