### PR TITLE
Update server extension disable instructions

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -399,7 +399,7 @@ Putting it all together, authors can distribute their extension following this s
 
     .. code-block:: console
 
-        jupyter server disable myextension
+        jupyter server extension disable myextension
 
     which will change the boolean value in the JSON file above.
 


### PR DESCRIPTION
The current server extension disable instructions are incorrect, they are missing the keyword `extension`.