### PR TITLE
Parse list value for `terminado_settings`

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -75,6 +75,7 @@ from traitlets import (
     TraitError,
     Type,
     Unicode,
+    Union,
     default,
     observe,
     validate,
@@ -1318,7 +1319,7 @@ class ServerApp(JupyterApp):
         ),
     )
     terminado_settings = Dict(
-        List(),
+        Union([List(), Unicode()]),
         config=True,
         help=_i18n('Supply overrides for terminado. Currently only supports "shell_command".'),
     )

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1318,6 +1318,7 @@ class ServerApp(JupyterApp):
         ),
     )
     terminado_settings = Dict(
+        List(),
         config=True,
         help=_i18n('Supply overrides for terminado. Currently only supports "shell_command".'),
     )

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import shlex
 import shutil
 import sys
 
@@ -263,17 +264,11 @@ async def test_culling(jp_server_config, jp_fetch):
 @pytest.mark.parametrize(
     "terminado_settings,expected_shell",
     [
-        ("shell_command=['/path/to/shell', '-l']", ["/path/to/shell", "-l"]),
+        ("shell_command=\"['/path/to/shell', '-l']\"", ["/path/to/shell", "-l"]),
+        ('shell_command="/string/path/to/shell -l"', ["/string/path/to/shell", "-l"]),
     ],
 )
 def test_shell_command_override(terminado_settings, expected_shell, jp_configurable_serverapp):
-    argv = []
-    kwargs = {"root_dir": None}
-
-    argv.append(f"--ServerApp.terminado_settings={terminado_settings}")
-
-    if argv:
-        kwargs["argv"] = argv  # type:ignore
-
-        app = jp_configurable_serverapp(**kwargs)
-        assert app.web_app.settings["terminal_manager"].shell_command == expected_shell
+    argv = shlex.split(f"--ServerApp.terminado_settings={terminado_settings}")
+    app = jp_configurable_serverapp(argv=argv)
+    assert app.web_app.settings["terminal_manager"].shell_command == expected_shell

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -262,13 +262,16 @@ async def test_culling(jp_server_config, jp_fetch):
 
 
 @pytest.mark.parametrize(
-    "terminado_settings,expected_shell",
+    "terminado_settings,expected_shell,min_traitlets",
     [
-        ("shell_command=\"['/path/to/shell', '-l']\"", ["/path/to/shell", "-l"]),
-        ('shell_command="/string/path/to/shell -l"', ["/string/path/to/shell", "-l"]),
+        ("shell_command=\"['/path/to/shell', '-l']\"", ["/path/to/shell", "-l"], "5.4"),
+        ('shell_command="/string/path/to/shell -l"', ["/string/path/to/shell", "-l"], "5.1"),
     ],
 )
-def test_shell_command_override(terminado_settings, expected_shell, jp_configurable_serverapp):
+def test_shell_command_override(
+    terminado_settings, expected_shell, min_traitlets, jp_configurable_serverapp
+):
+    pytest.importorskip("traitlets", minversion=min_traitlets)
     argv = shlex.split(f"--ServerApp.terminado_settings={terminado_settings}")
     app = jp_configurable_serverapp(argv=argv)
     assert app.web_app.settings["terminal_manager"].shell_command == expected_shell

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -258,3 +258,22 @@ async def test_culling(jp_server_config, jp_fetch):
             await asyncio.sleep(1)
 
     assert culled
+
+
+@pytest.mark.parametrize(
+    "terminado_settings,expected_shell",
+    [
+        ("shell_command=['/path/to/shell', '-l']", ["/path/to/shell", "-l"]),
+    ],
+)
+def test_shell_command_override(terminado_settings, expected_shell, jp_configurable_serverapp):
+    argv = []
+    kwargs = {"root_dir": None}
+
+    argv.append(f"--ServerApp.terminado_settings={terminado_settings}")
+
+    if argv:
+        kwargs["argv"] = argv  # type:ignore
+
+        app = jp_configurable_serverapp(**kwargs)
+        assert app.web_app.settings["terminal_manager"].shell_command == expected_shell


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/12540. Allows configuring `terminado_settings` from command line with:

```
--ServerApp.terminado_settings="shell_command=['/bin/zsh']"
```

or if users are willing to accept the default tokenization by `shlex.split` with:

```
--ServerApp.terminado_settings="shell_command='/bin/zsh'"
```

Are there tests for configuration settings?

For context it is used in: [`jupyter_server_terminals`](https://github.com/jupyter-server/jupyter_server_terminals/blob/b8fea6404b8b5e5ee6ea8d69d3b680ee440e0508/jupyter_server_terminals/app.py#L44)