### PR TITLE
documentation correction

### DIFF
--- a/docs/source/operators/security.rst
+++ b/docs/source/operators/security.rst
@@ -101,7 +101,7 @@ as all requests requiring _authorization_ must first complete _authentication_.
 Identity Providers
 ******************
 
-The :class:`.IdentityProvider` class is responsible for the "authorization" step,
+The :class:`.IdentityProvider` class is responsible for the "authentication" step,
 identifying the user making the request,
 and constructing information about them.
 


### PR DESCRIPTION
If I'm reading this `The first step is "Authentication" (identifying who is making the request). This is handled by the :class:`.IdentityProvider`.` correctly,  I believe IdentityProvider is responsible for _authentication_, rather than _authorization_