### PR TITLE
Fix bug in `api/contents` requests for an allowed copy

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -218,13 +218,13 @@ class ContentsHandler(ContentsAPIHandler):
                     raise web.HTTPError(400, f"Cannot copy file or directory {path!r}")
                 else:
                     await self._copy(copy_from, path)
-
-            ext = model.get("ext", "")
-            type = model.get("type", "")
-            if type not in {None, "", "directory", "file", "notebook"}:
-                # fall back to file if unknown type
-                type = "file"
-            await self._new_untitled(path, type=type, ext=ext)
+            else:
+                ext = model.get("ext", "")
+                type = model.get("type", "")
+                if type not in {None, "", "directory", "file", "notebook"}:
+                    # fall back to file if unknown type
+                    type = "file"
+                await self._new_untitled(path, type=type, ext=ext)
         else:
             await self._new_untitled(path)
 


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/jupyter-server/jupyter_server/pull/937/files#r935733455), #937 introduced a bug in `api/contents` POST `copy_from` requests, leading to both `_copy` and a `_new_untitled` executing for an allowed copy. This PR fixes that bug by adding the `else` clause for the `copy_from` block.

Tested manually to ensure no `untitled` file is created on duplicate or copy/paste.