### PR TITLE
Accept and manage cookies when requesting gateways

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -382,10 +382,7 @@ class GatewayClient(SingletonConfigurable):
     @default("accept_cookies")
     def accept_cookies_default(self):
         return bool(
-            os.environ.get(
-                self.accept_cookies_env,
-                str(self.accept_cookies_value).lower(),
-            )
+            os.environ.get(self.accept_cookies_env, str(self.accept_cookies_value).lower())
             not in ["no", "false"]
         )
 

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -463,13 +463,17 @@ class GatewayClient(SingletonConfigurable):
 
         return kwargs
 
+    @staticmethod
+    def _get_expiration_check_time() -> datetime:
+        return datetime.now()
+
     def update_cookies(self, cookie: SimpleCookie) -> None:
         """Update stickiness cookies given Set-Cookie headers of the response
         to maintain stickiness to previous service nodes"""
         if not self.use_stickiness_cookie:
             return
 
-        store_time = datetime.now()
+        store_time = self._get_expiration_check_time()
         for key, item in cookie.items():
             if self.stickiness_cookie_name and key != self.stickiness_cookie_name:
                 continue
@@ -484,7 +488,7 @@ class GatewayClient(SingletonConfigurable):
             self._cookies[key] = (item, store_time)
 
     def _clear_expired_cookies(self) -> None:
-        check_time = datetime.now()
+        check_time = self._get_expiration_check_time()
         expired_keys = []
 
         for key, (morsel, store_time) in self._cookies.items():


### PR DESCRIPTION
This PR adds an `accept_cookies` argument to `GatewayClient` class. Once enabled, `GatewayClient` accepts and manages cookie expiration when receiving cookies generated by load balancers serving notebook gateways. These cookies will be sent back in request headers for load balancers to decide which backend node to use.

Purposes and discussions in #967.