### PR TITLE
Fix wording

### DIFF
--- a/docs/source/operators/security.rst
+++ b/docs/source/operators/security.rst
@@ -343,7 +343,7 @@ follows:
 
 The ``is_authorized()`` method will automatically be called whenever a handler is decorated with
 ``@authorized`` (from ``jupyter_server.auth``), similarly to the
-``@authenticated`` decorator for authorization (from ``tornado.web``).
+``@authenticated`` decorator for authentication (from ``tornado.web``).
 
 
 Security in notebook documents


### PR DESCRIPTION
I believe the wording is wrong here.

`@authorized` for authorization and `@authenticated` for authentication. Isn't it?