### PR TITLE
[Gateway] Fix and deprecate env whitelist handling

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -421,14 +421,15 @@ class GatewayKernelManager(AsyncKernelManager):
             if os.environ.get("KERNEL_USERNAME") is None and GatewayClient.instance().http_user:
                 os.environ["KERNEL_USERNAME"] = GatewayClient.instance().http_user
 
+            payload_envs = os.environ.copy()
+            payload_envs.update(kwargs.get("env", {}))  # Add any env entries in this request
+
+            # Build the actual env payload, filtering allowed_envs and those starting with 'KERNEL_'
             kernel_env = {
                 k: v
-                for (k, v) in dict(os.environ).items()
-                if k.startswith("KERNEL_") or k in GatewayClient.instance().env_whitelist.split(",")
+                for (k, v) in payload_envs.items()
+                if k.startswith("KERNEL_") or k in GatewayClient.instance().allowed_envs.split(",")
             }
-
-            # Add any env entries in this request
-            kernel_env.update(kwargs.get("env", {}))
 
             # Convey the full path to where this notebook file is located.
             if kwargs.get("cwd") is not None and kernel_env.get("KERNEL_WORKING_DIR") is None:


### PR DESCRIPTION
Today I learned that Lab includes the user's env in the `env` stanza of the kernel start request body.  I also learned that we were only filtering the server's env (i.e., the env of the jupyter server process) when applying the `env_whitelist` configurable to determine which envs to send to the gateway, then _unconditionally_ adding whatever was already in the start request's `env` stanza.  Instead, we need to be filtering _both_ the server's envs **and** the provided envs against the configured list.  This pull request makes this change.

Also, while we're at it, we should deprecate `env_whitelist` in favor of `allowed_envs` - similar to what was done with Kernelspec filtering in jupyter_client. This pull request makes that change as well.