### PR TITLE
fix issues with jupyter_events 0.5.0

### DIFF
--- a/tests/services/events/mock_event.yaml
+++ b/tests/services/events/mock_event.yaml
@@ -1,4 +1,4 @@
-$id: event.mock.jupyter.org/message
+$id: http://event.mock.jupyter.org/message
 version: 1
 title: Message
 description: |

--- a/tests/services/events/mockextension/mock_extension.py
+++ b/tests/services/events/mockextension/mock_extension.py
@@ -8,7 +8,7 @@ class MockEventHandler(JupyterHandler):
     def get(self):
         # Emit an event.
         self.event_logger.emit(
-            schema_id="event.mockextension.jupyter.org/message",
+            schema_id="http://event.mockextension.jupyter.org/message",
             data={"event_message": "Hello world, from mock extension!"},
         )
 

--- a/tests/services/events/mockextension/mock_extension_event.yaml
+++ b/tests/services/events/mockextension/mock_extension_event.yaml
@@ -1,4 +1,4 @@
-$id: event.mockextension.jupyter.org/message
+$id: http://event.mockextension.jupyter.org/message
 version: 1
 title: Message
 description: |

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -31,7 +31,7 @@ async def test_subscribe_websocket(event_logger, jp_ws_fetch):
     ws = await jp_ws_fetch("/api/events/subscribe")
 
     event_logger.emit(
-        schema_id="event.mock.jupyter.org/message",
+        schema_id="http://event.mock.jupyter.org/message",
         data={"event_message": "Hello, world!"},
     )
     # await event_logger.gather_listeners()
@@ -44,7 +44,7 @@ async def test_subscribe_websocket(event_logger, jp_ws_fetch):
 
 payload_1 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "version": 1,
     "data": {
         "event_message": "Hello, world!"
@@ -55,7 +55,7 @@ payload_1 = """\
 
 payload_2 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "version": 1,
     "data": {
         "event_message": "Hello, world!"
@@ -83,7 +83,7 @@ async def test_post_event(jp_fetch, event_logger_sink, payload):
 
 payload_3 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "data": {
         "event_message": "Hello, world!"
     }
@@ -101,7 +101,7 @@ payload_4 = """\
 
 payload_5 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "version": 1
 }
 """
@@ -128,7 +128,7 @@ async def test_post_event_400(jp_fetch, event_logger, payload):
 
 payload_7 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "version": 1,
     "data": {
         "message": "Hello, world!"
@@ -138,7 +138,7 @@ payload_7 = """\
 
 payload_8 = """\
 {
-    "schema_id": "event.mock.jupyter.org/message",
+    "schema_id": "http://event.mock.jupyter.org/message",
     "version": 2,
     "data": {
         "message": "Hello, world!"

--- a/tests/services/events/test_extension.py
+++ b/tests/services/events/test_extension.py
@@ -9,7 +9,7 @@ def jp_server_config():
         "ServerApp": {
             "jpserver_extensions": {"tests.services.events.mockextension": True},
         },
-        "EventBus": {"allowed_schemas": ["event.mockextension.jupyter.org/message"]},
+        "EventBus": {"allowed_schemas": ["http://event.mockextension.jupyter.org/message"]},
     }
     return config
 


### PR DESCRIPTION
Jupyter Events 0.5.0 enforces the `$id` field to be a URI. The unit tests here fail to meet this requirement. Updated the tests to handle this.