### PR TITLE
Headless/Scheduled Notebooks

### DIFF
--- a/jupyter_server/services/scheduling/__init__.py
+++ b/jupyter_server/services/scheduling/__init__.py
@@ -1,10 +1,8 @@
 """Scheduling API for JupyterLab"""
 from .extension import SchedulerApp
+
 __version__ = "0.1.0"
 
 
 def _jupyter_server_extension_points():
-    return [{
-        "module": "jupyter_scheduling",
-        "app": SchedulerApp
-    }]
+    return [{"module": "jupyter_scheduling", "app": SchedulerApp}]

--- a/jupyter_server/services/scheduling/__init__.py
+++ b/jupyter_server/services/scheduling/__init__.py
@@ -1,0 +1,10 @@
+"""Scheduling API for JupyterLab"""
+from .extension import SchedulerApp
+__version__ = "0.1.0"
+
+
+def _jupyter_server_extension_points():
+    return [{
+        "module": "jupyter_scheduling",
+        "app": SchedulerApp
+    }]

--- a/jupyter_server/services/scheduling/config.py
+++ b/jupyter_server/services/scheduling/config.py
@@ -1,0 +1,16 @@
+
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExecutionConfig:
+    """
+    Config values passed to the 
+    execution manager and scheduler
+    """
+    db_url: str
+    root_dir: str
+    execution_manager_class: any
+    environments_manager_class: any
+    scheduler_class: any

--- a/jupyter_server/services/scheduling/config.py
+++ b/jupyter_server/services/scheduling/config.py
@@ -1,14 +1,13 @@
-
-
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class ExecutionConfig:
     """
-    Config values passed to the 
+    Config values passed to the
     execution manager and scheduler
     """
+
     db_url: str
     root_dir: str
     execution_manager_class: any

--- a/jupyter_server/services/scheduling/environments.py
+++ b/jupyter_server/services/scheduling/environments.py
@@ -1,0 +1,82 @@
+
+from abc import ABC, abstractmethod
+import json
+import os
+import subprocess
+from typing import List
+from jupyter_scheduling.models import OutputFormat, RuntimeEnvironment
+
+
+class EnvironmentManager(ABC):
+
+    @abstractmethod
+    def list_environments() -> List[RuntimeEnvironment]:
+        pass
+
+    @abstractmethod
+    def manage_environments_command(self) -> str:
+        pass
+
+
+class CondaEnvironmentManager(EnvironmentManager):
+    """Provides list of system installed conda environments"""
+    
+    def list_environments(self) ->  List[RuntimeEnvironment]:
+        environments = []
+
+        try:
+            envs = subprocess.check_output(["conda", "env", "list", "--json"])
+            envs = json.loads(envs).get("envs", [])
+        except subprocess.CalledProcessError as e:
+            raise EnvironmentRetrievalError(e) from e
+
+        for env in envs:
+            name = os.path.basename(env)
+            environments.append(
+                RuntimeEnvironment(
+                    name=name,
+                    label=name,
+                    description=f"Conda environment: {name}",
+                    file_extensions=["ipynb", "py"],
+                    output_formats=[
+                        OutputFormat(
+                            name="ipynb",
+                            label="Notebook"
+                        ),
+                        OutputFormat(
+                            name="html",
+                            label="HTML"
+                        )
+                    ],
+                    metadata={"path": env}
+                )
+            )
+
+        return environments
+
+    def manage_environments_command(self) -> str:
+        return ""
+
+
+class StaticEnvironmentManager(EnvironmentManager):
+    """Provides a static list of environments, for demo purpose only"""
+
+    def list_environments(self) -> List[RuntimeEnvironment]:
+        name = "jupyterlab-env"
+        path = os.path.join(os.environ['HOME'], name)
+        return [
+            RuntimeEnvironment(
+                name=name,
+                label=name,
+                description=f"Virtual environment: {name}",
+                file_extensions=["ipynb", "py"],
+                metadata={"path": path}
+            )
+        ]
+
+    def manage_environments_command(self) -> str:
+        return ""
+
+
+class EnvironmentRetrievalError(Exception):
+    pass

--- a/jupyter_server/services/scheduling/environments.py
+++ b/jupyter_server/services/scheduling/environments.py
@@ -1,14 +1,13 @@
-
-from abc import ABC, abstractmethod
 import json
 import os
 import subprocess
+from abc import ABC, abstractmethod
 from typing import List
+
 from jupyter_scheduling.models import OutputFormat, RuntimeEnvironment
 
 
 class EnvironmentManager(ABC):
-
     @abstractmethod
     def list_environments() -> List[RuntimeEnvironment]:
         pass
@@ -20,8 +19,8 @@ class EnvironmentManager(ABC):
 
 class CondaEnvironmentManager(EnvironmentManager):
     """Provides list of system installed conda environments"""
-    
-    def list_environments(self) ->  List[RuntimeEnvironment]:
+
+    def list_environments(self) -> List[RuntimeEnvironment]:
         environments = []
 
         try:
@@ -39,16 +38,10 @@ class CondaEnvironmentManager(EnvironmentManager):
                     description=f"Conda environment: {name}",
                     file_extensions=["ipynb", "py"],
                     output_formats=[
-                        OutputFormat(
-                            name="ipynb",
-                            label="Notebook"
-                        ),
-                        OutputFormat(
-                            name="html",
-                            label="HTML"
-                        )
+                        OutputFormat(name="ipynb", label="Notebook"),
+                        OutputFormat(name="html", label="HTML"),
                     ],
-                    metadata={"path": env}
+                    metadata={"path": env},
                 )
             )
 
@@ -63,14 +56,14 @@ class StaticEnvironmentManager(EnvironmentManager):
 
     def list_environments(self) -> List[RuntimeEnvironment]:
         name = "jupyterlab-env"
-        path = os.path.join(os.environ['HOME'], name)
+        path = os.path.join(os.environ["HOME"], name)
         return [
             RuntimeEnvironment(
                 name=name,
                 label=name,
                 description=f"Virtual environment: {name}",
                 file_extensions=["ipynb", "py"],
-                metadata={"path": path}
+                metadata={"path": path},
             )
         ]
 

--- a/jupyter_server/services/scheduling/executors.py
+++ b/jupyter_server/services/scheduling/executors.py
@@ -1,0 +1,191 @@
+from abc import ABC, abstractclassmethod, abstractmethod
+from datetime import datetime
+import os
+import traceback
+from typing import Dict, List
+
+import nbformat
+import nbconvert
+from nbconvert.preprocessors import ExecutePreprocessor
+from jupyter_scheduling.config import ExecutionConfig
+
+from jupyter_scheduling.models import DescribeJob, JobFeature, OutputFormat, Status
+from jupyter_scheduling.parameterize import add_parameters
+from jupyter_scheduling.utils import get_utc_timestamp, resolve_path
+from jupyter_scheduling.orm import Job, create_session
+
+
+class ExecutionManager(ABC):
+    """ Base execution manager.
+    Clients are expected to override this class
+    to provide concrete implementations of the
+    execution manager. At the minimum, subclasses
+    should provide concrete implementation of the 
+    execute method.
+    """
+    
+    _model = None
+    _db_session = None
+
+    def __init__(self, job_id: str, config: ExecutionConfig = {}):
+        self.job_id = job_id
+        self.root_dir = config.root_dir
+        self.config = config
+
+    @property
+    def model(self):
+        if self._model is None:
+            with self.db_session() as session:
+                job = session.query(Job).filter(
+                    Job.job_id == self.job_id
+                ).first()
+                self._model = DescribeJob.from_orm(job)
+        return self._model
+
+
+    @property
+    def db_session(self):
+        if self._db_session is None:
+            self._db_session = create_session(self.config.db_url)
+
+        return self._db_session
+        
+
+    # Don't override this method
+    def process(self):
+        self.before_start()
+        try:
+            self.execute()
+        except Exception as e:
+            self.on_failure(e)
+        else:
+            self.on_complete()
+
+    @abstractmethod
+    def execute(self):
+        pass
+
+    @classmethod
+    @abstractmethod
+    def supported_features(cls) -> Dict[JobFeature, bool]:
+        """Returns a configuration of supported features
+        by the execution engine. Implementors are expected
+        to override this to return a dictionary of supported
+        job creation features.
+        """
+        pass
+
+    def before_start(self):
+        """Called before start of execute"""
+        job = self.model
+        with self.db_session() as session:
+            session.query(Job).filter(
+                Job.job_id == job.job_id
+            ).update(
+                {
+                    "start_time": get_utc_timestamp(),
+                    "status": Status.IN_PROGRESS
+                }
+            )
+            session.commit()
+
+    def on_failure(self, e: Exception):
+        """Called after failure of execute"""
+        job = self.model
+        with self.db_session() as session:
+            session.query(Job).filter(
+                Job.job_id == job.job_id
+            ).update(
+                {
+                    "status": Status.FAILED,
+                    "status_message": str(e)
+                }
+            )
+            session.commit()
+
+        traceback.print_exc()
+
+    def on_complete(self):
+        """Called after job is completed"""
+        job = self.model
+        with self.db_session() as session:
+            session.query(Job).filter(
+                Job.job_id == job.job_id
+            ).update({
+                "status": Status.COMPLETED,
+                "end_time": get_utc_timestamp()
+            })
+            session.commit()
+
+
+class DefaultExecutionManager(ExecutionManager):
+    """Default execution manager that executes notebooks"""
+    def execute(self):
+        job = self.model
+        
+        output_dir = os.path.dirname(resolve_path(job.output_uri, self.root_dir))
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        with open(resolve_path(job.input_uri, self.root_dir)) as f:
+            nb = nbformat.read(f, as_version=4)
+
+        if job.parameters:
+            nb = add_parameters(nb, job.parameters)
+
+        ep = ExecutePreprocessor(
+            timeout=job.timeout_seconds, 
+            kernel_name=nb.metadata.kernelspec['name'],
+            store_widget_state=True
+        )
+
+        ep.preprocess(
+            nb, 
+            {
+                'metadata': {
+                    'path': os.path.dirname(
+                        resolve_path(job.output_uri, self.root_dir)
+                    )
+                }
+            }
+        )
+        
+        if job.output_formats:
+            filepath = resolve_path(job.output_uri, self.root_dir)
+            base_filepath = os.path.splitext(filepath)[-2]
+            for output_format in job.output_formats:
+                cls = nbconvert.get_exporter(output_format)
+                output, resources = cls().from_notebook_node(nb)
+                with open(
+                    f'{base_filepath}.{output_format}', 
+                    'w', 
+                    encoding='utf-8'
+                ) as f:
+                    f.write(output)
+        else:
+            with open(
+                resolve_path(job.output_uri, self.root_dir), 
+                'w', 
+                encoding='utf-8'
+            ) as f:
+                nbformat.write(nb, f)
+
+
+    def supported_features(cls) -> Dict[JobFeature, bool]:
+        return {
+            JobFeature.job_name: True,
+            JobFeature.output_formats: True,
+            JobFeature.job_definition: False,
+            JobFeature.idempotency_token: False,
+            JobFeature.tags: False,
+            JobFeature.email_notifications: False,
+            JobFeature.timeout_seconds: False,
+            JobFeature.retry_on_timeout: False,
+            JobFeature.max_retries: False,
+            JobFeature.min_retry_interval_millis: False,
+            JobFeature.output_filename_template: False,
+            JobFeature.stop_job: True,
+            JobFeature.delete_job: True
+        } 
+
+        

--- a/jupyter_server/services/scheduling/extension.py
+++ b/jupyter_server/services/scheduling/extension.py
@@ -1,21 +1,29 @@
-from jupyter_server.extension.application import ExtensionApp
-
+from jupyter_core.paths import jupyter_data_dir
 from jupyter_scheduling.orm import create_tables
 from jupyter_scheduling.scheduler import Scheduler
-from .handlers import BatchJobHandler, ConfigHandler, FeaturesHandler, JobDefinitionHandler, JobHandler, JobsCountHandler, RuntimeEnvironmentsHandler, CreateJobWithDefinitionHandler
-from .environments import CondaEnvironmentManager
-from .executors import DefaultExecutionManager
+from traitlets import Bool, Unicode, default
 
+from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.traittypes import TypeFromClasses
 from jupyter_server.transutils import _i18n
-from jupyter_core.paths import jupyter_data_dir
-from traitlets import Unicode, Bool, default
 
 from .config import ExecutionConfig
-
+from .environments import CondaEnvironmentManager
+from .executors import DefaultExecutionManager
+from .handlers import (
+    BatchJobHandler,
+    ConfigHandler,
+    CreateJobWithDefinitionHandler,
+    FeaturesHandler,
+    JobDefinitionHandler,
+    JobHandler,
+    JobsCountHandler,
+    RuntimeEnvironmentsHandler,
+)
 
 JOB_DEFINITION_ID_REGEX = r"(?P<job_definition_id>\w+-\w+-\w+-\w+-\w+)"
 JOB_ID_REGEX = r"(?P<job_id>\w+-\w+-\w+-\w+-\w+)"
+
 
 class SchedulerApp(ExtensionApp):
     name = "jupyter_scheduling"
@@ -29,19 +37,12 @@ class SchedulerApp(ExtensionApp):
         (r"/runtime_environments", RuntimeEnvironmentsHandler),
         (r"/scheduler/features", FeaturesHandler),
         (r"/scheduler/config", ConfigHandler),
-        (r"/batch/jobs", BatchJobHandler)
+        (r"/batch/jobs", BatchJobHandler),
     ]
 
-    drop_tables = Bool(
-        False, 
-        config=True, 
-        help="Drop the database tables before starting."
-    )
+    drop_tables = Bool(False, config=True, help="Drop the database tables before starting.")
 
-    db_url = Unicode(
-        config=True,
-        help="URI for the scheduler database"
-    )
+    db_url = Unicode(config=True, help="URI for the scheduler database")
 
     @default("db_url")
     def get_demo_db_url_default(self):
@@ -49,43 +50,36 @@ class SchedulerApp(ExtensionApp):
 
     environment_manager_class = TypeFromClasses(
         default_value=CondaEnvironmentManager,
-        klasses=[
-            "jupyter_scheduling.environments.EnvironmentManager"
-        ],
+        klasses=["jupyter_scheduling.environments.EnvironmentManager"],
         config=True,
-        help=_i18n("The runtime environment manager class to use.")
+        help=_i18n("The runtime environment manager class to use."),
     )
-
 
     execution_manager_class = TypeFromClasses(
         default_value=DefaultExecutionManager,
-        klasses=[
-            "jupyter_scheduling.executors.ExecutionManager"
-        ],
+        klasses=["jupyter_scheduling.executors.ExecutionManager"],
         config=True,
-        help=_i18n("The execution manager class to use.")
+        help=_i18n("The execution manager class to use."),
     )
 
     scheduler_class = TypeFromClasses(
         default_value=Scheduler,
-        klasses=[
-            "jupyter_scheduling.scheduler.BaseScheduler"
-        ],
+        klasses=["jupyter_scheduling.scheduler.BaseScheduler"],
         config=True,
-        help=_i18n("The scheduler class to use.")
+        help=_i18n("The scheduler class to use."),
     )
 
     def initialize_settings(self):
         super().initialize_settings()
-        
+
         create_tables(self.db_url, self.drop_tables)
-        
+
         self.settings.update(
             execution_config=ExecutionConfig(
                 db_url=self.db_url,
                 execution_manager_class=self.execution_manager_class,
                 environments_manager_class=self.environment_manager_class,
                 scheduler_class=self.scheduler_class,
-                root_dir=self.settings.get("server_root_dir", None)
+                root_dir=self.settings.get("server_root_dir", None),
             )
         )

--- a/jupyter_server/services/scheduling/extension.py
+++ b/jupyter_server/services/scheduling/extension.py
@@ -1,0 +1,91 @@
+from jupyter_server.extension.application import ExtensionApp
+
+from jupyter_scheduling.orm import create_tables
+from jupyter_scheduling.scheduler import Scheduler
+from .handlers import BatchJobHandler, ConfigHandler, FeaturesHandler, JobDefinitionHandler, JobHandler, JobsCountHandler, RuntimeEnvironmentsHandler, CreateJobWithDefinitionHandler
+from .environments import CondaEnvironmentManager
+from .executors import DefaultExecutionManager
+
+from jupyter_server.traittypes import TypeFromClasses
+from jupyter_server.transutils import _i18n
+from jupyter_core.paths import jupyter_data_dir
+from traitlets import Unicode, Bool, default
+
+from .config import ExecutionConfig
+
+
+JOB_DEFINITION_ID_REGEX = r"(?P<job_definition_id>\w+-\w+-\w+-\w+-\w+)"
+JOB_ID_REGEX = r"(?P<job_id>\w+-\w+-\w+-\w+-\w+)"
+
+class SchedulerApp(ExtensionApp):
+    name = "jupyter_scheduling"
+    handlers = [
+        (r"/job_definitions", JobDefinitionHandler),
+        (r"/job_definitions/%s" % JOB_DEFINITION_ID_REGEX, JobDefinitionHandler),
+        (r"/job_definitions/%s/jobs" % JOB_DEFINITION_ID_REGEX, CreateJobWithDefinitionHandler),
+        (r"/jobs", JobHandler),
+        (r"/jobs/count", JobsCountHandler),
+        (r"/jobs/%s" % JOB_ID_REGEX, JobHandler),
+        (r"/runtime_environments", RuntimeEnvironmentsHandler),
+        (r"/scheduler/features", FeaturesHandler),
+        (r"/scheduler/config", ConfigHandler),
+        (r"/batch/jobs", BatchJobHandler)
+    ]
+
+    drop_tables = Bool(
+        False, 
+        config=True, 
+        help="Drop the database tables before starting."
+    )
+
+    db_url = Unicode(
+        config=True,
+        help="URI for the scheduler database"
+    )
+
+    @default("db_url")
+    def get_demo_db_url_default(self):
+        return f"sqlite:///{jupyter_data_dir()}/scheduler.sqlite"
+
+    environment_manager_class = TypeFromClasses(
+        default_value=CondaEnvironmentManager,
+        klasses=[
+            "jupyter_scheduling.environments.EnvironmentManager"
+        ],
+        config=True,
+        help=_i18n("The runtime environment manager class to use.")
+    )
+
+
+    execution_manager_class = TypeFromClasses(
+        default_value=DefaultExecutionManager,
+        klasses=[
+            "jupyter_scheduling.executors.ExecutionManager"
+        ],
+        config=True,
+        help=_i18n("The execution manager class to use.")
+    )
+
+    scheduler_class = TypeFromClasses(
+        default_value=Scheduler,
+        klasses=[
+            "jupyter_scheduling.scheduler.BaseScheduler"
+        ],
+        config=True,
+        help=_i18n("The scheduler class to use.")
+    )
+
+    def initialize_settings(self):
+        super().initialize_settings()
+        
+        create_tables(self.db_url, self.drop_tables)
+        
+        self.settings.update(
+            execution_config=ExecutionConfig(
+                db_url=self.db_url,
+                execution_manager_class=self.execution_manager_class,
+                environments_manager_class=self.environment_manager_class,
+                scheduler_class=self.scheduler_class,
+                root_dir=self.settings.get("server_root_dir", None)
+            )
+        )

--- a/jupyter_server/services/scheduling/handlers.py
+++ b/jupyter_server/services/scheduling/handlers.py
@@ -1,12 +1,9 @@
-from dataclasses import asdict
 import json
 import re
+from dataclasses import asdict
 
-from jupyter_server.extension.handler import ExtensionHandlerMixin
-from jupyter_server.base.handlers import APIHandler
 import tornado
 from jupyter_scheduling.environments import EnvironmentRetrievalError
-
 from jupyter_scheduling.models import (
     DEFAULT_SORT,
     CountJobsQuery,
@@ -15,8 +12,11 @@ from jupyter_scheduling.models import (
     SortDirection,
     SortField,
     Status,
-    UpdateJob
+    UpdateJob,
 )
+
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.extension.handler import ExtensionHandlerMixin
 
 
 class JobHandlersMixin:
@@ -50,15 +50,11 @@ class JobHandlersMixin:
 class JobDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
     @tornado.web.authenticated
     def get(self, job_definition_id=None):
-        raise tornado.web.HTTPError(
-            500, f"Not implemented yet"
-        )
+        raise tornado.web.HTTPError(500, f"Not implemented yet")
 
     @tornado.web.authenticated
     def post(self):
-        raise tornado.web.HTTPError(
-            500, f"Not implemented yet"
-        )
+        raise tornado.web.HTTPError(500, f"Not implemented yet")
 
 
 class CreateJobWithDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
@@ -69,16 +65,12 @@ class CreateJobWithDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, AP
             raise tornado.web.HTTPError(
                 404, f"Job definition with id: {job_definition_id} not found"
             )
-        
+
         payload = self.get_json_body()
 
-        job_id = self.scheduler.create_job(
-            CreateJob(**job_definition.dict().merge(payload))
-        )
-        self.finish(json.dumps(dict(
-            job_id=job_id
-        )))
-        
+        job_id = self.scheduler.create_job(CreateJob(**job_definition.dict().merge(payload)))
+        self.finish(json.dumps(dict(job_id=job_id)))
+
 
 def compute_sort_model(query_argument):
     sort_by = []
@@ -88,11 +80,11 @@ def compute_sort_model(query_argument):
         sort_dir, name = m.groups()
         sort_by.append(
             SortField(
-                name=name, 
-                direction=SortDirection(sort_dir.lower()) if sort_dir else SortDirection.asc
+                name=name,
+                direction=SortDirection(sort_dir.lower()) if sort_dir else SortDirection.asc,
             )
         )
-    
+
     return sort_by
 
 
@@ -115,7 +107,7 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
                     start_time=int(start_time) if start_time else None,
                     sort_by=sort_by if sort_by else [DEFAULT_SORT],
                     max_items=self.get_query_argument("max_items", None),
-                    next_token=self.get_query_argument("next_token", None)
+                    next_token=self.get_query_argument("next_token", None),
                 )
             )
             self.finish(list_jobs_response.json(exclude_none=True))
@@ -123,41 +115,26 @@ class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
     @tornado.web.authenticated
     def post(self):
         payload = self.get_json_body()
-        
-        job_id = self.scheduler.create_job(
-            CreateJob(**payload)
-        )
-        
-        self.finish(
-            json.dumps(
-                dict(job_id=job_id)
-            )
-        )
 
-    
+        job_id = self.scheduler.create_job(CreateJob(**payload))
+
+        self.finish(json.dumps(dict(job_id=job_id)))
+
     @tornado.web.authenticated
     def patch(self, job_id):
         payload = self.get_json_body()
-        
+
         if "status" not in payload:
-            raise tornado.web.HTTPError(
-                500, "Field 'status' missing in request body"
-            )
+            raise tornado.web.HTTPError(500, "Field 'status' missing in request body")
 
         status = Status(payload.get("status"))
         if status == Status.STOPPED:
             self.scheduler.stop_job(job_id)
         else:
-            self.scheduler.update_job(
-                UpdateJob(
-                    job_id=job_id,
-                    status=str(status)
-                )
-            )
+            self.scheduler.update_job(UpdateJob(job_id=job_id, status=str(status)))
         self.set_status(204)
         self.finish()
 
-    
     @tornado.web.authenticated
     def delete(self, job_id):
         self.scheduler.delete_job(job_id)
@@ -171,7 +148,7 @@ class BatchJobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
         job_ids = self.get_query_arguments("job_id")
         for job_id in job_ids:
             self.scheduler.delete_job(job_id)
-            
+
         self.set_status = 204
         self.finish()
 
@@ -181,9 +158,7 @@ class JobsCountHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
     def get(self):
         status = self.get_query_argument("status", None)
         count = self.scheduler.count_jobs(
-            CountJobsQuery(
-                status=Status(status.upper()) if status else Status.IN_PROGRESS
-            )
+            CountJobsQuery(status=Status(status.upper()) if status else Status.IN_PROGRESS)
         )
         self.finish(json.dumps(dict(count=count)))
 
@@ -204,30 +179,26 @@ class RuntimeEnvironmentsHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHan
         try:
             environments = self.environment_manager.list_environments()
         except EnvironmentRetrievalError as e:
-            raise tornado.web.HTTPError(
-                500, str(e)
-            ) 
+            raise tornado.web.HTTPError(500, str(e))
 
-        self.finish(
-            json.dumps([environment.dict() for environment in environments])
-        )
-        
+        self.finish(json.dumps([environment.dict() for environment in environments]))
+
 
 class FeaturesHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
-   
     @tornado.web.authenticated
     def get(self):
         cls = self.execution_manager_class
-        self.finish(
-            json.dumps(cls.supported_features(cls))
-        )
+        self.finish(json.dumps(cls.supported_features(cls)))
 
 
 class ConfigHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
-    
     @tornado.web.authenticated
     def get(self):
-        self.finish(dict(
-            supported_features=self.execution_manager_class.supported_features(self.execution_manager_class),
-            manage_environments_command=self.environment_manager.manage_environments_command()
-        ))
+        self.finish(
+            dict(
+                supported_features=self.execution_manager_class.supported_features(
+                    self.execution_manager_class
+                ),
+                manage_environments_command=self.environment_manager.manage_environments_command(),
+            )
+        )

--- a/jupyter_server/services/scheduling/handlers.py
+++ b/jupyter_server/services/scheduling/handlers.py
@@ -1,0 +1,233 @@
+from dataclasses import asdict
+import json
+import re
+
+from jupyter_server.extension.handler import ExtensionHandlerMixin
+from jupyter_server.base.handlers import APIHandler
+import tornado
+from jupyter_scheduling.environments import EnvironmentRetrievalError
+
+from jupyter_scheduling.models import (
+    DEFAULT_SORT,
+    CountJobsQuery,
+    CreateJob,
+    ListJobsQuery,
+    SortDirection,
+    SortField,
+    Status,
+    UpdateJob
+)
+
+
+class JobHandlersMixin:
+    _scheduler = None
+    _environment_manager = None
+
+    @property
+    def execution_config(self):
+        return self.settings.get("execution_config", {})
+
+    @property
+    def scheduler(self):
+        if self._scheduler is None:
+            scheduler_class = self.execution_config.scheduler_class
+            self._scheduler = scheduler_class(self.execution_config)
+
+        return self._scheduler
+
+    @property
+    def environment_manager(self):
+        if self._environment_manager is None:
+            config = self.settings.get("execution_config")
+            self._environment_manager = config.environments_manager_class()
+        return self._environment_manager
+
+    @property
+    def execution_manager_class(self):
+        return self.execution_config.execution_manager_class
+
+
+class JobDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    def get(self, job_definition_id=None):
+        raise tornado.web.HTTPError(
+            500, f"Not implemented yet"
+        )
+
+    @tornado.web.authenticated
+    def post(self):
+        raise tornado.web.HTTPError(
+            500, f"Not implemented yet"
+        )
+
+
+class CreateJobWithDefinitionHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    def post(self, job_definition_id: str):
+        job_definition = self.scheduler.get_job_definition(job_definition_id)
+        if job_definition is None:
+            raise tornado.web.HTTPError(
+                404, f"Job definition with id: {job_definition_id} not found"
+            )
+        
+        payload = self.get_json_body()
+
+        job_id = self.scheduler.create_job(
+            CreateJob(**job_definition.dict().merge(payload))
+        )
+        self.finish(json.dumps(dict(
+            job_id=job_id
+        )))
+        
+
+def compute_sort_model(query_argument):
+    sort_by = []
+    PATTERN = re.compile("^(asc|desc)?\\(?([^\\)]+)\\)?", re.IGNORECASE)
+    for query in query_argument:
+        m = re.match(PATTERN, query)
+        sort_dir, name = m.groups()
+        sort_by.append(
+            SortField(
+                name=name, 
+                direction=SortDirection(sort_dir.lower()) if sort_dir else SortDirection.asc
+            )
+        )
+    
+    return sort_by
+
+
+class JobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    def get(self, job_id=None):
+        if job_id:
+            job = self.scheduler.get_job(job_id)
+            self.finish(job.json())
+        else:
+            status = self.get_query_argument("status", None)
+            start_time = self.get_query_argument("start_time", None)
+            sort_by = compute_sort_model(self.get_query_arguments("sort_by"))
+            list_jobs_response = self.scheduler.list_jobs(
+                ListJobsQuery(
+                    job_definition_id=self.get_query_argument("job_definition_id", None),
+                    status=Status(status.upper()) if status else None,
+                    name=self.get_query_argument("name", None),
+                    tags=self.get_query_arguments("tags", None),
+                    start_time=int(start_time) if start_time else None,
+                    sort_by=sort_by if sort_by else [DEFAULT_SORT],
+                    max_items=self.get_query_argument("max_items", None),
+                    next_token=self.get_query_argument("next_token", None)
+                )
+            )
+            self.finish(list_jobs_response.json(exclude_none=True))
+
+    @tornado.web.authenticated
+    def post(self):
+        payload = self.get_json_body()
+        
+        job_id = self.scheduler.create_job(
+            CreateJob(**payload)
+        )
+        
+        self.finish(
+            json.dumps(
+                dict(job_id=job_id)
+            )
+        )
+
+    
+    @tornado.web.authenticated
+    def patch(self, job_id):
+        payload = self.get_json_body()
+        
+        if "status" not in payload:
+            raise tornado.web.HTTPError(
+                500, "Field 'status' missing in request body"
+            )
+
+        status = Status(payload.get("status"))
+        if status == Status.STOPPED:
+            self.scheduler.stop_job(job_id)
+        else:
+            self.scheduler.update_job(
+                UpdateJob(
+                    job_id=job_id,
+                    status=str(status)
+                )
+            )
+        self.set_status(204)
+        self.finish()
+
+    
+    @tornado.web.authenticated
+    def delete(self, job_id):
+        self.scheduler.delete_job(job_id)
+        self.set_status = 204
+        self.finish()
+
+
+class BatchJobHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    def delete(self):
+        job_ids = self.get_query_arguments("job_id")
+        for job_id in job_ids:
+            self.scheduler.delete_job(job_id)
+            
+        self.set_status = 204
+        self.finish()
+
+
+class JobsCountHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    @tornado.web.authenticated
+    def get(self):
+        status = self.get_query_argument("status", None)
+        count = self.scheduler.count_jobs(
+            CountJobsQuery(
+                status=Status(status.upper()) if status else Status.IN_PROGRESS
+            )
+        )
+        self.finish(json.dumps(dict(count=count)))
+
+
+class RuntimeEnvironmentsHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    _environment_manager = None
+
+    @property
+    def environment_manager(self):
+        if self._environment_manager is None:
+            config = self.settings.get("execution_config")
+            self._environment_manager = config.environments_manager_class()
+        return self._environment_manager
+
+    def get(self):
+        """Returns names of available runtime environments"""
+
+        try:
+            environments = self.environment_manager.list_environments()
+        except EnvironmentRetrievalError as e:
+            raise tornado.web.HTTPError(
+                500, str(e)
+            ) 
+
+        self.finish(
+            json.dumps([environment.dict() for environment in environments])
+        )
+        
+
+class FeaturesHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+   
+    @tornado.web.authenticated
+    def get(self):
+        cls = self.execution_manager_class
+        self.finish(
+            json.dumps(cls.supported_features(cls))
+        )
+
+
+class ConfigHandler(ExtensionHandlerMixin, JobHandlersMixin, APIHandler):
+    
+    @tornado.web.authenticated
+    def get(self):
+        self.finish(dict(
+            supported_features=self.execution_manager_class.supported_features(self.execution_manager_class),
+            manage_environments_command=self.environment_manager.manage_environments_command()
+        ))

--- a/jupyter_server/services/scheduling/models.py
+++ b/jupyter_server/services/scheduling/models.py
@@ -1,0 +1,204 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from pydantic import BaseModel
+from typing import Dict, List, Optional, Union
+
+
+
+Tags = List[str]
+ParameterValues = Union[int, str, float, bool]
+EnvironmentParameterValues = Union[int, str, float, bool]
+
+EMAIL_RE = ''
+SCHEDULE_RE = ''
+
+
+
+class OutputFormat(BaseModel):
+    name: str
+    label: str
+
+
+class RuntimeEnvironment(BaseModel):
+    name: str
+    label: str
+    description: str
+    file_extensions: List[str]
+    output_formats: List[OutputFormat]
+    metadata: Optional[Dict[str, str]]
+
+    def __str__(self):
+        return self.json()
+
+
+class EmailNotifications(BaseModel):
+    on_start: Optional[List[str]]
+    on_success: Optional[List[str]]
+    on_failure: Optional[List[str]]
+    no_alert_for_skipped_runs: bool = True
+
+    def __str__(self) -> str:
+        return self.json()
+
+
+class Status(str, Enum):
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    STOPPING = "STOPPING"
+    STOPPED = "STOPPED"
+
+    def __str__(self):
+        return self.value
+
+""" 
+A string template to use for naming the output file,
+this template will interpolate values from DescribeJob,
+filename is a special variable, because there is no
+matching attribute in DescribeJob, but probably the most
+expected in the output filename. These templates are 
+expecting jinja2 format for attributes. Attributes that
+don't follow valid filenames will be normalized. 
+
+Examples of other formats:
+"{{name}}-{{timestamp}}"
+"{{runtime_environment_name}}_{{filename}}_{{job_id}}" 
+"""
+OUTPUT_FILENAME_TEMPLATE = "{{filename}}-{{timestamp}}"
+
+
+class CreateJob(BaseModel):
+    input_uri: str
+    output_prefix: str 
+    runtime_environment_name: str
+    runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
+    output_formats: Optional[List[str]] = None
+    idempotency_token: Optional[str] = None
+    job_definition_id: Optional[str] = None
+    parameters: Optional[Dict[str, ParameterValues]] = None
+    tags: Optional[Tags] = None
+    name: Optional[str] = None
+    email_notifications: Optional[EmailNotifications] = None
+    timeout_seconds: Optional[int] = 600
+    retry_on_timeout: Optional[bool] = False
+    max_retries: Optional[int] = 0
+    min_retry_interval_millis: Optional[int] = 0
+    output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
+    compute_type: Optional[str] = None
+    
+
+class DescribeJob(CreateJob):
+    job_id: str
+    output_uri: str 
+    url: str
+    start_time: Optional[int] = None
+    end_time: Optional[int] = None
+    status: Status = Status.STOPPED
+    status_message: str = None
+
+    class Config:
+        orm_mode = True
+
+
+class SortDirection(Enum):
+    asc = "asc"
+    desc = "desc"
+
+
+class SortField(BaseModel):
+    name: str
+    direction: SortDirection
+
+
+DEFAULT_SORT = SortField(
+    name="start_time",
+    direction=SortDirection.desc
+)
+
+
+class ListJobsQuery(BaseModel):
+    job_definition_id: Optional[str] = None
+    status: Optional[Status] = None
+    name: Optional[str] = None
+    start_time: Optional[int] = None
+    tags: Optional[Tags] = None
+    sort_by: List[SortField] = [DEFAULT_SORT]
+    max_items: Optional[int] = 1000
+    next_token: Optional[str] = None
+
+
+class ListJobsResponse(BaseModel):
+    jobs: List[DescribeJob] = []
+    next_token: Optional[str] = None
+    tags: Optional[str]
+    sort_by: List[SortField] = None
+
+
+class CountJobsQuery(BaseModel):
+    status: Status = Status.IN_PROGRESS
+
+
+class UpdateJob(BaseModel):
+    job_id: str
+    end_time: Optional[int] = None
+    status: Optional[Status] = None
+    status_message: str = None
+    name: Optional[str] = None
+    
+
+class DeleteJob(BaseModel):
+    job_id: str
+    
+
+class CreateJobDefinition(CreateJob): 
+    schedule: Optional[str] = None
+    timezone: Optional[str] = None
+
+
+class DescribeJobDefinition(CreateJobDefinition):
+    job_definition_id: str
+    last_modified_time: int
+    job_ids: List[str]
+
+
+class UpdateJobDefinition(BaseModel):
+    job_definition_id: str
+    last_modified_time: Optional[int] = None
+    schedule: Optional[str] = None
+    input_uri: Optional[str] = None
+    output_prefix: Optional[str] = None
+    runtime_environment_name: Optional[str] = None
+    idempotency_token: Optional[str] = None
+    parameters: Optional[Dict[str, ParameterValues]] = None
+    tags: Optional[Tags] = None
+    name: Optional[str] = None
+    email_notifications: Optional[EmailNotifications] = None
+    timeout_seconds: Optional[int] = 600
+    max_retries: Optional[int] = 0
+    min_retry_interval_millis: Optional[int] = 0
+    retry_on_timeout: Optional[bool] = False
+    url: Optional[str] = None
+    timezone: Optional[str] = None # Should be a timezone e.g., US/Eastern, Asia/Kolkata
+    output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
+
+
+class ListJobDefinitionsQuery(BaseModel):
+    job_definition_id: str
+
+
+class JobFeature(str, Enum):
+    job_name = "job_name"
+    parameters = "parameters"
+    output_formats = "output_formats"
+    job_definition = "job_definition"
+    idempotency_token = "idempotency_token"
+    tags = "tags"
+    email_notifications = "email_notifications"
+    timeout_seconds = "timeout_seconds"
+    retry_on_timeout = "retry_on_timeout"
+    max_retries = "max_retries"
+    min_retry_interval_millis = "min_retry_interval_millis"
+    output_filename_template = "output_filename_template"
+    stop_job = "stop_job"
+    delete_job  = "delete_job"

--- a/jupyter_server/services/scheduling/models.py
+++ b/jupyter_server/services/scheduling/models.py
@@ -1,18 +1,15 @@
 from dataclasses import dataclass
 from enum import Enum
-
-from pydantic import BaseModel
 from typing import Dict, List, Optional, Union
 
-
+from pydantic import BaseModel
 
 Tags = List[str]
 ParameterValues = Union[int, str, float, bool]
 EnvironmentParameterValues = Union[int, str, float, bool]
 
-EMAIL_RE = ''
-SCHEDULE_RE = ''
-
+EMAIL_RE = ""
+SCHEDULE_RE = ""
 
 
 class OutputFormat(BaseModel):
@@ -52,25 +49,26 @@ class Status(str, Enum):
     def __str__(self):
         return self.value
 
-""" 
+
+"""
 A string template to use for naming the output file,
 this template will interpolate values from DescribeJob,
 filename is a special variable, because there is no
 matching attribute in DescribeJob, but probably the most
-expected in the output filename. These templates are 
+expected in the output filename. These templates are
 expecting jinja2 format for attributes. Attributes that
-don't follow valid filenames will be normalized. 
+don't follow valid filenames will be normalized.
 
 Examples of other formats:
 "{{name}}-{{timestamp}}"
-"{{runtime_environment_name}}_{{filename}}_{{job_id}}" 
+"{{runtime_environment_name}}_{{filename}}_{{job_id}}"
 """
 OUTPUT_FILENAME_TEMPLATE = "{{filename}}-{{timestamp}}"
 
 
 class CreateJob(BaseModel):
     input_uri: str
-    output_prefix: str 
+    output_prefix: str
     runtime_environment_name: str
     runtime_environment_parameters: Optional[Dict[str, EnvironmentParameterValues]]
     output_formats: Optional[List[str]] = None
@@ -86,11 +84,11 @@ class CreateJob(BaseModel):
     min_retry_interval_millis: Optional[int] = 0
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
     compute_type: Optional[str] = None
-    
+
 
 class DescribeJob(CreateJob):
     job_id: str
-    output_uri: str 
+    output_uri: str
     url: str
     start_time: Optional[int] = None
     end_time: Optional[int] = None
@@ -111,10 +109,7 @@ class SortField(BaseModel):
     direction: SortDirection
 
 
-DEFAULT_SORT = SortField(
-    name="start_time",
-    direction=SortDirection.desc
-)
+DEFAULT_SORT = SortField(name="start_time", direction=SortDirection.desc)
 
 
 class ListJobsQuery(BaseModel):
@@ -145,13 +140,13 @@ class UpdateJob(BaseModel):
     status: Optional[Status] = None
     status_message: str = None
     name: Optional[str] = None
-    
+
 
 class DeleteJob(BaseModel):
     job_id: str
-    
 
-class CreateJobDefinition(CreateJob): 
+
+class CreateJobDefinition(CreateJob):
     schedule: Optional[str] = None
     timezone: Optional[str] = None
 
@@ -179,7 +174,7 @@ class UpdateJobDefinition(BaseModel):
     min_retry_interval_millis: Optional[int] = 0
     retry_on_timeout: Optional[bool] = False
     url: Optional[str] = None
-    timezone: Optional[str] = None # Should be a timezone e.g., US/Eastern, Asia/Kolkata
+    timezone: Optional[str] = None  # Should be a timezone e.g., US/Eastern, Asia/Kolkata
     output_filename_template: Optional[str] = OUTPUT_FILENAME_TEMPLATE
 
 
@@ -201,4 +196,4 @@ class JobFeature(str, Enum):
     min_retry_interval_millis = "min_retry_interval_millis"
     output_filename_template = "output_filename_template"
     stop_job = "stop_job"
-    delete_job  = "delete_job"
+    delete_job = "delete_job"

--- a/jupyter_server/services/scheduling/orm.py
+++ b/jupyter_server/services/scheduling/orm.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+import json
+import os
+from sqlite3 import OperationalError
+import uuid
+from sqlalchemy.orm import registry
+from sqlalchemy import Column, Integer, String, Boolean, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+import sqlalchemy.types as types
+
+from jupyter_scheduling.models import EmailNotifications, Status
+from jupyter_scheduling.utils import create_output_filename, get_utc_timestamp
+
+Base = declarative_base()
+
+def generate_uuid():
+    return str(uuid.uuid4())
+
+def generate_url(context) -> str:
+    job_id = context.get_current_parameters()['job_id']
+    return f"/jobs/{job_id}"
+
+def output_uri(context) -> str:
+    input_uri = context.get_current_parameters()['input_uri']
+    output_prefix = context.get_current_parameters()['output_prefix']
+    output_formats = context.get_current_parameters()['output_formats']
+
+    if not output_formats or 'ipynb' in output_formats:
+        output_filename = create_output_filename(input_uri)
+    else:
+        output_filename = create_output_filename(
+            os.path.splitext(input_uri)[-2] + '.' + output_formats[0]
+        )
+    
+    return os.path.join(output_prefix, output_filename)
+
+
+class JsonType(types.TypeDecorator):
+    impl = String
+
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return json.dumps(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+
+        return json.loads(value)
+
+class EmailNotificationType(types.TypeDecorator):
+    impl = String
+
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        
+        if isinstance(value, EmailNotifications):
+            return json.dumps(value.dict(exclude_none=True))
+        else:
+            return value
+        
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        return EmailNotifications.construct(json.loads(value))
+
+
+
+mapper_registry = registry()
+
+class Job(Base):
+    __tablename__ = 'jobs'
+    job_id = Column(String(36), primary_key=True, default=generate_uuid)
+    runtime_environment_name = Column(String(256), nullable=False)
+    runtime_environment_parameters = Column(JsonType(1024))
+    compute_type = Column(String(256), nullable=True)
+    input_uri = Column(String(256), nullable=False)
+    output_prefix = Column(String(256))
+    output_formats = Column(JsonType(512))
+    output_uri = Column(String(256), default=output_uri)
+    name = Column(String(256))
+    job_definition_id = Column(String(36))
+    idempotency_token = Column(String(256))
+    status = Column(String(64), default=Status.STOPPED)
+    tags = Column(JsonType(1024))
+    status_message = Column(String(1024))
+    start_time = Column(Integer)
+    end_time = Column(Integer)
+    parameters = Column(JsonType(1024))
+    url = Column(String(256), default=generate_url)
+    email_notifications = Column(EmailNotificationType(1024))
+    timeout_seconds = Column(Integer, default=600)
+    retry_on_timeout = Column(Boolean, default=False)
+    max_retries = Column(Integer, default=0)
+    min_retry_interval_millis = Column(Integer, default=0)
+    output_filename_template = Column(String(256))
+    pid = Column(Integer)
+    update_time = Column(Integer, default=get_utc_timestamp, onupdate=get_utc_timestamp)
+
+
+def create_tables(db_url, drop_tables=False):
+    engine = create_engine(db_url)
+    try:
+        if drop_tables:
+            Base.metadata.drop_all(engine)
+    except OperationalError:
+        pass
+    finally:
+        Base.metadata.create_all(engine)
+    
+
+def create_session(db_url):
+    engine = create_engine(db_url, echo=True)
+    Session = sessionmaker(bind=engine)
+    
+    return Session

--- a/jupyter_server/services/scheduling/parameterize.py
+++ b/jupyter_server/services/scheduling/parameterize.py
@@ -1,0 +1,40 @@
+from typing import Dict
+
+from jupyter_scheduling.models import ParameterValues
+from jupyter_scheduling.utils import find_cell_index_with_tag
+from nbformat import NotebookNode, v4
+
+
+def add_parameters(nb: NotebookNode, parameters: Dict[str, ParameterValues]):
+    content = []
+
+    for key, value in parameters.items():
+        if type(value) == str:
+            content.append(
+                f"{key} = '{value}'"
+            )
+        else:
+            content.append(
+                f"{key} = {value}"
+            )
+
+
+    new_cell = v4.new_code_cell(source="\n".join(content))
+    new_cell.metadata['tags'] = ['injected-parameters']
+
+    parameters_cell_index = find_cell_index_with_tag(nb, 'parameters')
+    injected_cell_index = find_cell_index_with_tag(nb, 'injected-parameters')
+
+    if injected_cell_index >= 0:
+        before = nb.cells[:injected_cell_index]
+        after = nb.cells[injected_cell_index + 1 :]
+    elif parameters_cell_index >= 0:
+        before = nb.cells[: parameters_cell_index + 1]
+        after = nb.cells[parameters_cell_index + 1 :]
+    else:
+        before = []
+        after = nb.cells
+
+    nb.cells = before + [new_cell] + after
+
+    return nb

--- a/jupyter_server/services/scheduling/parameterize.py
+++ b/jupyter_server/services/scheduling/parameterize.py
@@ -10,20 +10,15 @@ def add_parameters(nb: NotebookNode, parameters: Dict[str, ParameterValues]):
 
     for key, value in parameters.items():
         if type(value) == str:
-            content.append(
-                f"{key} = '{value}'"
-            )
+            content.append(f"{key} = '{value}'")
         else:
-            content.append(
-                f"{key} = {value}"
-            )
-
+            content.append(f"{key} = {value}")
 
     new_cell = v4.new_code_cell(source="\n".join(content))
-    new_cell.metadata['tags'] = ['injected-parameters']
+    new_cell.metadata["tags"] = ["injected-parameters"]
 
-    parameters_cell_index = find_cell_index_with_tag(nb, 'parameters')
-    injected_cell_index = find_cell_index_with_tag(nb, 'injected-parameters')
+    parameters_cell_index = find_cell_index_with_tag(nb, "parameters")
+    injected_cell_index = find_cell_index_with_tag(nb, "injected-parameters")
 
     if injected_cell_index >= 0:
         before = nb.cells[:injected_cell_index]

--- a/jupyter_server/services/scheduling/scheduler.py
+++ b/jupyter_server/services/scheduling/scheduler.py
@@ -1,0 +1,249 @@
+from abc import ABC, abstractmethod
+from multiprocessing import Process
+import psutil
+from typing import List
+from jupyter_core.paths import jupyter_data_dir
+from jupyter_scheduling.models import CountJobsQuery, CreateJob, CreateJobDefinition, DescribeJob, DescribeJobDefinition, ListJobDefinitionsQuery, ListJobsQuery, ListJobsResponse, Status, UpdateJob, SortDirection
+
+from jupyter_scheduling.utils import create_output_filename, timestamp_to_int
+from jupyter_scheduling.config import ExecutionConfig
+from jupyter_scheduling.orm import Job, create_session
+
+from sqlalchemy import desc, asc, func, and_
+
+
+class BaseScheduler(ABC):
+    """Base class for schedulers. A default implementation 
+    is provided in the `Scheduler` class, but extension creators
+    can provide their own scheduler by subclassing this class.
+    By implementing this class, you will replace both the service
+    API and the persistence layer for the scheduler.
+    """
+
+    @abstractmethod
+    def create_job(self, model: CreateJob) -> str:
+        """Creates a new job record, may trigger execution of the job.
+        In case a task runner is actually handling execution of the jobs,
+        this method should just create the job record.
+        """
+        pass
+
+    @abstractmethod
+    def update_job(self, model: UpdateJob):
+        """Updates job metadata in the persistence store,
+        for example name, status etc. In case of status
+        change to STOPPED, should call stop_job
+        """
+        pass
+
+    @abstractmethod
+    def list_jobs(self, query: ListJobsQuery) -> ListJobsResponse:
+        """Returns list of all jobs filtered by query"""
+        pass
+
+    @abstractmethod
+    def count_jobs(self, query: CountJobsQuery) -> int:
+        """Returns number of jobs filtered by query"""
+        pass
+
+    @abstractmethod
+    def get_job(self, job_id: str) -> DescribeJob:
+        """Returns job record for a single job"""
+        pass
+
+    @abstractmethod
+    def delete_job(self, job_id: str):
+        """Deletes the job record, stops the job if running"""
+        pass
+
+    @abstractmethod
+    def stop_job(self, job_id: str):
+        """Stops the job, this is not analogous
+        to the REST API that will be called to 
+        stop the job. Front end will call the PUT
+        API with status update to STOPPED, which will
+        call the update_job method. This method is 
+        supposed to do the work of actually stopping 
+        the process that is executing the job. In case
+        of a task runner, you can assume a call to task
+        runner to suspend the job.
+        """
+        pass
+
+    @abstractmethod
+    def create_job_definition(self, model: CreateJobDefinition) -> str:
+        """Creates a new job definition record,
+        consider this as the template for creating
+        recurring/scheduled jobs.
+        """
+        pass
+
+    @abstractmethod
+    def update_job_definition(self, model: UpdateJob):
+        """Updates job definition metadata in the persistence store,
+        should only impact all future jobs.
+        """
+        pass
+
+    @abstractmethod
+    def delete_job_definition(self, job_definition_id: str):
+        """Deletes the job definition record,
+        implementors can optionally stop all running jobs
+        """
+        pass
+
+    @abstractmethod
+    def list_job_definitions(self, query: ListJobDefinitionsQuery) -> List[DescribeJobDefinition]:
+        """Returns list of all job definitions filtered by query"""
+        pass
+
+    @abstractmethod
+    def pause_jobs(self, job_definition_id: str):
+        """Pauses all future jobs for a job definition"""
+        pass
+
+
+
+class Scheduler(BaseScheduler):
+    
+    _db_session = None
+
+    def __init__(self, config: ExecutionConfig = {}):
+        self.config = config
+
+    @property
+    def db_session(self):
+        if not self._db_session:
+            self._db_session = create_session(self.config.db_url)
+
+        return self._db_session
+
+    @property
+    def execution_manager_class(self):
+        return self.config.execution_manager_class
+
+    def create_job(self, model: CreateJob) -> DescribeJob:
+        with self.db_session() as session:
+            job = Job(**model.dict(exclude_none=True))
+            session.add(job)
+            session.commit()
+
+            p = Process(target=self.execution_manager_class(job.job_id, self.config).process)
+            p.start()
+            
+            job.pid = p.pid
+            session.commit()
+
+            job_id = job.job_id
+
+        return job_id
+
+    def update_job(self, model: UpdateJob):
+        with self.db_session() as session:
+            session.query(Job).filter(Job.job_id == model.job_id).update(
+                model.dict(exclude_none=True)
+            )
+            session.commit()
+
+    def list_jobs(self, query: ListJobsQuery) -> ListJobsResponse:
+        with self.db_session() as session:
+            jobs = session.query(Job)
+            
+            if query.status:
+                jobs = jobs.filter(Job.status == query.status)
+            if query.job_definition_id:
+                jobs = jobs.filter(Job.status == query.job_definition_id)
+            if query.start_time:
+                jobs = jobs.filter(Job.start_time >= query.start_time)   
+            if query.name:
+                jobs = jobs.filter(Job.name.like(f"{query.name}%"))
+            if query.tags:
+                jobs = jobs.filter(and_(Job.tags.contains(tag) for tag in query.tags))
+            
+            total = jobs.count()
+            
+            if query.sort_by:
+                for sort_field in query.sort_by:
+                    direction = desc if sort_field.direction == SortDirection.desc else asc
+                    jobs = jobs.order_by(
+                        direction(
+                            getattr(Job, sort_field.name)
+                        )
+                    )
+            next_token = int(query.next_token) if query.next_token else 0                   
+            jobs = jobs.limit(query.max_items).offset(next_token)
+            
+            jobs = jobs.all()
+
+        next_token = next_token + len(jobs)
+        if next_token >= total:
+            next_token = None
+
+        list_jobs_response = ListJobsResponse(
+            jobs=[DescribeJob.from_orm(job) for job in jobs or []],
+            next_token=next_token
+        )    
+        
+        return list_jobs_response
+
+    
+    def count_jobs(self, query: CountJobsQuery) -> int:
+        with self.db_session() as session:
+            count = session.query(func.count(Job.job_id)).filter(Job.status == query.status).scalar()
+            return count if count else 0
+
+
+    def get_job(self, job_id: str) -> DescribeJob:
+        with self.db_session() as session:
+            job_record = session.query(Job).filter(Job.job_id == job_id).one()
+            
+            return DescribeJob.from_orm(job_record)
+
+    def delete_job(self, job_id: str):
+        with self.db_session() as session:
+            job_record = session.query(Job).filter(Job.job_id == job_id).one()
+            if Status(job_record.status) == Status.IN_PROGRESS:
+                self.stop_job(job_id)
+
+            session.query(Job).filter(Job.job_id == job_id).delete()
+            session.commit()
+    
+    def stop_job(self, job_id):
+        with self.db_session() as session:
+            job_record = session.query(Job).filter(Job.job_id == job_id).one()
+            job = DescribeJob.from_orm(job_record)
+            process_id = job_record.pid
+            if process_id and job.status == Status.IN_PROGRESS:
+                session.query(Job).filter(Job.job_id == job_id).update(
+                    {'status': Status.STOPPING}
+                )
+                session.commit()
+                
+                current_process = psutil.Process()
+                children = current_process.children(recursive=True)
+                for proc in children:
+                    if process_id == proc.pid:
+                        proc.kill()
+                        session.query(Job).filter(Job.job_id == job_id).update(
+                            {'status': Status.STOPPED}
+                        )
+                        session.commit()
+                        break
+
+    def create_job_definition(self, model: CreateJobDefinition) -> str:
+        pass
+
+    def update_job_definition(self, model: UpdateJob):
+        pass
+
+    def delete_job_definition(self, job_definition_id: str):
+        pass
+
+    def list_job_definitions(self, query: ListJobDefinitionsQuery) -> List[DescribeJobDefinition]:
+        pass
+
+    def pause_jobs(self, job_definition_id: str):
+        pass
+    
+        
+

--- a/jupyter_server/services/scheduling/utils.py
+++ b/jupyter_server/services/scheduling/utils.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+import json
+import os
+import pathlib
+from uuid import UUID
+
+from nbformat import NotebookNode
+
+from jupyter_scheduling.models import CreateJob
+
+class UUIDEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, UUID):
+            # if the obj is uuid, we simply return the value of uuid
+            return obj.hex
+        return json.JSONEncoder.default(self, obj)
+
+
+def timestamp_to_int(timestamp: str):
+    """Converts string date in format yyyy-mm-dd h:m:s to int"""
+    
+    dt = datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S')
+    return int(dt.timestamp())
+
+
+def create_output_filename(input_uri: str):
+    """Creates output filename from input_uri"""
+    
+    filename = os.path.basename(input_uri)
+    file_extension = pathlib.Path(input_uri).suffix
+    output_filename = f"{os.path.splitext(filename)[0]}-{datetime.now().strftime('%Y%m%d_%I%M%S_%p')}{file_extension}"
+
+    return output_filename
+
+
+def find_cell_index_with_tag(nb: NotebookNode, tag: str):
+    """Finds index of first cell tagged with ``tag``"""
+    
+    parameters_indices = []
+    for idx, cell in enumerate(nb.cells):
+        if 'tags' in cell.metadata and tag in cell.metadata['tags']:
+            parameters_indices.append(idx)
+    if not parameters_indices:
+        return -1
+    return parameters_indices[0]
+
+
+def resolve_path(path, root_dir=None):
+    if not root_dir:
+        return path
+
+    if '~' in root_dir:
+        root_dir = root_dir.replace('~', os.environ['HOME'])
+
+    return os.path.join(root_dir, path)
+
+
+def get_utc_timestamp() -> int:
+    return int(datetime.now(timezone.utc).timestamp() * 1000)

--- a/jupyter_server/services/scheduling/utils.py
+++ b/jupyter_server/services/scheduling/utils.py
@@ -1,12 +1,12 @@
-from datetime import datetime, timezone
 import json
 import os
 import pathlib
+from datetime import datetime, timezone
 from uuid import UUID
 
+from jupyter_scheduling.models import CreateJob
 from nbformat import NotebookNode
 
-from jupyter_scheduling.models import CreateJob
 
 class UUIDEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -18,14 +18,14 @@ class UUIDEncoder(json.JSONEncoder):
 
 def timestamp_to_int(timestamp: str):
     """Converts string date in format yyyy-mm-dd h:m:s to int"""
-    
-    dt = datetime.strptime(timestamp, '%Y-%m-%d %H:%M:%S')
+
+    dt = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
     return int(dt.timestamp())
 
 
 def create_output_filename(input_uri: str):
     """Creates output filename from input_uri"""
-    
+
     filename = os.path.basename(input_uri)
     file_extension = pathlib.Path(input_uri).suffix
     output_filename = f"{os.path.splitext(filename)[0]}-{datetime.now().strftime('%Y%m%d_%I%M%S_%p')}{file_extension}"
@@ -35,10 +35,10 @@ def create_output_filename(input_uri: str):
 
 def find_cell_index_with_tag(nb: NotebookNode, tag: str):
     """Finds index of first cell tagged with ``tag``"""
-    
+
     parameters_indices = []
     for idx, cell in enumerate(nb.cells):
-        if 'tags' in cell.metadata and tag in cell.metadata['tags']:
+        if "tags" in cell.metadata and tag in cell.metadata["tags"]:
             parameters_indices.append(idx)
     if not parameters_indices:
         return -1
@@ -49,8 +49,8 @@ def resolve_path(path, root_dir=None):
     if not root_dir:
         return path
 
-    if '~' in root_dir:
-        root_dir = root_dir.replace('~', os.environ['HOME'])
+    if "~" in root_dir:
+        root_dir = root_dir.replace("~", os.environ["HOME"])
 
     return os.path.join(root_dir, path)
 


### PR DESCRIPTION
## Summary

Headless/Scheduled notebooks will enable end users to run and schedule notebooks as jobs anywhere they are running JupyterLab (laptop, on-prem, JupyterHub etc.). This capability will be offered to JupyterLab users as two primary components:

1. The REST API which runs as a Jupyter Server extension and has extension points for different backends.
2. The UI, which is a JupyterLab extension

This PR will only include the relevant components of the server extension, UI extension will be presented in a separate PR, once we have acceptance from the community to setup the server extension repo. We will not be merging this code into jupyter-server/jupyter-server, but using this as a mechanism to get feedback from the community and to help set up a separate repo under the jupyter-server org. 


## Concepts

### Job definition

A **job definition** is a notebook and the metadata required to run it in an unattended fashion. A scheduled job definition contains additional metadata about a recurring schedule for running it. 

### Job

A **job** is a single instance of a notebook being run. There are two categories of jobs:

1. **Run now**: Run a notebook immediately, not on a schedule
2. **Scheduled job**: A notebook job that should run on a regular basis or run once based on a job definition

## Components 

### Rest API

Provides the REST API endpoints for managing jobs


#### GET /jobs/<job_id>

Returns job details for a specific job, calls get_job in Scheduler API


#### GET /jobs

Returns job details for jobs filtered by query, calls list_jobs in Scheduler API


#### POST /jobs

Creates a new run now job, calls create_job in Scheduler API


#### PATCH /jobs/<job_id>

Updates a job, calls update_job in Scheduler API


#### DELETE /jobs/<job_id>

Deletes a job, calls delete_job in Scheduler API


#### POST /job_definitions

Creates a new job definition, calls create_job_definition in Scheduler API


#### GET /job_definitions/<job_def_id>

Returns job definition details for a specific definition, calls get_job_definition in Scheduler API


#### POST /job_definitions/<job_def_id>/jobs

Creates a new job with job definition, calls create_job in Scheduler API


#### GET /job_definitions

Returns list of definitions filtered by query, calls list_job_definitions in Scheduler


#### PATCH /job_definitions/<job_def_id>

Updates a specific job definition, calls update_job_definition in Scheduler


#### DELETE /job_definitions/<job_def_id>

Deletes job definition, calls delete_job_definition in Scheduler API


#### GET /runtime_environments

Returns list of details for all environments, calls list_environments in EnvironmentsManager


### Extension points

#### ExecutionManager

Execution manager is a configurable trait class that provides a wrapper around the execution engine that will execute the notebook. The default implementation provided by the server extension uses `nbconvert` to execute the notebooks, supports `html` and `notebook` outputs, and allows Papermill-like job parameters.  


```py
execution_manager_class = TypeFromClasses(
        default_value=DefaultExecutionManager,
        klasses=[
            "jupyter_scheduling.executors.ExecutionManager"
        ],
        config=True,
        help=_i18n("The execution manager class to use.")
    )
```



```py
class ExecutionManager(ABC):
    """ Base execution manager.
    Clients are expected to override this class
    to provide concrete implementations of the
    execution manager. At the minimum, subclasses
    should provide implementation of the 
    execute, and supported_features methods.
    """

    def process(self):
        """The template method called by the 
        Scheduler, backend implementations 
        should not override this method. 
        """
        self.before_start()
        try:
            self.execute()
        except Exception as e:
            self.on_failure(e)
        else:
            self.on_complete()

    @abstractmethod
    def execute(self):
        """Performs notebook execution,
        custom backends are expected to
        add notebook execution logic within
        this method
        """
        pass

    @classmethod
    @abstractmethod
    def supported_features(cls) -> Dict[JobFeature, bool]:
        """Returns a configuration of supported features
        by the execution engine. Implementors are expected
        to override this to return a dictionary of supported
        job creation features.
        """
        pass

    def before_start(self):
        """Called before start of execute"""
        ...

    def on_failure(self, e: Exception):
        """Called after failure of execute"""
        ...    

    def on_complete(self):
        """Called after job is completed"""
        ...
```


Execution manager provides a second API that should return the list of features supported by the execution engine. This is useful for the UI to only show options that are supported by the specific backend. For example, here are the list of features supported by the default execution manager at this time.


```py
def supported_features(cls) -> Dict[JobFeature, bool]:
    return {
        JobFeature.job_name: True,
        JobFeature.output_formats: True,
        JobFeature.job_definition: False,
        JobFeature.idempotency_token: False,
        JobFeature.tags: True,
        JobFeature.email_notifications: False,
        JobFeature.timeout_seconds: False,
        JobFeature.retry_on_timeout: False,
        JobFeature.max_retries: False,
        JobFeature.min_retry_interval_millis: False,
        JobFeature.output_filename_template: False,
        JobFeature.stop_job: True,
        JobFeature.delete_job: True
    } 
```


This is an appropriate extension point for backends that only want to replace the execution engine that executes the notebook, but want to keep the rest of the backend and persistence layer intact.


#### Scheduler

`Scheduler` is a configurable trait class that can be used to replace the backend service api to support a different backend than the default provided by the server extension.

```py
scheduler_class = TypeFromClasses(
        default_value=Scheduler,
        klasses=[
            "jupyter_scheduling.scheduler.BaseScheduler"
        ],
        config=True,
        help=_i18n("The scheduler class to use.")
    )
```


This is the central API that is used by the REST handlers to run and schedule jobs. The `BaseScheduler` class is expected to be implemented by different backends to attach their own persistence store and task runner. A default implementation `Scheduler` is provided  that uses SQLite as persistence store and a python process to run jobs.


```py
class BaseScheduler(ABC):
    """Base class for schedulers. A default implementation 
    is provided in the `Scheduler` class, but extension creators
    can provide their own scheduler by subclassing this class.
    By implementing this class, you will replace both the service
    API and the persistence layer for the scheduler.
    """

    @abstractmethod
    def create_job(self, model: CreateJob) -> str:
        """Creates a new job record, may trigger execution of the job.
        In case a task runner is actually handling execution of the jobs,
        this method should just create the job record.
        """
        pass

    @abstractmethod
    def update_job(self, model: UpdateJob):
        """Updates job metadata in the persistence store,
        for example name, status etc. In case of status
        change to STOPPED, should call stop_job
        """
        pass

    @abstractmethod
    def list_jobs(self, query: ListJobsQuery) -> ListJobsResponse:
        """Returns list of all jobs filtered by query"""
        pass

    @abstractmethod
    def count_jobs(self, query: CountJobsQuery) -> int:
        """Returns number of jobs filtered by query"""
        pass

    @abstractmethod
    def get_job(self, job_id: str) -> DescribeJob:
        """Returns job record for a single job"""
        pass

    @abstractmethod
    def delete_job(self, job_id: str):
        """Deletes the job record, stops the job if running"""
        pass

    @abstractmethod
    def stop_job(self, job_id: str):
        """Stops the job, this is not analogous
        to the REST API that will be called to 
        stop the job. Front end will call the PUT
        API with status update to STOPPED. In case
        of a task runner, you can assume a call to task
        runner to suspend the job.
        """
        pass

    @abstractmethod
    def create_job_definition(self, model: CreateJobDefinition) -> str:
        """Creates a new job definition record,
        consider this as the template for creating
        recurring/scheduled jobs.
        """
        pass

    @abstractmethod
    def update_job_definition(self, model: UpdateJob):
        """Updates job definition metadata in the persistence store,
        should only impact all future jobs.
        """
        pass

    @abstractmethod
    def delete_job_definition(self, job_definition_id: str):
        """Deletes the job definition record,
        implementors can optionally stop
        jobs with this job definition
        """
        pass

    @abstractmethod
    def list_job_definitions(self, query: ListJobDefinitionsQuery) -> List[DescribeJobDefinition]:
        """Returns list of all job definitions filtered by query"""
        pass

    @abstractmethod
    def pause_jobs(self, job_definition_id: str):
        """Pauses all future jobs for a job definition"""
        pass
```




#### EnvironmentsManager

Environments provide a mechanism to switch runtime context while submitting a job execution. For example, the default environments manager bundled with this extension provides a list of locally installed `conda` environments. The user can select one of these environments during job submission, and the backend is expected to run the notebook in the selected `conda` environment. 

```py
def list_environments() -> List[RuntimeEnvironment]:
        pass
```


`EnvironmentsManager` is a configurable trait class that can be used to replace the list of environments presented to the user. Note that how the runtime context will change during execution of the notebook job relies on the specific backend implementation.

```py
environment_manager_class = TypeFromClasses(
        default_value=CondaEnvironmentManager,
        klasses=[
            "jupyter_scheduling.environments.EnvironmentManager"
        ],
        config=True,
        help=_i18n("The runtime environment manager class to use.")
    )
```


Environments manager also provides a second API to provide a command id which, if non-empty, allows the UI to launch the environment management UI. Note that the actual UI to manage environments is outside the scope of the scheduler lab extension; the server extension is merely providing this extension point so other backends can accommodate management of environments for their users. We expect that most users will not find the need to manage environments from within the job creation process, and will mostly select one of the pre-configured named environments.


```py
def manage_environments_command(self) -> str:
    pass
```



## Current features

The current extension supports these features:

* **Multiple backends**: The REST API can be retrofitted to work with different backends, for example JupyterHub
* **Run now jobs**: Submit a notebook job to run now
* **Job parameters**: Enables parameterization of jobs at runtime. This supports both notebook and non-notebook artifacts, for example python files.
* **Stop Job**: Allows stopping a job once it has been started
* **Delete Job**: Allows deletion of a job, stopping it if started
* **Sort**: Multi-field sort job attributes inside list API
* **Filter**: Filter jobs list by status, name, start_time, and tags
* **Pagination**: Token based pagination of jobs
* **Multiple outputs**: HTML and notebook outputs supported

## Planned features

* **Scheduled jobs**: Will allow submitting jobs with a schedule
* **Multiple files**: Will allow selection of multiple files, for example selecting other files needed by the target notebook
* **Offline runs**: Handle notebook runs when the JupyterLab instance is shutdown
* **File ID**: Integration with File ID service to track document moves
* **Multi-task jobs:** enable jobs that consist of multiple steps with dependencies

## Lab extension example

![headless-notebooks-ui](https://user-images.githubusercontent.com/289369/187819914-fa70d9af-1b18-4229-abf3-04f18ab2e197.gif)
