### PR TITLE
Simplify releaser setup

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -18,6 +18,8 @@ on:
         type: boolean
 jobs:
   prep_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -34,7 +36,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter-releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           target: ${{ github.repository }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   publish_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -30,7 +32,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter-releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ github.repository }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
@@ -43,7 +45,7 @@ jobs:
           TWINE_USERNAME: __token__
         uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ github.repository }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 


### PR DESCRIPTION
Use the GITHUB_TOKEN from the workflow run and rely on tag protection

cf https://github.com/jupyter-server/jupyter_releaser/issues/433

(This won't work for releasing until that change is made)
