### PR TITLE
Add pyproject validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
+        stages: [manual]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
       - id: mypy
         additional_dependencies: [types-requests]
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
+    hooks:
+      - id: validate-pyproject
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:


### PR DESCRIPTION
Use https://github.com/abravalheri/validate-pyproject to validate the pyproject.toml, including trove classifiers.