### PR TITLE
Use more explicit version template for pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ version_template = '({major}, {minor}, {patch}, "{channel}", "{release}")'
 
 [[tool.tbump.file]]
 src = "pyproject.toml"
-version_template = "{major}.{minor}.{patch}{channel}{release}"
+version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\""
 
 [[tool.tbump.file]]
 src = "docs/source/conf.py"


### PR DESCRIPTION
To avoid accidentally bumping a dependency