### PR TITLE
draft: File ID Manager base implementation

### DIFF
--- a/jupyter_server/benchmarks/fileidmanager_benchmark.py
+++ b/jupyter_server/benchmarks/fileidmanager_benchmark.py
@@ -1,0 +1,133 @@
+import os
+import timeit
+
+from jupyter_core.paths import jupyter_data_dir
+
+from jupyter_server.services.contents.fileidmanager import FileIdManager
+
+db_path = os.path.join(jupyter_data_dir(), "file_id_manager_perftest.db")
+
+
+def build_setup(n, insert=True):
+    def setup():
+        try:
+            os.remove(db_path)
+        except:
+            pass
+        fid_manager = FileIdManager(db_path=db_path)
+
+        if not insert:
+            return
+
+        for i in range(n):
+            fid_manager.con.execute(
+                "INSERT INTO Files (path) VALUES (?)", (f"abracadabra/{i}.txt",)
+            )
+        fid_manager.con.commit()
+
+    return setup
+
+
+BATCH_SIZE = 100_000
+
+
+def build_test_index(n, single_transaction, batched=False):
+    def test_index():
+        fid_manager = FileIdManager(db_path=db_path)
+
+        if single_transaction:
+            if batched:
+                for batch_start in range(0, n, BATCH_SIZE):
+                    batch_end = batch_start + BATCH_SIZE
+                    fid_manager.con.execute(
+                        "INSERT INTO FILES (path) VALUES "
+                        + ",".join(
+                            [f'("abracadabra/{i}.txt")' for i in range(batch_start, batch_end)]
+                        )
+                    )
+            else:
+                for i in range(n):
+                    fid_manager.con.execute(
+                        "INSERT INTO Files (path) VALUES (?)", (f"abracadabra/{i}.txt",)
+                    )
+
+            fid_manager.con.commit()
+        else:
+            for i in range(n):
+                fid_manager.index(f"abracadabra/{i}.txt")
+
+    return test_index
+
+
+def test_copy():
+    fid_manager = FileIdManager(db_path=db_path)
+    fid_manager.copy("abracadabra", "shazam", recursive=True)
+
+
+def test_move():
+    fid_manager = FileIdManager(db_path=db_path)
+    fid_manager.move("abracadabra", "shazam", recursive=True)
+
+
+def test_delete():
+    fid_manager = FileIdManager(db_path=db_path)
+    fid_manager.delete("abracadabra", recursive=True)
+
+
+row_template = "{:<9,d} files | {:<8.4f} s"
+
+
+# too slow for 1k+
+print("Index benchmark (separate transactions)")
+for i in [100, 1_000]:
+    print(
+        row_template.format(
+            i,
+            timeit.timeit(
+                build_test_index(i, single_transaction=False),
+                build_setup(i, insert=False),
+                number=1,
+            ),
+        )
+    )
+
+print("Index benchmark (single transaction, atomic INSERTs)")
+for i in [100, 1_000, 10_000, 100_000, 1_000_000]:
+    print(
+        row_template.format(
+            i,
+            timeit.timeit(
+                build_test_index(i, single_transaction=True, batched=False),
+                build_setup(i, insert=False),
+                number=1,
+            ),
+        )
+    )
+
+# suggested by https://stackoverflow.com/a/72527058/12548458
+# asymptotically faster because it reduces work being done by the SQLite VDBE https://www.sqlite.org/opcode.html
+# weird constant time factor that makes it sub-optimal for <1M records.
+print("Index benchmark (single transaction, batched INSERTs)")
+for i in [100, 1_000, 10_000, 100_000, 1_000_000]:
+    print(
+        row_template.format(
+            i,
+            timeit.timeit(
+                build_test_index(i, single_transaction=True, batched=True),
+                build_setup(i, insert=False),
+                number=1,
+            ),
+        )
+    )
+
+print("Recursive move benchmark")
+for i in [100, 1_000, 10_000, 100_000, 1_000_000]:
+    print(row_template.format(i, timeit.timeit(test_move, build_setup(i), number=1)))
+
+print("Recursive copy benchmark")
+for i in [100, 1_000, 10_000, 100_000, 1_000_000]:
+    print(row_template.format(i, timeit.timeit(test_copy, build_setup(i), number=1)))
+
+print("Recursive delete benchmark")
+for i in [100, 1_000, 10_000, 100_000, 1_000_000]:
+    print(row_template.format(i, timeit.timeit(test_delete, build_setup(i), number=1)))

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -475,12 +475,13 @@ def delete_fid_db(fid_db_path):
 
 
 @pytest.fixture
-def fid_manager(fid_db_path, tmp_path):
+def fid_manager(fid_db_path, jp_root_dir):
     """Fixture returning a test-configured instance of `FileIdManager`."""
-    fid_manager = FileIdManager(db_path=fid_db_path, root_dir=str(tmp_path))
+    fid_manager = FileIdManager(db_path=fid_db_path, root_dir=str(jp_root_dir))
     # disable journal so no temp journal file is created under `tmp_path`.
     # reduces test flakiness since sometimes journal file has same ino and
     # crtime as a deleted file, so FID manager detects it wrongly as a move
+    # also makes tests run faster :)
     fid_manager.con.execute("PRAGMA journal_mode = OFF")
     return fid_manager
 

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -477,7 +477,12 @@ def delete_fid_db(fid_db_path):
 @pytest.fixture
 def fid_manager(fid_db_path, tmp_path):
     """Fixture returning a test-configured instance of `FileIdManager`."""
-    return FileIdManager(db_path=fid_db_path, root_dir=str(tmp_path))
+    fid_manager = FileIdManager(db_path=fid_db_path, root_dir=str(tmp_path))
+    # disable journal so no temp journal file is created under `tmp_path`.
+    # reduces test flakiness since sometimes journal file has same ino and
+    # crtime as a deleted file, so FID manager detects it wrongly as a move
+    fid_manager.con.execute("PRAGMA journal_mode = OFF")
+    return fid_manager
 
 
 @pytest.fixture

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -465,8 +465,9 @@ def fid_db_path(jp_data_dir):
 
 
 @pytest.fixture(autouse=True)
-def delete_db(fid_db_path):
-    """Fixture that automatically deletes the DB file before each test."""
+def delete_fid_db(fid_db_path):
+    """Fixture that automatically deletes the DB file after each test."""
+    yield
     try:
         os.remove(fid_db_path)
     except OSError:
@@ -474,9 +475,9 @@ def delete_db(fid_db_path):
 
 
 @pytest.fixture
-def fid_manager(fid_db_path):
+def fid_manager(fid_db_path, tmp_path):
     """Fixture returning a test-configured instance of `FileIdManager`."""
-    return FileIdManager(db_path=fid_db_path)
+    return FileIdManager(db_path=fid_db_path, root_dir=str(tmp_path))
 
 
 @pytest.fixture

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -18,6 +18,7 @@ from traitlets.config import Config
 
 from jupyter_server.extension import serverextension
 from jupyter_server.serverapp import ServerApp
+from jupyter_server.services.contents.fileidmanager import FileIdManager
 from jupyter_server.services.contents.filemanager import FileContentsManager
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.utils import url_path_join
@@ -455,6 +456,27 @@ def jp_contents_manager(request, tmp_path):
 def jp_large_contents_manager(tmp_path):
     """Returns a LargeFileManager instance."""
     return LargeFileManager(root_dir=str(tmp_path))
+
+
+@pytest.fixture
+def fid_db_path(jp_data_dir):
+    """Fixture that returns the file ID DB path used for tests."""
+    return str(jp_data_dir / "fileidmanager_test.db")
+
+
+@pytest.fixture(autouse=True)
+def delete_db(fid_db_path):
+    """Fixture that automatically deletes the DB file before each test."""
+    try:
+        os.remove(fid_db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def fid_manager(fid_db_path):
+    """Fixture returning a test-configured instance of `FileIdManager`."""
+    return FileIdManager(db_path=fid_db_path)
 
 
 @pytest.fixture

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1887,7 +1887,7 @@ class ServerApp(JupyterApp):
             connection_dir=self.runtime_dir,
             kernel_spec_manager=self.kernel_spec_manager,
         )
-        self.file_id_manager = FileIdManager(parent=self, log=self.log)
+        self.file_id_manager = FileIdManager(parent=self, log=self.log, root_dir=self.root_dir)
         self.contents_manager = self.contents_manager_class(
             parent=self, log=self.log, file_id_manager=self.file_id_manager
         )

--- a/jupyter_server/services/contents/fileidmanager.py
+++ b/jupyter_server/services/contents/fileidmanager.py
@@ -1,0 +1,126 @@
+import os
+import sqlite3
+
+from jupyter_core.paths import jupyter_data_dir
+from traitlets import Unicode
+from traitlets.config.configurable import LoggingConfigurable
+
+
+class FileIdManager(LoggingConfigurable):
+    db_path = Unicode(
+        default_value=os.path.join(jupyter_data_dir(), "file_id_manager.db"),
+        help=(
+            "The path of the DB file used by `FileIdManager`. "
+            "Defaults to `jupyter_data_dir()/file_id_manager.db`."
+        ),
+        config=True,
+    )
+
+    def __init__(self, *args, **kwargs):
+        # pass args and kwargs to parent Configurable
+        super().__init__(*args, **kwargs)
+        # initialize connection with db
+        self.con = sqlite3.connect(self.db_path)
+        self.log.debug("Creating File ID tables and indices")
+        self.con.execute(
+            "CREATE TABLE IF NOT EXISTS Files(id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE)"
+        )
+        self.con.execute("CREATE INDEX IF NOT EXISTS ix_Files_path ON FILES (path)")
+        self.con.commit()
+
+    def _normalize_path(self, path):
+        """Normalizes a given file path."""
+        path = os.path.normcase(path)
+        path = os.path.normpath(path)
+        return path
+
+    def index(self, path):
+        """Adds the file path to the Files table, then returns the file ID. If
+        the file is already indexed, the file ID is immediately returned."""
+        path = self._normalize_path(path)
+        existing_id = self.get_id(path)
+        if existing_id is not None:
+            return existing_id
+
+        cursor = self.con.execute("INSERT INTO Files (path) VALUES (?)", (path,))
+        self.con.commit()
+        return cursor.lastrowid
+
+    def get_id(self, path):
+        """Retrieves the file ID associated with a file path. Returns None if
+        the file path has not yet been indexed."""
+        path = self._normalize_path(path)
+        row = self.con.execute("SELECT id FROM Files WHERE path = ?", (path,)).fetchone()
+        self.con.commit()
+        return row[0] if row else None
+
+    def get_path(self, id):
+        """Retrieves the file path associated with a file ID. Returns None if
+        the ID does not exist in the Files table."""
+        row = self.con.execute("SELECT path FROM Files WHERE id = ?", (id,)).fetchone()
+        self.con.commit()
+        return row[0] if row else None
+
+    def move(self, old_path, new_path, recursive=False):
+        """Handles file moves by updating the file path of the associated file
+        ID.  Returns the file ID."""
+        old_path = self._normalize_path(old_path)
+        new_path = self._normalize_path(new_path)
+        self.log.debug(f"Moving file from ${old_path} to ${new_path}")
+
+        if recursive:
+            old_path_glob = os.path.join(old_path, "*")
+            self.con.execute(
+                "UPDATE Files SET path = ? || substr(path, ?) WHERE path GLOB ?",
+                (new_path, len(old_path) + 1, old_path_glob),
+            )
+            self.con.commit()
+
+        id = self.get_id(old_path)
+        if id is None:
+            return self.index(new_path)
+        else:
+            self.con.execute("UPDATE Files SET path = ? WHERE id = ?", (new_path, id))
+            self.con.commit()
+            return id
+
+    def copy(self, from_path, to_path, recursive=False):
+        """Handles file copies by creating a new record in the Files table.
+        Returns the file ID associated with `new_path`. Also indexes `old_path`
+        if record does not exist in Files table. TODO: emit to event bus to
+        inform client extensions to copy records associated with old file ID to
+        the new file ID."""
+        from_path = self._normalize_path(from_path)
+        to_path = self._normalize_path(to_path)
+        self.log.debug(f"Copying file from ${from_path} to ${to_path}")
+
+        if recursive:
+            from_path_glob = os.path.join(from_path, "*")
+            self.con.execute(
+                "INSERT INTO Files (path) SELECT (? || substr(path, ?)) FROM Files WHERE path GLOB ?",
+                (to_path, len(from_path) + 1, from_path_glob),
+            )
+            self.con.commit()
+
+        self.index(from_path)
+        return self.index(to_path)
+
+    def delete(self, path, recursive=False):
+        """Handles file deletions by deleting the associated record in the File
+        table. Returns None."""
+        path = self._normalize_path(path)
+        self.log.debug(f"Deleting file {path}")
+
+        if recursive:
+            path_glob = os.path.join(path, "*")
+            self.con.execute("DELETE FROM Files WHERE path GLOB ?", (path_glob,))
+            self.con.commit()
+
+        self.con.execute("DELETE FROM Files WHERE path = ?", (path,))
+        self.con.commit()
+
+    def _cleanup(self):
+        """Cleans up `FileIdManager` by committing any pending transactions and
+        closing the connection."""
+        self.con.commit()
+        self.con.close()

--- a/jupyter_server/services/contents/fileidmanager.py
+++ b/jupyter_server/services/contents/fileidmanager.py
@@ -44,9 +44,9 @@ class FileIdManager(LoggingConfigurable):
         config=True,
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         # pass args and kwargs to parent Configurable
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         # initialize connection with db
         self.con = sqlite3.connect(self.db_path)
         self.log.debug("FileIdManager : Creating File ID tables and indices")

--- a/jupyter_server/services/contents/fileidmanager.py
+++ b/jupyter_server/services/contents/fileidmanager.py
@@ -298,7 +298,13 @@ class FileIdManager(LoggingConfigurable):
         self._sync_all()
         self.con.commit()
         row = self.con.execute("SELECT path FROM Files WHERE id = ?", (id,)).fetchone()
-        return row[0] if row else None
+        path = row and row[0]
+
+        # if no record associated with ID or if file no longer exists at path, return None
+        if path is None or self._stat(path) is None:
+            return None
+
+        return path
 
     def move(self, old_path, new_path, recursive=False):
         """Handles file moves by updating the file path of the associated file

--- a/jupyter_server/services/contents/fileidmanager.py
+++ b/jupyter_server/services/contents/fileidmanager.py
@@ -1,12 +1,22 @@
 import os
 import sqlite3
+from typing import Optional
 
 from jupyter_core.paths import jupyter_data_dir
 from traitlets import Unicode
 from traitlets.config.configurable import LoggingConfigurable
 
 
+class StatStruct:
+    empty = True
+    ino: int
+    crtime: Optional[int]
+    mtime: int
+
+
 class FileIdManager(LoggingConfigurable):
+    root_dir = Unicode(help=("The root being served by Jupyter server."), config=True)
+
     db_path = Unicode(
         default_value=os.path.join(jupyter_data_dir(), "file_id_manager.db"),
         help=(
@@ -23,9 +33,16 @@ class FileIdManager(LoggingConfigurable):
         self.con = sqlite3.connect(self.db_path)
         self.log.debug("Creating File ID tables and indices")
         self.con.execute(
-            "CREATE TABLE IF NOT EXISTS Files(id INTEGER PRIMARY KEY, path TEXT NOT NULL UNIQUE)"
+            "CREATE TABLE IF NOT EXISTS Files("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "path TEXT NOT NULL UNIQUE, "
+            "ino INTEGER NOT NULL UNIQUE, "
+            "crtime INTEGER, "
+            "mtime INTEGER NOT NULL"
+            ")"
         )
         self.con.execute("CREATE INDEX IF NOT EXISTS ix_Files_path ON FILES (path)")
+        self.con.execute("CREATE INDEX IF NOT EXISTS ix_Files_ino ON FILES (ino)")
         self.con.commit()
 
     def _normalize_path(self, path):
@@ -34,31 +51,103 @@ class FileIdManager(LoggingConfigurable):
         path = os.path.normpath(path)
         return path
 
+    def _stat(self, path, stat_info=StatStruct()):
+        """Returns stat info on a path in a StatStruct object. Writes to
+        `stat_info` StatStruct arg if passed. Returns None if file does not
+        exist at path."""
+        try:
+            raw_stat = os.stat(path)
+        except OSError:
+            return None
+
+        stat_info.empty = False
+        stat_info.ino = raw_stat.st_ino
+        stat_info.crtime = (
+            raw_stat.st_ctime
+            if os.name == "nt"
+            else raw_stat.st_birthtime  # type: ignore
+            if hasattr(raw_stat, "st_birthtime")
+            else None
+        )
+        stat_info.mtime = raw_stat.st_mtime
+
+        return stat_info
+
     def index(self, path):
-        """Adds the file path to the Files table, then returns the file ID. If
-        the file is already indexed, the file ID is immediately returned."""
-        path = self._normalize_path(path)
-        existing_id = self.get_id(path)
+        """Returns the file ID for the file at `path`, creating a new file ID if
+        one does not exist. Returns None only if file does not exist at path.
+        Note that this essentially just wraps `get_id()` and creates a new
+        record if it returns None and the file exists."""
+        stat_info = StatStruct()
+        existing_id = self.get_id(path, stat_info)
         if existing_id is not None:
             return existing_id
+        if stat_info.empty:
+            return None
 
-        cursor = self.con.execute("INSERT INTO Files (path) VALUES (?)", (path,))
+        # if path does not exist in the DB and an out-of-band move is not indicated, create a new record
+        path = self._normalize_path(path)
+        cursor = self.con.execute(
+            "INSERT INTO Files (path, ino, crtime, mtime) VALUES (?, ?, ?, ?)",
+            (path, stat_info.ino, stat_info.crtime, stat_info.mtime),
+        )
         self.con.commit()
         return cursor.lastrowid
 
-    def get_id(self, path):
-        """Retrieves the file ID associated with a file path. Returns None if
-        the file path has not yet been indexed."""
+    def get_id(self, path, stat_info=StatStruct()):
+        """Retrieves the file ID associated with a file path. Tracks out-of-band
+        moves by searching the table for a record with an identical `ino` and
+        `crtime` (falling back to `mtime` if `crtime` is not supported on the
+        current platform). Updates the file's stat info on invocation and caches
+        this in the `stat_info` arg if passed.  Returns None if the file has not
+        yet been indexed or does not exist at the given path."""
         path = self._normalize_path(path)
+        stat_info = self._stat(path, stat_info)
+        if not stat_info:
+            return None
+
+        # if id already exists, just update the stat info and return id
         row = self.con.execute("SELECT id FROM Files WHERE path = ?", (path,)).fetchone()
+        if row:
+            (existing_id,) = row
+            self.con.execute(
+                "UPDATE Files SET ino = ?, crtime = ?, mtime = ? WHERE id = ?",
+                (stat_info.ino, stat_info.crtime, stat_info.mtime, existing_id),
+            )
+            self.con.commit()
+            return existing_id
+
+        # then check if file at path was indexed but moved out-of-band
+        src = self.con.execute(
+            "SELECT id, crtime, mtime FROM Files WHERE ino = ?", (stat_info.ino,)
+        ).fetchone()
+
+        ## if no matching ino, then return None
+        if not src:
+            return None
+
+        id, src_crtime, src_mtime = src
+        src_timestamp = src_crtime if src_crtime is not None else src_mtime
+        dst_timestamp = stat_info.crtime if stat_info.crtime is not None else stat_info.mtime
+
+        ## if identical ino and crtime/mtime to an existing record, update it with new destination path and stat info, returning its id
+        if src_timestamp == dst_timestamp:
+            self.con.execute(
+                "UPDATE Files SET path = ?, crtime = ?, mtime = ? WHERE id = ?",
+                (path, stat_info.crtime, stat_info.mtime, id),
+            )
+            self.con.commit()
+            return id
+
+        ## otherwise delete the existing record with identical `ino`, since inos must be unique. then return None
+        self.con.execute("DELETE FROM Files WHERE id = ?", (id,))
         self.con.commit()
-        return row[0] if row else None
+        return None
 
     def get_path(self, id):
         """Retrieves the file path associated with a file ID. Returns None if
         the ID does not exist in the Files table."""
         row = self.con.execute("SELECT path FROM Files WHERE id = ?", (id,)).fetchone()
-        self.con.commit()
         return row[0] if row else None
 
     def move(self, old_path, new_path, recursive=False):
@@ -70,10 +159,21 @@ class FileIdManager(LoggingConfigurable):
 
         if recursive:
             old_path_glob = os.path.join(old_path, "*")
-            self.con.execute(
-                "UPDATE Files SET path = ? || substr(path, ?) WHERE path GLOB ?",
-                (new_path, len(old_path) + 1, old_path_glob),
-            )
+            records = self.con.execute(
+                "SELECT id, path FROM Files WHERE path GLOB ?", (old_path_glob,)
+            ).fetchall()
+            for record in records:
+                if not record:
+                    continue
+                id, old_recpath = record
+                new_recpath = os.path.join(new_path, os.path.basename(old_recpath))
+                stat_info = self._stat(new_recpath)
+                if not stat_info:
+                    continue
+                self.con.execute(
+                    "UPDATE Files SET path = ?, mtime = ? WHERE id = ?",
+                    (id, stat_info.mtime, new_recpath),
+                )
             self.con.commit()
 
         id = self.get_id(old_path)
@@ -96,10 +196,21 @@ class FileIdManager(LoggingConfigurable):
 
         if recursive:
             from_path_glob = os.path.join(from_path, "*")
-            self.con.execute(
-                "INSERT INTO Files (path) SELECT (? || substr(path, ?)) FROM Files WHERE path GLOB ?",
-                (to_path, len(from_path) + 1, from_path_glob),
-            )
+            records = self.con.execute(
+                "SELECT path FROM Files WHERE path GLOB ?", (from_path_glob,)
+            ).fetchall()
+            for record in records:
+                if not record:
+                    continue
+                (from_recpath,) = record
+                to_recpath = os.path.join(to_path, os.path.basename(from_recpath))
+                stat_info = self._stat(to_recpath)
+                if not stat_info:
+                    continue
+                self.con.execute(
+                    "INSERT INTO FILES (path, ino, crtime, mtime) VALUES (?, ?, ?, ?)",
+                    (to_recpath, stat_info.ino, stat_info.crtime, stat_info.mtime),
+                )
             self.con.commit()
 
         self.index(from_path)

--- a/jupyter_server/services/contents/fileidmanager.py
+++ b/jupyter_server/services/contents/fileidmanager.py
@@ -87,7 +87,7 @@ class FileIdManager(LoggingConfigurable):
         with os.scandir(dir_path) as scan_iter:
             for entry in scan_iter:
                 if entry.is_dir():
-                    self._index_dir_recursively(entry.path, self._parse_raw_stat(entry.stat()))
+                    self._index_dir_recursively(entry.path, self._stat(entry.path))
         scan_iter.close()
 
     def _sync_all(self):
@@ -134,7 +134,7 @@ class FileIdManager(LoggingConfigurable):
         """
         with os.scandir(dir_path) as scan_iter:
             for entry in scan_iter:
-                stat_info = self._parse_raw_stat(entry.stat())
+                stat_info = self._stat(entry.path)
                 id, is_dirty_dir = self._sync_file(entry.path, stat_info)
 
                 # if entry is unindexed directory, create new record

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -395,6 +395,10 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             if type == "directory":
                 raise web.HTTPError(400, "%s is not a directory" % path, reason="bad type")
             model = self._file_model(path, content=content, format=format)
+
+        # append file ID to model
+        model["id"] = self.file_id_manager.index(path)
+
         return model
 
     def _save_directory(self, os_path, model, path=""):

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -271,7 +271,7 @@ class ContentsHandler(ContentsAPIHandler):
         if await ensure_async(cm.is_hidden(path)) and not cm.allow_hidden:
             raise web.HTTPError(400, f"Cannot delete file or directory {path!r}")
 
-        self.log.warning("delete %s", path)
+        self.log.warning("Deleting file at %s", path)
         await ensure_async(cm.delete(path))
         self.set_status(204)
         self.finish()

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -61,7 +61,10 @@ class ContentsManager(LoggingConfigurable):
     notary = Instance(sign.NotebookNotary)
 
     file_id_manager = Instance(
-        FileIdManager, args=(), help="File ID manager instance to use. Defaults to `FileIdManager`."
+        FileIdManager,
+        args=(),
+        kw={"root_dir": root_dir},
+        help="File ID manager instance to use. Defaults to `FileIdManager`.",
     )
 
     def _notary_default(self):

--- a/tests/services/contents/test_fileidmanager.py
+++ b/tests/services/contents/test_fileidmanager.py
@@ -106,6 +106,16 @@ def test_get_id_oob_move(fid_manager, old_path, new_path):
     assert fid_manager.get_id(new_path) == id
 
 
+def test_get_id_oob_move_recursive(fid_manager, old_path, old_path_child, new_path, new_path_child):
+    parent_id = fid_manager.index(old_path)
+    child_id = fid_manager.index(old_path_child)
+
+    os.rename(old_path, new_path)
+
+    assert fid_manager.get_id(new_path) == parent_id
+    assert fid_manager.get_id(new_path_child) == child_id
+
+
 def test_get_path_oob_move(fid_manager, old_path, new_path):
     id = fid_manager.index(old_path)
     os.rename(old_path, new_path)
@@ -134,6 +144,8 @@ def test_move_indexed(fid_manager, old_path, new_path):
     assert fid_manager.get_path(old_id) == new_path
 
 
+# test for disjoint move handling
+# disjoint move: any out-of-band move that does not preserve stat info
 def test_disjoint_move_indexed(fid_manager, old_path, new_path):
     old_id = fid_manager.index(old_path)
 
@@ -145,11 +157,13 @@ def test_disjoint_move_indexed(fid_manager, old_path, new_path):
 
 
 def test_move_recursive(fid_manager, old_path, old_path_child, new_path, new_path_child):
-    os.rename(old_path, new_path)
-    fid_manager.index(old_path)
+    parent_id = fid_manager.index(old_path)
     child_id = fid_manager.index(old_path_child)
+
+    os.rename(old_path, new_path)
     fid_manager.move(old_path, new_path, recursive=True)
 
+    assert fid_manager.get_id(new_path) == parent_id
     assert fid_manager.get_id(new_path_child) == child_id
 
 

--- a/tests/services/contents/test_fileidmanager.py
+++ b/tests/services/contents/test_fileidmanager.py
@@ -141,6 +141,30 @@ def test_get_path_oob_move(fid_manager, old_path, new_path):
     assert fid_manager.get_path(id) == new_path
 
 
+def test_get_path_oob_move_recursive(
+    fid_manager, old_path, old_path_child, new_path, new_path_child
+):
+    id = fid_manager.index(old_path)
+    child_id = fid_manager.index(old_path_child)
+
+    os.rename(old_path, new_path)
+
+    assert fid_manager.get_path(id) == new_path
+    assert fid_manager.get_path(child_id) == new_path_child
+
+
+def test_get_path_oob_move_into_unindexed(
+    fid_manager, old_path, old_path_child, new_path, new_path_child
+):
+    fid_manager.index(old_path)
+    id = fid_manager.index(old_path_child)
+
+    os.mkdir(new_path)
+    os.rename(old_path_child, new_path_child)
+
+    assert fid_manager.get_path(id) == new_path_child
+
+
 def test_move_unindexed(fid_manager, old_path, new_path):
     os.rename(old_path, new_path)
     id = fid_manager.move(old_path, new_path)

--- a/tests/services/contents/test_fileidmanager.py
+++ b/tests/services/contents/test_fileidmanager.py
@@ -68,15 +68,18 @@ def test_index_already_indexed(fid_manager, test_path):
     assert id == fid_manager.index(test_path)
 
 
+# test out-of-band move detection for FIM.index()
+def test_index_oob_move(fid_manager, old_path, new_path):
+    id = fid_manager.index(old_path)
+    os.rename(old_path, new_path)
+    assert fid_manager.index(new_path) == id
+
+
 def test_getters_indexed(fid_manager, test_path):
     id = fid_manager.index(test_path)
 
     assert fid_manager.get_id(test_path) == id
     assert fid_manager.get_path(id) == test_path
-
-
-def test_get_id_unindexed(fid_manager, test_path_child):
-    assert fid_manager.get_id(test_path_child) == None
 
 
 def test_getters_nonnormalized(fid_manager, test_path):
@@ -92,11 +95,17 @@ def test_getters_nonnormalized(fid_manager, test_path):
     assert fid_manager.get_id(path3) == id
 
 
-# test out-of-band move detection for FIM.index()
-def test_index_oob_move(fid_manager, old_path, new_path):
-    id = fid_manager.index(old_path)
-    os.rename(old_path, new_path)
-    assert fid_manager.index(new_path) == id
+def test_getters_oob_delete(fid_manager, test_path):
+    id = fid_manager.index(test_path)
+    os.rmdir(test_path)
+    print(fid_manager.con.execute("select * from Files").fetchall())
+    assert id is not None
+    assert fid_manager.get_id(test_path) == None
+    assert fid_manager.get_path(id) == None
+
+
+def test_get_id_unindexed(fid_manager, test_path_child):
+    assert fid_manager.get_id(test_path_child) == None
 
 
 # test out-of-band move detection for FIM.get_id()

--- a/tests/services/contents/test_fileidmanager.py
+++ b/tests/services/contents/test_fileidmanager.py
@@ -1,63 +1,122 @@
 import os
+import shutil
+from pathlib import Path
+
+import pytest
 
 
-def test_index(fid_manager):
-    path = os.path.join("path", "to", "file")
-    id = fid_manager.index(path)
+@pytest.fixture
+def test_path(tmp_path):
+    path = os.path.join(tmp_path, "test_path")
+    os.mkdir(path)
+    return path
+
+
+@pytest.fixture
+def test_path_child(test_path):
+    path = os.path.join(test_path, "child")
+    Path(path).touch()
+    return path
+
+
+@pytest.fixture
+def old_path(tmp_path):
+    """Fixture for source path to be moved/copied via FID manager"""
+    path = os.path.join(tmp_path, "old_path")
+    os.mkdir(path)
+    return path
+
+
+@pytest.fixture
+def old_path_child(old_path):
+    path = os.path.join(old_path, "child")
+    Path(path).touch()
+    return path
+
+
+@pytest.fixture
+def new_path(tmp_path):
+    """Fixture for destination path for a FID manager move/copy operation"""
+    return os.path.join(tmp_path, "new_path")
+
+
+@pytest.fixture
+def new_path_child(new_path):
+    return os.path.join(new_path, "child")
+
+
+def test_index(fid_manager, test_path):
+    id = fid_manager.index(test_path)
     assert id is not None
 
 
-def test_index_already_indexed(fid_manager):
-    path = os.path.join("path", "to", "file")
-    id = fid_manager.index(path)
-    assert id == fid_manager.index(path)
+def test_index_already_indexed(fid_manager, test_path):
+    id = fid_manager.index(test_path)
+    assert id == fid_manager.index(test_path)
 
 
-def test_getters_indexed(fid_manager):
-    path = os.path.join("path", "to", "file")
+def test_getters_indexed(fid_manager, test_path):
+    id = fid_manager.index(test_path)
 
-    id = fid_manager.index(path)
-    id = fid_manager.index(path)
-
-    assert fid_manager.get_id(path) == id
-    assert fid_manager.get_path(id) == path
+    assert fid_manager.get_id(test_path) == id
+    assert fid_manager.get_path(id) == test_path
 
 
-def test_getters_unindexed(fid_manager):
-    path = os.path.join("path", "to", "file")
+def test_getters_unindexed(fid_manager, test_path):
     id = 1
 
-    assert fid_manager.get_id(path) == None
+    assert fid_manager.get_id(test_path) == None
     assert fid_manager.get_path(id) == None
 
 
-def test_getters_nonnormalized(fid_manager):
-    path1 = os.path.join("dir", "something", "..", "file")
-    path2 = os.path.join("dir", "file")
-    path3 = os.path.join("dir", ".", ".", ".", "file")
+def test_getters_nonnormalized(fid_manager, test_path):
+    path1 = os.path.join(test_path, "file")
+    path2 = os.path.join(test_path, "some_dir", "..", "file")
+    path3 = os.path.join(test_path, ".", ".", ".", "file")
+    Path(path1).touch()
 
     id = fid_manager.index(path1)
 
+    assert fid_manager.get_id(path1) == id
     assert fid_manager.get_id(path2) == id
     assert fid_manager.get_id(path3) == id
 
 
-def test_move_unindexed(fid_manager):
-    old_path = os.path.join("old", "path")
-    new_path = os.path.join("new", "path")
+# test out-of-band move detection for FIM.index()
+def test_index_oob_move(fid_manager, old_path, new_path):
+    id = fid_manager.index(old_path)
+    os.rename(old_path, new_path)
+    assert fid_manager.index(new_path) == id
 
-    id = fid_manager.move(old_path, new_path)
 
-    assert fid_manager.get_id(old_path) is None
-    assert fid_manager.get_id(new_path) is id
+# test out-of-band move detection for FIM.get_id()
+def test_get_id_oob_move(fid_manager, old_path, new_path):
+    id = fid_manager.index(old_path)
+    os.rename(old_path, new_path)
+    assert fid_manager.get_id(new_path) == id
+
+
+def test_get_path_oob_move(fid_manager, old_path, new_path):
+    id = fid_manager.index(old_path)
+    os.rename(old_path, new_path)
     assert fid_manager.get_path(id) == new_path
 
 
-def test_move_indexed(fid_manager):
-    old_path = os.path.join("old", "path")
-    new_path = os.path.join("new", "path")
+def test_move_unindexed(fid_manager, old_path, new_path):
+    os.rename(old_path, new_path)
+    id = fid_manager.move(old_path, new_path)
 
+    assert id is not None
+    assert fid_manager.get_id(old_path) is None
+    assert fid_manager.get_id(new_path) is id
+    print(fid_manager.con.execute("SELECT * FROM Files").fetchall())
+    assert fid_manager.get_path(id) == new_path
+
+
+def test_move_indexed(fid_manager, old_path, new_path):
     old_id = fid_manager.index(old_path)
+
+    os.rename(old_path, new_path)
     new_id = fid_manager.move(old_path, new_path)
 
     assert old_id == new_id
@@ -66,23 +125,17 @@ def test_move_indexed(fid_manager):
     assert fid_manager.get_path(old_id) == new_path
 
 
-def test_move_recursive(fid_manager):
-    old_path = os.path.join("old", "path")
-    old_path_child = os.path.join(old_path, "child")
-    new_path = os.path.join("new", "path")
-    expected_new_path_child = os.path.join(new_path, "child")
-
+def test_move_recursive(fid_manager, old_path, old_path_child, new_path, new_path_child):
+    os.rename(old_path, new_path)
     fid_manager.index(old_path)
     child_id = fid_manager.index(old_path_child)
     fid_manager.move(old_path, new_path, recursive=True)
 
-    assert fid_manager.get_id(expected_new_path_child) == child_id
+    assert fid_manager.get_id(new_path_child) == child_id
 
 
-def test_copy(fid_manager):
-    old_path = os.path.join("old", "path")
-    new_path = os.path.join("new", "path")
-
+def test_copy(fid_manager, old_path, new_path):
+    shutil.copytree(old_path, new_path)
     new_id = fid_manager.copy(old_path, new_path)
     old_id = fid_manager.get_id(old_path)
 
@@ -91,35 +144,31 @@ def test_copy(fid_manager):
     assert old_id != new_id
 
 
-def test_copy_recursive(fid_manager):
-    from_path = os.path.join("from", "path")
-    from_path_child = os.path.join(from_path, "child")
-    to_path = os.path.join("to", "path")
-    expected_to_path_child = os.path.join(to_path, "child")
+def test_copy_recursive(fid_manager, old_path, old_path_child, new_path, new_path_child):
+    fid_manager.index(old_path)
+    fid_manager.index(old_path_child)
 
-    fid_manager.index(from_path)
-    fid_manager.index(from_path_child)
-    fid_manager.copy(from_path, to_path, recursive=True)
+    shutil.copytree(old_path, new_path)
+    fid_manager.copy(old_path, new_path, recursive=True)
 
-    assert fid_manager.get_id(expected_to_path_child) is not None
+    assert fid_manager.get_id(new_path_child) is not None
 
 
-def test_delete(fid_manager):
-    path = os.path.join("path", "to", "file")
+def test_delete(fid_manager, test_path):
+    id = fid_manager.index(test_path)
 
-    id = fid_manager.index(path)
-    fid_manager.delete(path)
+    shutil.rmtree(test_path)
+    fid_manager.delete(test_path)
 
-    assert fid_manager.get_id(path) is None
+    assert fid_manager.get_id(test_path) is None
     assert fid_manager.get_path(id) is None
 
 
-def test_delete_recursive(fid_manager):
-    path = "path"
-    path_child = os.path.join(path, "child")
+def test_delete_recursive(fid_manager, test_path, test_path_child):
+    fid_manager.index(test_path)
+    fid_manager.index(test_path_child)
 
-    fid_manager.index(path)
-    fid_manager.index(path_child)
-    fid_manager.delete(path, recursive=True)
+    shutil.rmtree(test_path)
+    fid_manager.delete(test_path, recursive=True)
 
-    assert fid_manager.get_id(path_child) is None
+    assert fid_manager.get_id(test_path_child) is None

--- a/tests/services/contents/test_fileidmanager.py
+++ b/tests/services/contents/test_fileidmanager.py
@@ -1,0 +1,125 @@
+import os
+
+
+def test_index(fid_manager):
+    path = os.path.join("path", "to", "file")
+    id = fid_manager.index(path)
+    assert id is not None
+
+
+def test_index_already_indexed(fid_manager):
+    path = os.path.join("path", "to", "file")
+    id = fid_manager.index(path)
+    assert id == fid_manager.index(path)
+
+
+def test_getters_indexed(fid_manager):
+    path = os.path.join("path", "to", "file")
+
+    id = fid_manager.index(path)
+    id = fid_manager.index(path)
+
+    assert fid_manager.get_id(path) == id
+    assert fid_manager.get_path(id) == path
+
+
+def test_getters_unindexed(fid_manager):
+    path = os.path.join("path", "to", "file")
+    id = 1
+
+    assert fid_manager.get_id(path) == None
+    assert fid_manager.get_path(id) == None
+
+
+def test_getters_nonnormalized(fid_manager):
+    path1 = os.path.join("dir", "something", "..", "file")
+    path2 = os.path.join("dir", "file")
+    path3 = os.path.join("dir", ".", ".", ".", "file")
+
+    id = fid_manager.index(path1)
+
+    assert fid_manager.get_id(path2) == id
+    assert fid_manager.get_id(path3) == id
+
+
+def test_move_unindexed(fid_manager):
+    old_path = os.path.join("old", "path")
+    new_path = os.path.join("new", "path")
+
+    id = fid_manager.move(old_path, new_path)
+
+    assert fid_manager.get_id(old_path) is None
+    assert fid_manager.get_id(new_path) is id
+    assert fid_manager.get_path(id) == new_path
+
+
+def test_move_indexed(fid_manager):
+    old_path = os.path.join("old", "path")
+    new_path = os.path.join("new", "path")
+
+    old_id = fid_manager.index(old_path)
+    new_id = fid_manager.move(old_path, new_path)
+
+    assert old_id == new_id
+    assert fid_manager.get_id(old_path) is None
+    assert fid_manager.get_id(new_path) is new_id
+    assert fid_manager.get_path(old_id) == new_path
+
+
+def test_move_recursive(fid_manager):
+    old_path = os.path.join("old", "path")
+    old_path_child = os.path.join(old_path, "child")
+    new_path = os.path.join("new", "path")
+    expected_new_path_child = os.path.join(new_path, "child")
+
+    fid_manager.index(old_path)
+    child_id = fid_manager.index(old_path_child)
+    fid_manager.move(old_path, new_path, recursive=True)
+
+    assert fid_manager.get_id(expected_new_path_child) == child_id
+
+
+def test_copy(fid_manager):
+    old_path = os.path.join("old", "path")
+    new_path = os.path.join("new", "path")
+
+    new_id = fid_manager.copy(old_path, new_path)
+    old_id = fid_manager.get_id(old_path)
+
+    assert old_id is not None
+    assert new_id is not None
+    assert old_id != new_id
+
+
+def test_copy_recursive(fid_manager):
+    from_path = os.path.join("from", "path")
+    from_path_child = os.path.join(from_path, "child")
+    to_path = os.path.join("to", "path")
+    expected_to_path_child = os.path.join(to_path, "child")
+
+    fid_manager.index(from_path)
+    fid_manager.index(from_path_child)
+    fid_manager.copy(from_path, to_path, recursive=True)
+
+    assert fid_manager.get_id(expected_to_path_child) is not None
+
+
+def test_delete(fid_manager):
+    path = os.path.join("path", "to", "file")
+
+    id = fid_manager.index(path)
+    fid_manager.delete(path)
+
+    assert fid_manager.get_id(path) is None
+    assert fid_manager.get_path(id) is None
+
+
+def test_delete_recursive(fid_manager):
+    path = "path"
+    path_child = os.path.join(path, "child")
+
+    fid_manager.index(path)
+    fid_manager.index(path_child)
+    fid_manager.delete(path, recursive=True)
+
+    assert fid_manager.get_id(path_child) is None


### PR DESCRIPTION
# Overview

Draft implementation of File ID service proposed [here](https://github.com/jupyterlab/jupyterlab/issues/12614).

File ID Service maintains a bi-directional mapping between file IDs and file names. This service permits bi-directional lookup, and preserves file ID across filesystem operations done through the `ContentsManager`.

- Adds `FileIdManager` class with assoc. unit tests
- Integrates `FileIdManager` methods into `ContentsManager` and `AsyncContentsManager` filesystem methods
- Appends `id` property that contains the file ID to the Contents API [GET/POST/PUT/PATCH /api/contents/{path}](https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html) operations.
- Adds benchmark under `jupyter_server/benchmarks/fileidmanager_benchmark.py`.

## Testing

To test with JupyterLab stable, developers can run the following in a separate `conda` environment:

```
git clone git@github.com:jupyter-server/jupyter_server.git
cd jupyter_server/
git remote add dlqqq git@github.com:dlqqq/jupyter_server.git
git pull dlqqq file-id-service
pip install jupyterlab
pip install -e ".[dev,test]"
```

## Benchmarks

To run File ID Manager benchmark:

```
python jupyter_server/benchmarks/fileidmanager_benchmark.py
```

Benchmarks run on `m5.12xlarge` AWS EC2 instance.

```
% python jupyter_server/benchmarks/fileidmanager_benchmark.py
Index benchmark (separate transactions)
100       files | 0.2932   s
1,000     files | 2.9968   s
Index benchmark (single transaction, atomic INSERTs)
100       files | 0.0032   s
1,000     files | 0.0072   s
10,000    files | 0.0362   s
100,000   files | 0.3430   s
1,000,000 files | 3.5570   s
Index benchmark (single transaction, batched INSERTs)
100       files | 0.2897   s
1,000     files | 0.2663   s
10,000    files | 0.2613   s
100,000   files | 0.2678   s
1,000,000 files | 2.7359   s
Recursive move benchmark
100       files | 0.0065   s
1,000     files | 0.0093   s
10,000    files | 0.0370   s
100,000   files | 0.3499   s
1,000,000 files | 3.6639   s
Recursive copy benchmark
100       files | 0.0106   s
1,000     files | 0.0121   s
10,000    files | 0.0233   s
100,000   files | 0.1632   s
1,000,000 files | 1.5505   s
Recursive delete benchmark
100       files | 0.0033   s
1,000     files | 0.0047   s
10,000    files | 0.0150   s
100,000   files | 0.1359   s
1,000,000 files | 1.4314   s
```
