### PR TITLE
Fix typo in IdentityProvider documentation

### DIFF
--- a/docs/source/operators/security.rst
+++ b/docs/source/operators/security.rst
@@ -101,7 +101,7 @@ as all requests requiring _authorization_ must first complete _authentication_.
 Identity Providers
 ******************
 
-The :class:`.IdentityProvider` class is responsible for the "authorization" step,
+The :class:`.IdentityProvider` class is responsible for the "authentication" step,
 identifying the user making the request,
 and constructing information about them.
 


### PR DESCRIPTION
[Previous section](https://github.com/jupyter-server/jupyter_server/blob/main/docs/source/operators/security.rst#authentication-and-authorization) has the following description
> The first step is "Authentication" (identifying who is making the request). This is handled by the [:class:`.IdentityProvider`](https://github.com/jupyter-server/jupyter_server/blob/main/docs/source/operators/security.rst#id7).

I think it's more correct to say `IdentityProvider` class is responsible for the "authentication" step, instead of "authorization"