### PR TITLE
avoid creating asyncio.Lock at import time

### DIFF
--- a/jupyter_server/services/nbconvert/handlers.py
+++ b/jupyter_server/services/nbconvert/handlers.py
@@ -11,11 +11,16 @@ from ...base.handlers import APIHandler
 AUTH_RESOURCE = "nbconvert"
 
 
-LOCK = asyncio.Lock()
-
-
 class NbconvertRootHandler(APIHandler):
     auth_resource = AUTH_RESOURCE
+    _exporter_lock: asyncio.Lock
+
+    def initialize(self, **kwargs):
+        super().initialize(**kwargs)
+        # share lock across instances of this handler class
+        if not hasattr(self.__class__, "_exporter_lock"):
+            self.__class__._exporter_lock = asyncio.Lock()
+        self._exporter_lock = self.__class__._exporter_lock
 
     @web.authenticated
     @authorized
@@ -28,22 +33,22 @@ class NbconvertRootHandler(APIHandler):
         # Some exporters use the filesystem when instantiating, delegate that
         # to a thread so we don't block the event loop for it.
         exporters = await run_sync(base.get_export_names)
-        for exporter_name in exporters:
-            try:
-                async with LOCK:
+        async with self._exporter_lock:
+            for exporter_name in exporters:
+                try:
                     exporter_class = await run_sync(base.get_exporter, exporter_name)
-            except ValueError:
-                # I think the only way this will happen is if the entrypoint
-                # is uninstalled while this method is running
-                continue
-            # XXX: According to the docs, it looks like this should be set to None
-            # if the exporter shouldn't be exposed to the front-end and a friendly
-            # name if it should. However, none of the built-in exports have it defined.
-            # if not exporter_class.export_from_notebook:
-            #    continue
-            res[exporter_name] = {
-                "output_mimetype": exporter_class.output_mimetype,
-            }
+                except ValueError:
+                    # I think the only way this will happen is if the entrypoint
+                    # is uninstalled while this method is running
+                    continue
+                # XXX: According to the docs, it looks like this should be set to None
+                # if the exporter shouldn't be exposed to the front-end and a friendly
+                # name if it should. However, none of the built-in exports have it defined.
+                # if not exporter_class.export_from_notebook:
+                #    continue
+                res[exporter_name] = {
+                    "output_mimetype": exporter_class.output_mimetype,
+                }
 
         self.finish(json.dumps(res))
 


### PR DESCRIPTION
asyncio.Lock references the current event loop, but there usually isn't one at import time. The result is that importing this handler always instantiates a current loop and attaches a lock to it, which may or may not be the loop that ultimately runs (app.io_loop).

Instead, create lock and attach it to the Handler class upon initializing the first handler of the class, which is always run inside the loop.

Also related to #876