### PR TITLE
Make node optional

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,5 +1,0 @@
-name: jupyter_server_docs
-dependencies:
-  - nodejs
-  - python
-  - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ validate-bump = false
 artifacts = ["jupyter_server/static/style"]
 
 [tool.hatch.build.hooks.jupyter-builder]
-dependencies = ["hatch-jupyter-builder>=0.8"]
+dependencies = ["hatch-jupyter-builder>=0.8.1"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
   "jupyter_server/static/style/bootstrap.min.css",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling >=1.0"]
+requires = ["hatchling >=1.11"]
 build-backend = "hatchling.build"
 
 [project]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,6 +6,6 @@ python:
   install:
     # install itself with pip install .
     - method: pip
-      path: "-e ."
+      path: .
       extra_requirements:
         - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,6 +6,6 @@ python:
   install:
     # install itself with pip install .
     - method: pip
-      path: .
+      path: "-e ."
       extra_requirements:
         - docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,8 +1,6 @@
 version: 2
 sphinx:
   configuration: docs/source/conf.py
-conda:
-  environment: docs/environment.yml
 python:
   version: 3.8
   install:


### PR DESCRIPTION
Added `SKIP_JUPYTER_BUILDER=1` to readthedocs config for the project.
When installing in editable mode locally, node is now optional.