### PR TITLE
Fix error that prevents posting to `api/contents` endpoint with no body

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -208,28 +208,23 @@ class ContentsHandler(ContentsAPIHandler):
             raise web.HTTPError(400, "Cannot POST to files, use PUT instead.")
 
         model = self.get_json_body()
-        copy_from = model.get("copy_from")
-        if (
-            copy_from
-            and (
-                await ensure_async(cm.is_hidden(path))
-                or await ensure_async(cm.is_hidden(copy_from))
-            )
-            and not cm.allow_hidden
-        ):
-            raise web.HTTPError(400, f"Cannot copy file or directory {path!r}")
-
-        if model is not None:
+        if model:
             copy_from = model.get("copy_from")
+            if copy_from:
+                if not cm.allow_hidden and (
+                    await ensure_async(cm.is_hidden(path))
+                    or await ensure_async(cm.is_hidden(copy_from))
+                ):
+                    raise web.HTTPError(400, f"Cannot copy file or directory {path!r}")
+                else:
+                    await self._copy(copy_from, path)
+
             ext = model.get("ext", "")
             type = model.get("type", "")
             if type not in {None, "", "directory", "file", "notebook"}:
                 # fall back to file if unknown type
                 type = "file"
-            if copy_from:
-                await self._copy(copy_from, path)
-            else:
-                await self._new_untitled(path, type=type, ext=ext)
+            await self._new_untitled(path, type=type, ext=ext)
         else:
             await self._new_untitled(path)
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -349,6 +349,10 @@ async def test_create_untitled(jp_fetch, contents, contents_dir, _check_created)
     r = await jp_fetch("api", "contents", path, method="POST", body=json.dumps({"ext": ".ipynb"}))
     _check_created(r, str(contents_dir), path, name, type="notebook")
 
+    name = "untitled"
+    r = await jp_fetch("api", "contents", path, method="POST", allow_nonstandard_methods=True)
+    _check_created(r, str(contents_dir), path, name=name, type="file")
+
 
 async def test_create_untitled_txt(jp_fetch, contents, contents_dir, _check_created):
     name = "untitled.txt"


### PR DESCRIPTION
Fixes #931 

This is a small refactor to avoid a 'NoneType' `AttributeError` when sending a POST request to `api/contents` that does not include a body. 

A body-less POST to the `api/contents/{path}` endpoint is also added to `services/contents/test_api.py:test_create_untitled`.