### PR TITLE
Improve logging of bare exceptions and other cleanups.

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -99,7 +99,7 @@ class AuthenticatedHandler(web.RequestHandler):
                 # tornado raise Exception (not a subclass)
                 # if method is unsupported (websocket and Access-Control-Allow-Origin
                 # for example, so just ignore)
-                self.log.debug(e)
+                self.log.exception("Could not set default headers: %s", e)
 
     @property
     def cookie_name(self):
@@ -723,7 +723,7 @@ class APIHandler(JupyterHandler):
                 reply["message"] = "Unhandled error"
                 reply["reason"] = None
                 reply["traceback"] = "".join(traceback.format_exception(*exc_info))
-        self.log.warning(reply["message"])
+        self.log.warning("wrote error: %r", reply["message"])
         self.finish(json.dumps(reply))
 
     def get_login_url(self):

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -227,15 +227,15 @@ class MappingKernelManager(MultiKernelManager):
             kernel.execution_state = "starting"
             kernel.reason = ""
             kernel.last_activity = utcnow()
-            self.log.info("Kernel started: %s" % kernel_id)
-            self.log.debug("Kernel args: %r" % kwargs)
+            self.log.info("Kernel started: %s", kernel_id)
+            self.log.debug("Kernel args: %r", kwargs)
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1
             KERNEL_CURRENTLY_RUNNING_TOTAL.labels(type=self._kernels[kernel_id].kernel_name).inc()
 
         else:
-            self.log.info("Using existing kernel: %s" % kernel_id)
+            self.log.info("Using existing kernel: %s", kernel_id)
 
         # Initialize culling if not already
         if not self._initialized_culler:
@@ -248,8 +248,8 @@ class MappingKernelManager(MultiKernelManager):
         if hasattr(km, "ready"):
             try:
                 await km.ready
-            except Exception as e:
-                self.log.exception(e)
+            except Exception:
+                self.log.exception("Error waiting for kernel manager ready")
                 return
 
         self._kernel_ports[kernel_id] = km.ports
@@ -276,7 +276,7 @@ class MappingKernelManager(MultiKernelManager):
         changed_ports = self._get_changed_ports(kernel_id)
         if changed_ports:
             # If changed, update captured ports and return True, else return False.
-            self.log.debug(f"Port change detected for kernel: {kernel_id}")
+            self.log.debug("Port change detected for kernel: %s", kernel_id)
             self._kernel_ports[kernel_id] = changed_ports
             return True
         return False

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -163,10 +163,10 @@ def test_stop_extension(jp_serverapp, caplog):
     run_sync(jp_serverapp.cleanup_extensions())
     assert {msg for *_, msg in caplog.record_tuples} == {
         "Shutting down 2 extensions",
-        'jupyter_server_terminals | extension app "jupyter_server_terminals" stopping',
-        f'{extension_name} | extension app "mockextension" stopping',
-        'jupyter_server_terminals | extension app "jupyter_server_terminals" stopped',
-        f'{extension_name} | extension app "mockextension" stopped',
+        "jupyter_server_terminals | extension app 'jupyter_server_terminals' stopping",
+        f"{extension_name} | extension app 'mockextension' stopping",
+        "jupyter_server_terminals | extension app 'jupyter_server_terminals' stopped",
+        f"{extension_name} | extension app 'mockextension' stopped",
     }
 
     # check the shutdown method was called twice


### PR DESCRIPTION
This change finds a few places where `log.[somelevel](some_exc)`
was called and rewrites them to provide more information. Also updates
other logging statements in the same files to use logging best practices
(always put a static message in the first parameter, only substitute
variables in with `%` expressions).