### PR TITLE
Fix some typos in release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,9 +25,9 @@ npm run build
 
 ```bash
 echo "Enter new version"
-read script_version
-hachling version ${script_version}
-git tag -a ${script_version} -m "Release ${script_version}"
+read new_version
+hatchling version ${new_version}
+git tag -a ${new_version} -m "Release ${new_version}"
 ```
 
 ### Build the artifacts
@@ -42,7 +42,7 @@ python -m build .
 ```bash
 echo "Enter dev version"
 read dev_version
-hatchling ${dev_version}
+hatchling version ${dev_version}
 git push origin $(git branch --show-current)
 ```
 


### PR DESCRIPTION
While looking into adopting recent build framework changes in another repo, I ran into a couple of (minor) issues with the recently-added `hatchling` instructions.  I also took the liberty to update the variable `script_version` to `new_version` to have parity with its prompt (as well as `dev_version`).