### PR TITLE
Fallback new file type to file for contents put

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -254,6 +254,9 @@ class ContentsHandler(ContentsAPIHandler):
                 raise web.HTTPError(400, f"Cannot create file or directory {path!r}")
 
             exists = await ensure_async(self.contents_manager.file_exists(path))
+            if model.get("type", "") not in {None, "", "directory", "file", "notebook"}:
+                # fall back to file if unknown type
+                model["type"] = "file"
             if exists:
                 await self._save(model, path)
             else:


### PR DESCRIPTION
This changes allow new file type can be saved by contents put request.
I think this should be fixed during https://github.com/jupyter-server/jupyter_server/pull/895.

Related Issue:
https://github.com/jupyter-server/jupyter_server/issues/884

