### PR TITLE
Update to version2 releaser

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   check_release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group: [check_release, link_check]
-      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,11 +17,6 @@ jobs:
         run: |
           pip install -e .
       - name: Check Release
-        if: ${{ matrix.group == 'check_release' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@version2
         with:
-          version_spec: 100.100.100
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Link Check
-        if: ${{ matrix.group == 'link_check' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -148,6 +148,15 @@ jobs:
         with:
           test_command: pytest -vv || pytest -vv --lf
 
+  check_links:
+    name: Check Links
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
   python_tests_check: # This job does nothing and is only used for the branch protection
     if: always()
     needs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ filterwarnings = [
   "ignore:run_pre_save_hook is deprecated:DeprecationWarning"
 ]
 
-[tool.jupyter-releaser]
-skip = ["check-links"]
-
 [tool.jupyter-releaser.hooks]
 before-build-python = ["npm install", "npm run build"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ filterwarnings = [
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:unclosed <socket.socket:ResourceWarning",
   "ignore:unclosed event loop:ResourceWarning",
-  "ignore:run_pre_save_hook is deprecated:DeprecationWarning"
+  "ignore:run_pre_save_hook is deprecated:DeprecationWarning",
+  "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
 ]
 
 [tool.jupyter-releaser.hooks]


### PR DESCRIPTION
This updates us to use the version2 branch of releaser for check-release, and the check-links action from maintainer tools.  Once we release a v2 tag of releaser, we can update the workflows to target that tag.