### PR TITLE
Use async managers by default and deprecate synchronous managers

### DIFF
--- a/jupyter_server/services/contents/checkpoints.py
+++ b/jupyter_server/services/contents/checkpoints.py
@@ -3,13 +3,51 @@ Classes for managing Checkpoints.
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import warnings
+
 from tornado.web import HTTPError
 from traitlets.config.configurable import LoggingConfigurable
 
 
-class Checkpoints(LoggingConfigurable):
+class AsyncCheckpoints(LoggingConfigurable):
     """
-    Base class for managing checkpoints for a ContentsManager.
+    Base class for managing checkpoints for a ContentsManager asynchronously.
+    """
+
+    async def create_checkpoint(self, contents_mgr, path):
+        """Create a checkpoint."""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
+        """Restore a checkpoint"""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def rename_checkpoint(self, checkpoint_id, old_path, new_path):
+        """Rename a single checkpoint from old_path to new_path."""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def delete_checkpoint(self, checkpoint_id, path):
+        """delete a checkpoint for a file"""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def list_checkpoints(self, path):
+        """Return a list of checkpoints for a given file"""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def rename_all_checkpoints(self, old_path, new_path):
+        """Rename all checkpoints for old_path to new_path."""
+        for cp in await self.list_checkpoints(old_path):
+            await self.rename_checkpoint(cp["id"], old_path, new_path)
+
+    async def delete_all_checkpoints(self, path):
+        """Delete all checkpoints for the given path."""
+        for checkpoint in await self.list_checkpoints(path):
+            await self.delete_checkpoint(checkpoint["id"], path)
+
+
+class Checkpoints(AsyncCheckpoints):
+    """
+    Synchronous class for managing checkpoints for a ContentsManager.
 
     Subclasses are required to implement:
 
@@ -19,6 +57,14 @@ class Checkpoints(LoggingConfigurable):
     delete_checkpoint(self, checkpoint_id, path)
     list_checkpoints(self, path)
     """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "Checkpoints will become an alias for AsyncCheckpoints in Jupyter Server 3.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def create_checkpoint(self, contents_mgr, path):
         """Create a checkpoint."""
@@ -51,7 +97,80 @@ class Checkpoints(LoggingConfigurable):
             self.delete_checkpoint(checkpoint["id"], path)
 
 
-class GenericCheckpointsMixin:
+class AsyncGenericCheckpointsMixin:
+    """
+    Helper for creating Asynchronous Checkpoints subclasses that can be used with any
+    ContentsManager.
+    """
+
+    async def create_checkpoint(self, contents_mgr, path):
+        model = await contents_mgr.get(path, content=True)
+        type = model["type"]
+        if type == "notebook":
+            return await self.create_notebook_checkpoint(
+                model["content"],
+                path,
+            )
+        elif type == "file":
+            return await self.create_file_checkpoint(
+                model["content"],
+                model["format"],
+                path,
+            )
+        else:
+            raise HTTPError(500, "Unexpected type %s" % type)
+
+    async def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
+        """Restore a checkpoint."""
+        type = await contents_mgr.get(path, content=False)["type"]
+        if type == "notebook":
+            model = await self.get_notebook_checkpoint(checkpoint_id, path)
+        elif type == "file":
+            model = await self.get_file_checkpoint(checkpoint_id, path)
+        else:
+            raise HTTPError(500, "Unexpected type %s" % type)
+        await contents_mgr.save(model, path)
+
+    # Required Methods
+    async def create_file_checkpoint(self, content, format, path):
+        """Create a checkpoint of the current state of a file
+
+        Returns a checkpoint model for the new checkpoint.
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def create_notebook_checkpoint(self, nb, path):
+        """Create a checkpoint of the current state of a file
+
+        Returns a checkpoint model for the new checkpoint.
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def get_file_checkpoint(self, checkpoint_id, path):
+        """Get the content of a checkpoint for a non-notebook file.
+
+        Returns a dict of the form:
+        {
+            'type': 'file',
+            'content': <str>,
+            'format': {'text','base64'},
+        }
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def get_notebook_checkpoint(self, checkpoint_id, path):
+        """Get the content of a checkpoint for a notebook.
+
+        Returns a dict of the form:
+        {
+            'type': 'notebook',
+            'content': <output of nbformat.read>,
+        }
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+
+class GenericCheckpointsMixin(AsyncGenericCheckpointsMixin):
     """
     Helper for creating Checkpoints subclasses that can be used with any
     ContentsManager.
@@ -129,115 +248,6 @@ class GenericCheckpointsMixin:
         raise NotImplementedError("must be implemented in a subclass")
 
     def get_notebook_checkpoint(self, checkpoint_id, path):
-        """Get the content of a checkpoint for a notebook.
-
-        Returns a dict of the form:
-        {
-            'type': 'notebook',
-            'content': <output of nbformat.read>,
-        }
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-
-class AsyncCheckpoints(Checkpoints):
-    """
-    Base class for managing checkpoints for a ContentsManager asynchronously.
-    """
-
-    async def create_checkpoint(self, contents_mgr, path):
-        """Create a checkpoint."""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
-        """Restore a checkpoint"""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def rename_checkpoint(self, checkpoint_id, old_path, new_path):
-        """Rename a single checkpoint from old_path to new_path."""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def delete_checkpoint(self, checkpoint_id, path):
-        """delete a checkpoint for a file"""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def list_checkpoints(self, path):
-        """Return a list of checkpoints for a given file"""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def rename_all_checkpoints(self, old_path, new_path):
-        """Rename all checkpoints for old_path to new_path."""
-        for cp in await self.list_checkpoints(old_path):
-            await self.rename_checkpoint(cp["id"], old_path, new_path)
-
-    async def delete_all_checkpoints(self, path):
-        """Delete all checkpoints for the given path."""
-        for checkpoint in await self.list_checkpoints(path):
-            await self.delete_checkpoint(checkpoint["id"], path)
-
-
-class AsyncGenericCheckpointsMixin(GenericCheckpointsMixin):
-    """
-    Helper for creating Asynchronous Checkpoints subclasses that can be used with any
-    ContentsManager.
-    """
-
-    async def create_checkpoint(self, contents_mgr, path):
-        model = await contents_mgr.get(path, content=True)
-        type = model["type"]
-        if type == "notebook":
-            return await self.create_notebook_checkpoint(
-                model["content"],
-                path,
-            )
-        elif type == "file":
-            return await self.create_file_checkpoint(
-                model["content"],
-                model["format"],
-                path,
-            )
-        else:
-            raise HTTPError(500, "Unexpected type %s" % type)
-
-    async def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
-        """Restore a checkpoint."""
-        type = await contents_mgr.get(path, content=False)["type"]
-        if type == "notebook":
-            model = await self.get_notebook_checkpoint(checkpoint_id, path)
-        elif type == "file":
-            model = await self.get_file_checkpoint(checkpoint_id, path)
-        else:
-            raise HTTPError(500, "Unexpected type %s" % type)
-        await contents_mgr.save(model, path)
-
-    # Required Methods
-    async def create_file_checkpoint(self, content, format, path):
-        """Create a checkpoint of the current state of a file
-
-        Returns a checkpoint model for the new checkpoint.
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def create_notebook_checkpoint(self, nb, path):
-        """Create a checkpoint of the current state of a file
-
-        Returns a checkpoint model for the new checkpoint.
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def get_file_checkpoint(self, checkpoint_id, path):
-        """Get the content of a checkpoint for a non-notebook file.
-
-        Returns a dict of the form:
-        {
-            'type': 'file',
-            'content': <str>,
-            'format': {'text','base64'},
-        }
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def get_notebook_checkpoint(self, checkpoint_id, path):
         """Get the content of a checkpoint for a notebook.
 
         Returns a dict of the form:

--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -20,14 +20,7 @@ from .checkpoints import (
 from .fileio import AsyncFileManagerMixin, FileManagerMixin
 
 
-class FileCheckpoints(FileManagerMixin, Checkpoints):
-    """
-    A Checkpoints that caches checkpoints for files in adjacent
-    directories.
-
-    Only works with FileContentsManager.  Use GenericFileCheckpoints if
-    you want file-based checkpoints with another ContentsManager.
-    """
+class AsyncFileCheckpoints(AsyncFileManagerMixin, AsyncCheckpoints):
 
     checkpoint_dir = Unicode(
         ".ipynb_checkpoints",
@@ -48,94 +41,6 @@ class FileCheckpoints(FileManagerMixin, Checkpoints):
         except AttributeError:
             return os.getcwd()
 
-    # ContentsManager-dependent checkpoint API
-    def create_checkpoint(self, contents_mgr, path):
-        """Create a checkpoint."""
-        checkpoint_id = "checkpoint"
-        src_path = contents_mgr._get_os_path(path)
-        dest_path = self.checkpoint_path(checkpoint_id, path)
-        self._copy(src_path, dest_path)
-        return self.checkpoint_model(checkpoint_id, dest_path)
-
-    def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
-        """Restore a checkpoint."""
-        src_path = self.checkpoint_path(checkpoint_id, path)
-        dest_path = contents_mgr._get_os_path(path)
-        self._copy(src_path, dest_path)
-
-    # ContentsManager-independent checkpoint API
-    def rename_checkpoint(self, checkpoint_id, old_path, new_path):
-        """Rename a checkpoint from old_path to new_path."""
-        old_cp_path = self.checkpoint_path(checkpoint_id, old_path)
-        new_cp_path = self.checkpoint_path(checkpoint_id, new_path)
-        if os.path.isfile(old_cp_path):
-            self.log.debug(
-                "Renaming checkpoint %s -> %s",
-                old_cp_path,
-                new_cp_path,
-            )
-            with self.perm_to_403():
-                shutil.move(old_cp_path, new_cp_path)
-
-    def delete_checkpoint(self, checkpoint_id, path):
-        """delete a file's checkpoint"""
-        path = path.strip("/")
-        cp_path = self.checkpoint_path(checkpoint_id, path)
-        if not os.path.isfile(cp_path):
-            self.no_such_checkpoint(path, checkpoint_id)
-
-        self.log.debug("unlinking %s", cp_path)
-        with self.perm_to_403():
-            os.unlink(cp_path)
-
-    def list_checkpoints(self, path):
-        """list the checkpoints for a given file
-
-        This contents manager currently only supports one checkpoint per file.
-        """
-        path = path.strip("/")
-        checkpoint_id = "checkpoint"
-        os_path = self.checkpoint_path(checkpoint_id, path)
-        if not os.path.isfile(os_path):
-            return []
-        else:
-            return [self.checkpoint_model(checkpoint_id, os_path)]
-
-    # Checkpoint-related utilities
-    def checkpoint_path(self, checkpoint_id, path):
-        """find the path to a checkpoint"""
-        path = path.strip("/")
-        parent, name = ("/" + path).rsplit("/", 1)
-        parent = parent.strip("/")
-        basename, ext = os.path.splitext(name)
-        filename = "{name}-{checkpoint_id}{ext}".format(
-            name=basename,
-            checkpoint_id=checkpoint_id,
-            ext=ext,
-        )
-        os_path = self._get_os_path(path=parent)
-        cp_dir = os.path.join(os_path, self.checkpoint_dir)
-        with self.perm_to_403():
-            ensure_dir_exists(cp_dir)
-        cp_path = os.path.join(cp_dir, filename)
-        return cp_path
-
-    def checkpoint_model(self, checkpoint_id, os_path):
-        """construct the info dict for a given checkpoint"""
-        stats = os.stat(os_path)
-        last_modified = tz.utcfromtimestamp(stats.st_mtime)
-        info = dict(
-            id=checkpoint_id,
-            last_modified=last_modified,
-        )
-        return info
-
-    # Error Handling
-    def no_such_checkpoint(self, path, checkpoint_id):
-        raise HTTPError(404, f"Checkpoint does not exist: {path}@{checkpoint_id}")
-
-
-class AsyncFileCheckpoints(FileCheckpoints, AsyncFileManagerMixin, AsyncCheckpoints):
     async def create_checkpoint(self, contents_mgr, path):
         """Create a checkpoint."""
         checkpoint_id = "checkpoint"
@@ -197,6 +102,102 @@ class AsyncFileCheckpoints(FileCheckpoints, AsyncFileManagerMixin, AsyncCheckpoi
             return []
         else:
             return [await self.checkpoint_model(checkpoint_id, os_path)]
+
+    # Checkpoint-related utilities
+    def checkpoint_path(self, checkpoint_id, path):
+        """find the path to a checkpoint"""
+        path = path.strip("/")
+        parent, name = ("/" + path).rsplit("/", 1)
+        parent = parent.strip("/")
+        basename, ext = os.path.splitext(name)
+        filename = "{name}-{checkpoint_id}{ext}".format(
+            name=basename,
+            checkpoint_id=checkpoint_id,
+            ext=ext,
+        )
+        os_path = self._get_os_path(path=parent)
+        cp_dir = os.path.join(os_path, self.checkpoint_dir)
+        with self.perm_to_403():
+            ensure_dir_exists(cp_dir)
+        cp_path = os.path.join(cp_dir, filename)
+        return cp_path
+
+    # Error Handling
+    def no_such_checkpoint(self, path, checkpoint_id):
+        raise HTTPError(404, f"Checkpoint does not exist: {path}@{checkpoint_id}")
+
+
+class FileCheckpoints(FileManagerMixin, AsyncFileCheckpoints, Checkpoints):
+    """
+    A Checkpoints that caches checkpoints for files in adjacent
+    directories.
+
+    Only works with FileContentsManager.  Use GenericFileCheckpoints if
+    you want file-based checkpoints with another ContentsManager.
+    """
+
+    # ContentsManager-dependent checkpoint API
+    def create_checkpoint(self, contents_mgr, path):
+        """Create a checkpoint."""
+        checkpoint_id = "checkpoint"
+        src_path = contents_mgr._get_os_path(path)
+        dest_path = self.checkpoint_path(checkpoint_id, path)
+        self._copy(src_path, dest_path)
+        return self.checkpoint_model(checkpoint_id, dest_path)
+
+    def restore_checkpoint(self, contents_mgr, checkpoint_id, path):
+        """Restore a checkpoint."""
+        src_path = self.checkpoint_path(checkpoint_id, path)
+        dest_path = contents_mgr._get_os_path(path)
+        self._copy(src_path, dest_path)
+
+    # ContentsManager-independent checkpoint API
+    def rename_checkpoint(self, checkpoint_id, old_path, new_path):
+        """Rename a checkpoint from old_path to new_path."""
+        old_cp_path = self.checkpoint_path(checkpoint_id, old_path)
+        new_cp_path = self.checkpoint_path(checkpoint_id, new_path)
+        if os.path.isfile(old_cp_path):
+            self.log.debug(
+                "Renaming checkpoint %s -> %s",
+                old_cp_path,
+                new_cp_path,
+            )
+            with self.perm_to_403():
+                shutil.move(old_cp_path, new_cp_path)
+
+    def delete_checkpoint(self, checkpoint_id, path):
+        """delete a file's checkpoint"""
+        path = path.strip("/")
+        cp_path = self.checkpoint_path(checkpoint_id, path)
+        if not os.path.isfile(cp_path):
+            self.no_such_checkpoint(path, checkpoint_id)
+
+        self.log.debug("unlinking %s", cp_path)
+        with self.perm_to_403():
+            os.unlink(cp_path)
+
+    def list_checkpoints(self, path):
+        """list the checkpoints for a given file
+
+        This contents manager currently only supports one checkpoint per file.
+        """
+        path = path.strip("/")
+        checkpoint_id = "checkpoint"
+        os_path = self.checkpoint_path(checkpoint_id, path)
+        if not os.path.isfile(os_path):
+            return []
+        else:
+            return [self.checkpoint_model(checkpoint_id, os_path)]
+
+    def checkpoint_model(self, checkpoint_id, os_path):
+        """construct the info dict for a given checkpoint"""
+        stats = os.stat(os_path)
+        last_modified = tz.utcfromtimestamp(stats.st_mtime)
+        info = dict(
+            id=checkpoint_id,
+            last_modified=last_modified,
+        )
+        return info
 
 
 class GenericFileCheckpoints(GenericCheckpointsMixin, FileCheckpoints):

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -229,13 +229,6 @@ class FileManagerMixinBase(Configurable):
             else:
                 raise
 
-    def _copy(self, src, dest):
-        """copy src to dest
-
-        like shutil.copy2, but log errors in copystat
-        """
-        copy2_safe(src, dest, log=self.log)
-
     def _get_os_path(self, path):
         """Given an API path, return its file system path.
 
@@ -299,6 +292,13 @@ class FileManagerMixin(FileManagerMixinBase):
                 version=nbformat.NO_CONVERT,
                 capture_validation_error=capture_validation_error,
             )
+
+    def _copy(self, src, dest):
+        """copy src to dest
+
+        like shutil.copy2, but log errors in copystat
+        """
+        copy2_safe(src, dest, log=self.log)
 
     def _read_file(self, os_path, format):
         """Read a non-notebook file.

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -165,7 +165,7 @@ def _simple_writing(path, text=True, encoding="utf-8", log=None, **kwargs):
     fileobj.close()
 
 
-class FileManagerMixin(Configurable):
+class FileManagerMixinBase(Configurable):
     """
     Mixin for ContentsAPI classes that interact with the filesystem.
 
@@ -259,6 +259,8 @@ class FileManagerMixin(Configurable):
             raise HTTPError(404, "%s is outside root contents directory" % path)
         return os_path
 
+
+class FileManagerMixin(FileManagerMixinBase):
     def _read_notebook(self, os_path, as_version=4, capture_validation_error=None):
         """Read a notebook from an os path."""
         with self.open(os_path, "r", encoding="utf-8") as f:
@@ -347,7 +349,7 @@ class FileManagerMixin(Configurable):
             f.write(bcontent)
 
 
-class AsyncFileManagerMixin(FileManagerMixin):
+class AsyncFileManagerMixin(FileManagerMixinBase):
     """
     Mixin for ContentsAPI classes that interact with the filesystem asynchronously.
     """

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -33,7 +33,7 @@ except ImportError:
 _script_exporter = None
 
 
-class FileContentsManager(FileManagerMixin, ContentsManager):
+class AsyncFileContentsManager(AsyncFileManagerMixin, AsyncContentsManager):
 
     root_dir = Unicode(config=True)
 
@@ -54,10 +54,6 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not os.path.isdir(value):
             raise TraitError("%r is not a directory" % value)
         return value
-
-    @default("checkpoints_class")
-    def _checkpoints_class_default(self):
-        return FileCheckpoints
 
     delete_to_trash = Bool(
         True,
@@ -85,493 +81,6 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     def _files_handler_params_default(self):
         return {"path": self.root_dir}
 
-    def is_hidden(self, path):
-        """Does the API style path correspond to a hidden directory or file?
-
-        Parameters
-        ----------
-        path : string
-            The path to check. This is an API path (`/` separated,
-            relative to root_dir).
-
-        Returns
-        -------
-        hidden : bool
-            Whether the path exists and is hidden.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path=path)
-        return is_hidden(os_path, self.root_dir)
-
-    def is_writable(self, path):
-        """Does the API style path correspond to a writable directory or file?
-
-        Parameters
-        ----------
-        path : string
-            The path to check. This is an API path (`/` separated,
-            relative to root_dir).
-
-        Returns
-        -------
-        hidden : bool
-            Whether the path exists and is writable.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path=path)
-        try:
-            return os.access(os_path, os.W_OK)
-        except OSError:
-            self.log.error("Failed to check write permissions on %s", os_path)
-            return False
-
-    def file_exists(self, path):
-        """Returns True if the file exists, else returns False.
-
-        API-style wrapper for os.path.isfile
-
-        Parameters
-        ----------
-        path : string
-            The relative path to the file (with '/' as separator)
-
-        Returns
-        -------
-        exists : bool
-            Whether the file exists.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path)
-        return os.path.isfile(os_path)
-
-    def dir_exists(self, path):
-        """Does the API-style path refer to an extant directory?
-
-        API-style wrapper for os.path.isdir
-
-        Parameters
-        ----------
-        path : string
-            The path to check. This is an API path (`/` separated,
-            relative to root_dir).
-
-        Returns
-        -------
-        exists : bool
-            Whether the path is indeed a directory.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path=path)
-        return os.path.isdir(os_path)
-
-    def exists(self, path):
-        """Returns True if the path exists, else returns False.
-
-        API-style wrapper for os.path.exists
-
-        Parameters
-        ----------
-        path : string
-            The API path to the file (with '/' as separator)
-
-        Returns
-        -------
-        exists : bool
-            Whether the target exists.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path=path)
-        return exists(os_path)
-
-    def _base_model(self, path):
-        """Build the common base of a contents model"""
-        os_path = self._get_os_path(path)
-        info = os.lstat(os_path)
-
-        four_o_four = "file or directory does not exist: %r" % path
-
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
-            raise web.HTTPError(404, four_o_four)
-
-        try:
-            # size of file
-            size = info.st_size
-        except (ValueError, OSError):
-            self.log.warning("Unable to get size.")
-            size = None
-
-        try:
-            last_modified = tz.utcfromtimestamp(info.st_mtime)
-        except (ValueError, OSError):
-            # Files can rarely have an invalid timestamp
-            # https://github.com/jupyter/notebook/issues/2539
-            # https://github.com/jupyter/notebook/issues/2757
-            # Use the Unix epoch as a fallback so we don't crash.
-            self.log.warning("Invalid mtime %s for %s", info.st_mtime, os_path)
-            last_modified = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
-
-        try:
-            created = tz.utcfromtimestamp(info.st_ctime)
-        except (ValueError, OSError):  # See above
-            self.log.warning("Invalid ctime %s for %s", info.st_ctime, os_path)
-            created = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
-
-        # Create the base model.
-        model = {}
-        model["name"] = path.rsplit("/", 1)[-1]
-        model["path"] = path
-        model["last_modified"] = last_modified
-        model["created"] = created
-        model["content"] = None
-        model["format"] = None
-        model["mimetype"] = None
-        model["size"] = size
-        model["writable"] = self.is_writable(path)
-
-        return model
-
-    def _dir_model(self, path, content=True):
-        """Build a model for a directory
-
-        if content is requested, will include a listing of the directory
-        """
-        os_path = self._get_os_path(path)
-
-        four_o_four = "directory does not exist: %r" % path
-
-        if not os.path.isdir(os_path):
-            raise web.HTTPError(404, four_o_four)
-        elif is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
-            raise web.HTTPError(404, four_o_four)
-
-        model = self._base_model(path)
-        model["type"] = "directory"
-        model["size"] = None
-        if content:
-            model["content"] = contents = []
-            os_dir = self._get_os_path(path)
-            for name in os.listdir(os_dir):
-                try:
-                    os_path = os.path.join(os_dir, name)
-                except UnicodeDecodeError as e:
-                    self.log.warning("failed to decode filename '%s': %s", name, e)
-                    continue
-
-                try:
-                    st = os.lstat(os_path)
-                except OSError as e:
-                    # skip over broken symlinks in listing
-                    if e.errno == errno.ENOENT:
-                        self.log.warning("%s doesn't exist", os_path)
-                    elif e.errno != errno.EACCES:  # Don't provide clues about protected files
-                        self.log.warning("Error stat-ing %s: %s", os_path, e)
-                    continue
-
-                if (
-                    not stat.S_ISLNK(st.st_mode)
-                    and not stat.S_ISREG(st.st_mode)
-                    and not stat.S_ISDIR(st.st_mode)
-                ):
-                    self.log.debug("%s not a regular file", os_path)
-                    continue
-
-                try:
-                    if self.should_list(name):
-                        if self.allow_hidden or not is_file_hidden(os_path, stat_res=st):
-                            contents.append(self.get(path=f"{path}/{name}", content=False))
-                except OSError as e:
-                    # ELOOP: recursive symlink, also don't show failure due to permissions
-                    if e.errno not in [errno.ELOOP, errno.EACCES]:
-                        self.log.warning(
-                            "Unknown error checking if file %r is hidden",
-                            os_path,
-                            exc_info=True,
-                        )
-
-            model["format"] = "json"
-
-        return model
-
-    def _file_model(self, path, content=True, format=None):
-        """Build a model for a file
-
-        if content is requested, include the file contents.
-
-        format:
-          If 'text', the contents will be decoded as UTF-8.
-          If 'base64', the raw bytes contents will be encoded as base64.
-          If not specified, try to decode as UTF-8, and fall back to base64
-        """
-        model = self._base_model(path)
-        model["type"] = "file"
-
-        os_path = self._get_os_path(path)
-        model["mimetype"] = mimetypes.guess_type(os_path)[0]
-
-        if content:
-            content, format = self._read_file(os_path, format)
-            if model["mimetype"] is None:
-                default_mime = {
-                    "text": "text/plain",
-                    "base64": "application/octet-stream",
-                }[format]
-                model["mimetype"] = default_mime
-
-            model.update(
-                content=content,
-                format=format,
-            )
-
-        return model
-
-    def _notebook_model(self, path, content=True):
-        """Build a notebook model
-
-        if content is requested, the notebook content will be populated
-        as a JSON structure (not double-serialized)
-        """
-        model = self._base_model(path)
-        model["type"] = "notebook"
-        os_path = self._get_os_path(path)
-
-        if content:
-            validation_error: dict = {}
-            nb = self._read_notebook(
-                os_path, as_version=4, capture_validation_error=validation_error
-            )
-            self.mark_trusted_cells(nb, path)
-            model["content"] = nb
-            model["format"] = "json"
-            self.validate_notebook_model(model, validation_error)
-
-        return model
-
-    def get(self, path, content=True, type=None, format=None):
-        """Takes a path for an entity and returns its model
-
-        Parameters
-        ----------
-        path : str
-            the API path that describes the relative path for the target
-        content : bool
-            Whether to include the contents in the reply
-        type : str, optional
-            The requested type - 'file', 'notebook', or 'directory'.
-            Will raise HTTPError 400 if the content doesn't match.
-        format : str, optional
-            The requested format for file contents. 'text' or 'base64'.
-            Ignored if this returns a notebook or directory model.
-
-        Returns
-        -------
-        model : dict
-            the contents model. If content=True, returns the contents
-            of the file or directory as well.
-        """
-        path = path.strip("/")
-        os_path = self._get_os_path(path)
-        four_o_four = "file or directory does not exist: %r" % path
-
-        if not self.exists(path):
-            raise web.HTTPError(404, four_o_four)
-
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
-            raise web.HTTPError(404, four_o_four)
-
-        if os.path.isdir(os_path):
-            if type not in (None, "directory"):
-                raise web.HTTPError(
-                    400,
-                    f"{path} is a directory, not a {type}",
-                    reason="bad type",
-                )
-            model = self._dir_model(path, content=content)
-        elif type == "notebook" or (type is None and path.endswith(".ipynb")):
-            model = self._notebook_model(path, content=content)
-        else:
-            if type == "directory":
-                raise web.HTTPError(400, "%s is not a directory" % path, reason="bad type")
-            model = self._file_model(path, content=content, format=format)
-        self.emit(data={"action": "get", "path": path})
-        return model
-
-    def _save_directory(self, os_path, model, path=""):
-        """create a directory"""
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            raise web.HTTPError(400, "Cannot create directory %r" % os_path)
-        if not os.path.exists(os_path):
-            with self.perm_to_403():
-                os.mkdir(os_path)
-        elif not os.path.isdir(os_path):
-            raise web.HTTPError(400, "Not a directory: %s" % (os_path))
-        else:
-            self.log.debug("Directory %r already exists", os_path)
-
-    def save(self, model, path=""):
-        """Save the file model and return the model with no content."""
-        path = path.strip("/")
-
-        self.run_pre_save_hooks(model=model, path=path)
-
-        if "type" not in model:
-            raise web.HTTPError(400, "No file type provided")
-        if "content" not in model and model["type"] != "directory":
-            raise web.HTTPError(400, "No file content provided")
-
-        os_path = self._get_os_path(path)
-
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            raise web.HTTPError(400, f"Cannot create file or directory {os_path!r}")
-
-        self.log.debug("Saving %s", os_path)
-
-        validation_error: dict = {}
-        try:
-            if model["type"] == "notebook":
-                nb = nbformat.from_dict(model["content"])
-                self.check_and_sign(nb, path)
-                self._save_notebook(os_path, nb, capture_validation_error=validation_error)
-                # One checkpoint should always exist for notebooks.
-                if not self.checkpoints.list_checkpoints(path):
-                    self.create_checkpoint(path)
-            elif model["type"] == "file":
-                # Missing format will be handled internally by _save_file.
-                self._save_file(os_path, model["content"], model.get("format"))
-            elif model["type"] == "directory":
-                self._save_directory(os_path, model, path)
-            else:
-                raise web.HTTPError(400, "Unhandled contents type: %s" % model["type"])
-        except web.HTTPError:
-            raise
-        except Exception as e:
-            self.log.error("Error while saving file: %s %s", path, e, exc_info=True)
-            raise web.HTTPError(500, f"Unexpected error while saving file: {path} {e}") from e
-
-        validation_message = None
-        if model["type"] == "notebook":
-            self.validate_notebook_model(model, validation_error=validation_error)
-            validation_message = model.get("message", None)
-
-        model = self.get(path, content=False)
-        if validation_message:
-            model["message"] = validation_message
-
-        self.run_post_save_hooks(model=model, os_path=os_path)
-        self.emit(data={"action": "save", "path": path})
-        return model
-
-    def delete_file(self, path):
-        """Delete file at path."""
-        path = path.strip("/")
-        os_path = self._get_os_path(path)
-        rm = os.unlink
-        four_o_four = "file or directory does not exist: %r" % path
-
-        if not self.exists(path):
-            raise web.HTTPError(404, four_o_four)
-
-        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
-            raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
-
-        def _check_trash(os_path):
-            if sys.platform in {"win32", "darwin"}:
-                return True
-
-            # It's a bit more nuanced than this, but until we can better
-            # distinguish errors from send2trash, assume that we can only trash
-            # files on the same partition as the home directory.
-            file_dev = os.stat(os_path).st_dev
-            home_dev = os.stat(os.path.expanduser("~")).st_dev
-            return file_dev == home_dev
-
-        def is_non_empty_dir(os_path):
-            if os.path.isdir(os_path):
-                # A directory containing only leftover checkpoints is
-                # considered empty.
-                cp_dir = getattr(self.checkpoints, "checkpoint_dir", None)
-                if set(os.listdir(os_path)) - {cp_dir}:
-                    return True
-
-            return False
-
-        if self.delete_to_trash:
-            if not self.always_delete_dir and sys.platform == "win32" and is_non_empty_dir(os_path):
-                # send2trash can really delete files on Windows, so disallow
-                # deleting non-empty files. See Github issue 3631.
-                raise web.HTTPError(400, "Directory %s not empty" % os_path)
-            if _check_trash(os_path):
-                # Looking at the code in send2trash, I don't think the errors it
-                # raises let us distinguish permission errors from other errors in
-                # code. So for now, the "look before you leap" approach is used.
-                if not self.is_writable(path):
-                    raise web.HTTPError(403, "Permission denied: %s" % path)
-                self.log.debug("Sending %s to trash", os_path)
-                send2trash(os_path)
-                return
-            else:
-                self.log.warning(
-                    "Skipping trash for %s, on different device to home directory",
-                    os_path,
-                )
-
-        if os.path.isdir(os_path):
-            # Don't permanently delete non-empty directories.
-            if not self.always_delete_dir and is_non_empty_dir(os_path):
-                raise web.HTTPError(400, "Directory %s not empty" % os_path)
-            self.log.debug("Removing directory %s", os_path)
-            with self.perm_to_403():
-                shutil.rmtree(os_path)
-        else:
-            self.log.debug("Unlinking file %s", os_path)
-            with self.perm_to_403():
-                rm(os_path)
-
-    def rename_file(self, old_path, new_path):
-        """Rename a file."""
-        old_path = old_path.strip("/")
-        new_path = new_path.strip("/")
-        if new_path == old_path:
-            return
-
-        new_os_path = self._get_os_path(new_path)
-        old_os_path = self._get_os_path(old_path)
-
-        if (
-            is_hidden(old_os_path, self.root_dir) or is_hidden(new_os_path, self.root_dir)
-        ) and not self.allow_hidden:
-            raise web.HTTPError(400, f"Cannot rename file or directory {old_os_path!r}")
-
-        # Should we proceed with the move?
-        if os.path.exists(new_os_path) and not samefile(old_os_path, new_os_path):
-            raise web.HTTPError(409, "File already exists: %s" % new_path)
-
-        # Move the file
-        try:
-            with self.perm_to_403():
-                shutil.move(old_os_path, new_os_path)
-        except web.HTTPError:
-            raise
-        except Exception as e:
-            raise web.HTTPError(500, f"Unknown error renaming file: {old_path} {e}") from e
-
-    def info_string(self):
-        return _i18n("Serving notebooks from local directory: %s") % self.root_dir
-
-    def get_kernel_path(self, path, model=None):
-        """Return the initial API path of  a kernel associated with a given notebook"""
-        if self.dir_exists(path):
-            return path
-        if "/" in path:
-            parent_dir = path.rsplit("/", 1)[0]
-        else:
-            parent_dir = ""
-        return parent_dir
-
-
-class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, AsyncContentsManager):
     @default("checkpoints_class")
     def _checkpoints_class_default(self):
         return AsyncFileCheckpoints
@@ -910,6 +419,497 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
     async def get_kernel_path(self, path, model=None):
         """Return the initial API path of a kernel associated with a given notebook"""
         if await self.dir_exists(path):
+            return path
+        if "/" in path:
+            parent_dir = path.rsplit("/", 1)[0]
+        else:
+            parent_dir = ""
+        return parent_dir
+
+    def is_writable(self, path):
+        """Does the API style path correspond to a writable directory or file?
+
+        Parameters
+        ----------
+        path : string
+            The path to check. This is an API path (`/` separated,
+            relative to root_dir).
+
+        Returns
+        -------
+        hidden : bool
+            Whether the path exists and is writable.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        try:
+            return os.access(os_path, os.W_OK)
+        except OSError:
+            self.log.error("Failed to check write permissions on %s", os_path)
+            return False
+
+    def exists(self, path):
+        """Returns True if the path exists, else returns False.
+
+        API-style wrapper for os.path.exists
+
+        Parameters
+        ----------
+        path : string
+            The API path to the file (with '/' as separator)
+
+        Returns
+        -------
+        exists : bool
+            Whether the target exists.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        return exists(os_path)
+
+    def _base_model(self, path):
+        """Build the common base of a contents model"""
+        os_path = self._get_os_path(path)
+        info = os.lstat(os_path)
+
+        four_o_four = "file or directory does not exist: %r" % path
+
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
+            raise web.HTTPError(404, four_o_four)
+
+        try:
+            # size of file
+            size = info.st_size
+        except (ValueError, OSError):
+            self.log.warning("Unable to get size.")
+            size = None
+
+        try:
+            last_modified = tz.utcfromtimestamp(info.st_mtime)
+        except (ValueError, OSError):
+            # Files can rarely have an invalid timestamp
+            # https://github.com/jupyter/notebook/issues/2539
+            # https://github.com/jupyter/notebook/issues/2757
+            # Use the Unix epoch as a fallback so we don't crash.
+            self.log.warning("Invalid mtime %s for %s", info.st_mtime, os_path)
+            last_modified = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
+
+        try:
+            created = tz.utcfromtimestamp(info.st_ctime)
+        except (ValueError, OSError):  # See above
+            self.log.warning("Invalid ctime %s for %s", info.st_ctime, os_path)
+            created = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
+
+        # Create the base model.
+        model = {}
+        model["name"] = path.rsplit("/", 1)[-1]
+        model["path"] = path
+        model["last_modified"] = last_modified
+        model["created"] = created
+        model["content"] = None
+        model["format"] = None
+        model["mimetype"] = None
+        model["size"] = size
+        model["writable"] = self.is_writable(path)
+
+        return model
+
+    def info_string(self):
+        return _i18n("Serving notebooks from local directory: %s") % self.root_dir
+
+
+class FileContentsManager(AsyncFileContentsManager, FileManagerMixin, ContentsManager):
+    @default("checkpoints_class")
+    def _checkpoints_class_default(self):
+        return FileCheckpoints
+
+    def is_hidden(self, path):
+        """Does the API style path correspond to a hidden directory or file?
+
+        Parameters
+        ----------
+        path : string
+            The path to check. This is an API path (`/` separated,
+            relative to root_dir).
+
+        Returns
+        -------
+        hidden : bool
+            Whether the path exists and is hidden.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        return is_hidden(os_path, self.root_dir)
+
+    def file_exists(self, path):
+        """Returns True if the file exists, else returns False.
+
+        API-style wrapper for os.path.isfile
+
+        Parameters
+        ----------
+        path : string
+            The relative path to the file (with '/' as separator)
+
+        Returns
+        -------
+        exists : bool
+            Whether the file exists.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path)
+        return os.path.isfile(os_path)
+
+    def dir_exists(self, path):
+        """Does the API-style path refer to an extant directory?
+
+        API-style wrapper for os.path.isdir
+
+        Parameters
+        ----------
+        path : string
+            The path to check. This is an API path (`/` separated,
+            relative to root_dir).
+
+        Returns
+        -------
+        exists : bool
+            Whether the path is indeed a directory.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path=path)
+        return os.path.isdir(os_path)
+
+    def _dir_model(self, path, content=True):
+        """Build a model for a directory
+
+        if content is requested, will include a listing of the directory
+        """
+        os_path = self._get_os_path(path)
+
+        four_o_four = "directory does not exist: %r" % path
+
+        if not os.path.isdir(os_path):
+            raise web.HTTPError(404, four_o_four)
+        elif is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
+            raise web.HTTPError(404, four_o_four)
+
+        model = self._base_model(path)
+        model["type"] = "directory"
+        model["size"] = None
+        if content:
+            model["content"] = contents = []
+            os_dir = self._get_os_path(path)
+            for name in os.listdir(os_dir):
+                try:
+                    os_path = os.path.join(os_dir, name)
+                except UnicodeDecodeError as e:
+                    self.log.warning("failed to decode filename '%s': %s", name, e)
+                    continue
+
+                try:
+                    st = os.lstat(os_path)
+                except OSError as e:
+                    # skip over broken symlinks in listing
+                    if e.errno == errno.ENOENT:
+                        self.log.warning("%s doesn't exist", os_path)
+                    elif e.errno != errno.EACCES:  # Don't provide clues about protected files
+                        self.log.warning("Error stat-ing %s: %s", os_path, e)
+                    continue
+
+                if (
+                    not stat.S_ISLNK(st.st_mode)
+                    and not stat.S_ISREG(st.st_mode)
+                    and not stat.S_ISDIR(st.st_mode)
+                ):
+                    self.log.debug("%s not a regular file", os_path)
+                    continue
+
+                try:
+                    if self.should_list(name):
+                        if self.allow_hidden or not is_file_hidden(os_path, stat_res=st):
+                            contents.append(self.get(path=f"{path}/{name}", content=False))
+                except OSError as e:
+                    # ELOOP: recursive symlink, also don't show failure due to permissions
+                    if e.errno not in [errno.ELOOP, errno.EACCES]:
+                        self.log.warning(
+                            "Unknown error checking if file %r is hidden",
+                            os_path,
+                            exc_info=True,
+                        )
+
+            model["format"] = "json"
+
+        return model
+
+    def _file_model(self, path, content=True, format=None):
+        """Build a model for a file
+
+        if content is requested, include the file contents.
+
+        format:
+          If 'text', the contents will be decoded as UTF-8.
+          If 'base64', the raw bytes contents will be encoded as base64.
+          If not specified, try to decode as UTF-8, and fall back to base64
+        """
+        model = self._base_model(path)
+        model["type"] = "file"
+
+        os_path = self._get_os_path(path)
+        model["mimetype"] = mimetypes.guess_type(os_path)[0]
+
+        if content:
+            content, format = self._read_file(os_path, format)
+            if model["mimetype"] is None:
+                default_mime = {
+                    "text": "text/plain",
+                    "base64": "application/octet-stream",
+                }[format]
+                model["mimetype"] = default_mime
+
+            model.update(
+                content=content,
+                format=format,
+            )
+
+        return model
+
+    def _notebook_model(self, path, content=True):
+        """Build a notebook model
+
+        if content is requested, the notebook content will be populated
+        as a JSON structure (not double-serialized)
+        """
+        model = self._base_model(path)
+        model["type"] = "notebook"
+        os_path = self._get_os_path(path)
+
+        if content:
+            validation_error: dict = {}
+            nb = self._read_notebook(
+                os_path, as_version=4, capture_validation_error=validation_error
+            )
+            self.mark_trusted_cells(nb, path)
+            model["content"] = nb
+            model["format"] = "json"
+            self.validate_notebook_model(model, validation_error)
+
+        return model
+
+    def get(self, path, content=True, type=None, format=None):
+        """Takes a path for an entity and returns its model
+
+        Parameters
+        ----------
+        path : str
+            the API path that describes the relative path for the target
+        content : bool
+            Whether to include the contents in the reply
+        type : str, optional
+            The requested type - 'file', 'notebook', or 'directory'.
+            Will raise HTTPError 400 if the content doesn't match.
+        format : str, optional
+            The requested format for file contents. 'text' or 'base64'.
+            Ignored if this returns a notebook or directory model.
+
+        Returns
+        -------
+        model : dict
+            the contents model. If content=True, returns the contents
+            of the file or directory as well.
+        """
+        path = path.strip("/")
+        os_path = self._get_os_path(path)
+        four_o_four = "file or directory does not exist: %r" % path
+
+        if not self.exists(path):
+            raise web.HTTPError(404, four_o_four)
+
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
+            raise web.HTTPError(404, four_o_four)
+
+        if os.path.isdir(os_path):
+            if type not in (None, "directory"):
+                raise web.HTTPError(
+                    400,
+                    f"{path} is a directory, not a {type}",
+                    reason="bad type",
+                )
+            model = self._dir_model(path, content=content)
+        elif type == "notebook" or (type is None and path.endswith(".ipynb")):
+            model = self._notebook_model(path, content=content)
+        else:
+            if type == "directory":
+                raise web.HTTPError(400, "%s is not a directory" % path, reason="bad type")
+            model = self._file_model(path, content=content, format=format)
+        self.emit(data={"action": "get", "path": path})
+        return model
+
+    def _save_directory(self, os_path, model, path=""):
+        """create a directory"""
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            raise web.HTTPError(400, "Cannot create directory %r" % os_path)
+        if not os.path.exists(os_path):
+            with self.perm_to_403():
+                os.mkdir(os_path)
+        elif not os.path.isdir(os_path):
+            raise web.HTTPError(400, "Not a directory: %s" % (os_path))
+        else:
+            self.log.debug("Directory %r already exists", os_path)
+
+    def save(self, model, path=""):
+        """Save the file model and return the model with no content."""
+        path = path.strip("/")
+
+        self.run_pre_save_hooks(model=model, path=path)
+
+        if "type" not in model:
+            raise web.HTTPError(400, "No file type provided")
+        if "content" not in model and model["type"] != "directory":
+            raise web.HTTPError(400, "No file content provided")
+
+        os_path = self._get_os_path(path)
+
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            raise web.HTTPError(400, f"Cannot create file or directory {os_path!r}")
+
+        self.log.debug("Saving %s", os_path)
+
+        validation_error: dict = {}
+        try:
+            if model["type"] == "notebook":
+                nb = nbformat.from_dict(model["content"])
+                self.check_and_sign(nb, path)
+                self._save_notebook(os_path, nb, capture_validation_error=validation_error)
+                # One checkpoint should always exist for notebooks.
+                if not self.checkpoints.list_checkpoints(path):
+                    self.create_checkpoint(path)
+            elif model["type"] == "file":
+                # Missing format will be handled internally by _save_file.
+                self._save_file(os_path, model["content"], model.get("format"))
+            elif model["type"] == "directory":
+                self._save_directory(os_path, model, path)
+            else:
+                raise web.HTTPError(400, "Unhandled contents type: %s" % model["type"])
+        except web.HTTPError:
+            raise
+        except Exception as e:
+            self.log.error("Error while saving file: %s %s", path, e, exc_info=True)
+            raise web.HTTPError(500, f"Unexpected error while saving file: {path} {e}") from e
+
+        validation_message = None
+        if model["type"] == "notebook":
+            self.validate_notebook_model(model, validation_error=validation_error)
+            validation_message = model.get("message", None)
+
+        model = self.get(path, content=False)
+        if validation_message:
+            model["message"] = validation_message
+
+        self.run_post_save_hooks(model=model, os_path=os_path)
+        self.emit(data={"action": "save", "path": path})
+        return model
+
+    def delete_file(self, path):
+        """Delete file at path."""
+        path = path.strip("/")
+        os_path = self._get_os_path(path)
+        rm = os.unlink
+        four_o_four = "file or directory does not exist: %r" % path
+
+        if not self.exists(path):
+            raise web.HTTPError(404, four_o_four)
+
+        if is_hidden(os_path, self.root_dir) and not self.allow_hidden:
+            raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
+
+        def _check_trash(os_path):
+            if sys.platform in {"win32", "darwin"}:
+                return True
+
+            # It's a bit more nuanced than this, but until we can better
+            # distinguish errors from send2trash, assume that we can only trash
+            # files on the same partition as the home directory.
+            file_dev = os.stat(os_path).st_dev
+            home_dev = os.stat(os.path.expanduser("~")).st_dev
+            return file_dev == home_dev
+
+        def is_non_empty_dir(os_path):
+            if os.path.isdir(os_path):
+                # A directory containing only leftover checkpoints is
+                # considered empty.
+                cp_dir = getattr(self.checkpoints, "checkpoint_dir", None)
+                if set(os.listdir(os_path)) - {cp_dir}:
+                    return True
+
+            return False
+
+        if self.delete_to_trash:
+            if not self.always_delete_dir and sys.platform == "win32" and is_non_empty_dir(os_path):
+                # send2trash can really delete files on Windows, so disallow
+                # deleting non-empty files. See Github issue 3631.
+                raise web.HTTPError(400, "Directory %s not empty" % os_path)
+            if _check_trash(os_path):
+                # Looking at the code in send2trash, I don't think the errors it
+                # raises let us distinguish permission errors from other errors in
+                # code. So for now, the "look before you leap" approach is used.
+                if not self.is_writable(path):
+                    raise web.HTTPError(403, "Permission denied: %s" % path)
+                self.log.debug("Sending %s to trash", os_path)
+                send2trash(os_path)
+                return
+            else:
+                self.log.warning(
+                    "Skipping trash for %s, on different device to home directory",
+                    os_path,
+                )
+
+        if os.path.isdir(os_path):
+            # Don't permanently delete non-empty directories.
+            if not self.always_delete_dir and is_non_empty_dir(os_path):
+                raise web.HTTPError(400, "Directory %s not empty" % os_path)
+            self.log.debug("Removing directory %s", os_path)
+            with self.perm_to_403():
+                shutil.rmtree(os_path)
+        else:
+            self.log.debug("Unlinking file %s", os_path)
+            with self.perm_to_403():
+                rm(os_path)
+
+    def rename_file(self, old_path, new_path):
+        """Rename a file."""
+        old_path = old_path.strip("/")
+        new_path = new_path.strip("/")
+        if new_path == old_path:
+            return
+
+        new_os_path = self._get_os_path(new_path)
+        old_os_path = self._get_os_path(old_path)
+
+        if (
+            is_hidden(old_os_path, self.root_dir) or is_hidden(new_os_path, self.root_dir)
+        ) and not self.allow_hidden:
+            raise web.HTTPError(400, f"Cannot rename file or directory {old_os_path!r}")
+
+        # Should we proceed with the move?
+        if os.path.exists(new_os_path) and not samefile(old_os_path, new_os_path):
+            raise web.HTTPError(409, "File already exists: %s" % new_path)
+
+        # Move the file
+        try:
+            with self.perm_to_403():
+                shutil.move(old_os_path, new_os_path)
+        except web.HTTPError:
+            raise
+        except Exception as e:
+            raise web.HTTPError(500, f"Unknown error renaming file: {old_path} {e}") from e
+
+    def get_kernel_path(self, path, model=None):
+        """Return the initial API path of  a kernel associated with a given notebook"""
+        if self.dir_exists(path):
             return path
         if "/" in path:
             parent_dir = path.rsplit("/", 1)[0]

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -264,7 +264,7 @@ class AsyncFileContentsManager(AsyncFileManagerMixin, AsyncContentsManager):
         """Save the file model and return the model with no content."""
         path = path.strip("/")
 
-        self.run_pre_save_hook(model=model, path=path)
+        self.run_pre_save_hooks(model=model, path=path)
 
         if "type" not in model:
             raise web.HTTPError(400, "No file type provided")

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -519,7 +519,7 @@ class AsyncFileContentsManager(AsyncFileManagerMixin, AsyncContentsManager):
         return _i18n("Serving notebooks from local directory: %s") % self.root_dir
 
 
-class FileContentsManager(AsyncFileContentsManager, FileManagerMixin, ContentsManager):
+class FileContentsManager(FileManagerMixin, AsyncFileContentsManager, ContentsManager):
     @default("checkpoints_class")
     def _checkpoints_class_default(self):
         return FileCheckpoints

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -36,8 +36,8 @@ from .checkpoints import AsyncCheckpoints, Checkpoints
 copy_pat = re.compile(r"\-Copy\d*\.")
 
 
-class ContentsManager(LoggingConfigurable):
-    """Base class for serving files and directories.
+class AsyncContentsManager(LoggingConfigurable):
+    """Async class for serving files and directories.
 
     This serves any text or binary file,
     as well as directories,
@@ -278,8 +278,8 @@ class ContentsManager(LoggingConfigurable):
                 )
                 raise HTTPError(500, "Unexpected error while running post hook save: %s" % e) from e
 
-    checkpoints_class = Type(Checkpoints, config=True)
-    checkpoints = Instance(Checkpoints, config=True)
+    checkpoints_class = Type(AsyncCheckpoints, config=True)
+    checkpoints = Instance(AsyncCheckpoints, config=True)
     checkpoints_kwargs = Dict(config=True)
 
     @default("checkpoints")
@@ -328,6 +328,345 @@ class ContentsManager(LoggingConfigurable):
         if self.files_handler_class:
             handlers.append((r"/files/(.*)", self.files_handler_class, self.files_handler_params))
         return handlers
+
+    # ContentsManager API part 1: methods that must be
+    # implemented in subclasses.
+
+    async def dir_exists(self, path):
+        """Does a directory exist at the given path?
+
+        Like os.path.isdir
+
+        Override this method in subclasses.
+
+        Parameters
+        ----------
+        path : string
+            The path to check
+
+        Returns
+        -------
+        exists : bool
+            Whether the path does indeed exist.
+        """
+        raise NotImplementedError
+
+    async def is_hidden(self, path):
+        """Is path a hidden directory or file?
+
+        Parameters
+        ----------
+        path : string
+            The path to check. This is an API path (`/` separated,
+            relative to root dir).
+
+        Returns
+        -------
+        hidden : bool
+            Whether the path is hidden.
+
+        """
+        raise NotImplementedError
+
+    async def file_exists(self, path=""):
+        """Does a file exist at the given path?
+
+        Like os.path.isfile
+
+        Override this method in subclasses.
+
+        Parameters
+        ----------
+        path : string
+            The API path of a file to check for.
+
+        Returns
+        -------
+        exists : bool
+            Whether the file exists.
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def exists(self, path):
+        """Does a file or directory exist at the given path?
+
+        Like os.path.exists
+
+        Parameters
+        ----------
+        path : string
+            The API path of a file or directory to check for.
+
+        Returns
+        -------
+        exists : bool
+            Whether the target exists.
+        """
+        return await ensure_async(self.file_exists(path)) or await ensure_async(
+            self.dir_exists(path)
+        )
+
+    async def get(self, path, content=True, type=None, format=None):
+        """Get a file or directory model."""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def save(self, model, path):
+        """
+        Save a file or directory model to path.
+
+        Should return the saved model with no content.  Save implementations
+        should call self.run_pre_save_hook(model=model, path=path) prior to
+        writing any data.
+        """
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def delete_file(self, path):
+        """Delete the file or directory at path."""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    async def rename_file(self, old_path, new_path):
+        """Rename a file or directory."""
+        raise NotImplementedError("must be implemented in a subclass")
+
+    # ContentsManager API part 2: methods that have useable default
+    # implementations, but can be overridden in subclasses.
+
+    async def delete(self, path):
+        """Delete a file/directory and any associated checkpoints."""
+        path = path.strip("/")
+        if not path:
+            raise HTTPError(400, "Can't delete root")
+
+        await self.delete_file(path)
+        await self.checkpoints.delete_all_checkpoints(path)
+        self.emit(data={"action": "delete", "path": path})
+
+    async def rename(self, old_path, new_path):
+        """Rename a file and any checkpoints associated with that file."""
+        await self.rename_file(old_path, new_path)
+        await self.checkpoints.rename_all_checkpoints(old_path, new_path)
+        self.emit(data={"action": "rename", "path": new_path, "source_path": old_path})
+
+    async def update(self, model, path):
+        """Update the file's path
+
+        For use in PATCH requests, to enable renaming a file without
+        re-uploading its contents. Only used for renaming at the moment.
+        """
+        path = path.strip("/")
+        new_path = model.get("path", path).strip("/")
+        if path != new_path:
+            await self.rename(path, new_path)
+        model = await self.get(new_path, content=False)
+        return model
+
+    async def increment_filename(self, filename, path="", insert=""):
+        """Increment a filename until it is unique.
+
+        Parameters
+        ----------
+        filename : unicode
+            The name of a file, including extension
+        path : unicode
+            The API path of the target's directory
+        insert : unicode
+            The characters to insert after the base filename
+
+        Returns
+        -------
+        name : unicode
+            A filename that is unique, based on the input filename.
+        """
+        # Extract the full suffix from the filename (e.g. .tar.gz)
+        path = path.strip("/")
+        basename, dot, ext = filename.rpartition(".")
+        if ext != "ipynb":
+            basename, dot, ext = filename.partition(".")
+
+        suffix = dot + ext
+
+        for i in itertools.count():
+            if i:
+                insert_i = f"{insert}{i}"
+            else:
+                insert_i = ""
+            name = "{basename}{insert}{suffix}".format(
+                basename=basename, insert=insert_i, suffix=suffix
+            )
+            file_exists = await ensure_async(self.exists(f"{path}/{name}"))
+            if not file_exists:
+                break
+        return name
+
+    async def new_untitled(self, path="", type="", ext=""):
+        """Create a new untitled file or directory in path
+
+        path must be a directory
+
+        File extension can be specified.
+
+        Use `new` to create files with a fully specified path (including filename).
+        """
+        path = path.strip("/")
+        dir_exists = await ensure_async(self.dir_exists(path))
+        if not dir_exists:
+            raise HTTPError(404, "No such directory: %s" % path)
+
+        model = {}
+        if type:
+            model["type"] = type
+
+        if ext == ".ipynb":
+            model.setdefault("type", "notebook")
+        else:
+            model.setdefault("type", "file")
+
+        insert = ""
+        if model["type"] == "directory":
+            untitled = self.untitled_directory
+            insert = " "
+        elif model["type"] == "notebook":
+            untitled = self.untitled_notebook
+            ext = ".ipynb"
+        elif model["type"] == "file":
+            untitled = self.untitled_file
+        else:
+            raise HTTPError(400, "Unexpected model type: %r" % model["type"])
+
+        name = await self.increment_filename(untitled + ext, path, insert=insert)
+        path = f"{path}/{name}"
+        return await self.new(model, path)
+
+    async def new(self, model=None, path=""):
+        """Create a new file or directory and return its model with no content.
+
+        To create a new untitled entity in a directory, use `new_untitled`.
+        """
+        path = path.strip("/")
+        if model is None:
+            model = {}
+
+        if path.endswith(".ipynb"):
+            model.setdefault("type", "notebook")
+        else:
+            model.setdefault("type", "file")
+
+        # no content, not a directory, so fill out new-file model
+        if "content" not in model and model["type"] != "directory":
+            if model["type"] == "notebook":
+                model["content"] = new_notebook()
+                model["format"] = "json"
+            else:
+                model["content"] = ""
+                model["type"] = "file"
+                model["format"] = "text"
+
+        model = await self.save(model, path)
+        return model
+
+    async def copy(self, from_path, to_path=None):
+        """Copy an existing file and return its new model.
+
+        If to_path not specified, it will be the parent directory of from_path.
+        If to_path is a directory, filename will increment `from_path-Copy#.ext`.
+        Considering multi-part extensions, the Copy# part will be placed before the first dot for all the extensions except `ipynb`.
+        For easier manual searching in case of notebooks, the Copy# part will be placed before the last dot.
+
+        from_path must be a full path to a file.
+        """
+        path = from_path.strip("/")
+
+        if to_path is not None:
+            to_path = to_path.strip("/")
+
+        if "/" in path:
+            from_dir, from_name = path.rsplit("/", 1)
+        else:
+            from_dir = ""
+            from_name = path
+
+        model = await self.get(path)
+        model.pop("path", None)
+        model.pop("name", None)
+        if model["type"] == "directory":
+            raise HTTPError(400, "Can't copy directories")
+
+        is_destination_specified = to_path is not None
+        if not is_destination_specified:
+            to_path = from_dir
+        if await ensure_async(self.dir_exists(to_path)):
+            name = copy_pat.sub(".", from_name)
+            to_name = await self.increment_filename(name, to_path, insert="-Copy")
+            to_path = f"{to_path}/{to_name}"
+        elif is_destination_specified:
+            if "/" in to_path:
+                to_dir, to_name = to_path.rsplit("/", 1)
+                if not await ensure_async(self.dir_exists(to_dir)):
+                    raise HTTPError(404, "No such parent directory: %s to copy file in" % to_dir)
+        else:
+            raise HTTPError(404, "No such directory: %s" % to_path)
+
+        model = await self.save(model, to_path)
+        self.emit(data={"action": "copy", "path": to_path, "source_path": from_path})
+        return model
+
+    async def trust_notebook(self, path):
+        """Explicitly trust a notebook
+
+        Parameters
+        ----------
+        path : string
+            The path of a notebook
+        """
+        model = await self.get(path)
+        nb = model["content"]
+        self.log.warning("Trusting notebook %s", path)
+        self.notary.mark_cells(nb, True)
+        self.check_and_sign(nb, path)
+
+    # Part 3: Checkpoints API
+    async def create_checkpoint(self, path):
+        """Create a checkpoint."""
+        return await self.checkpoints.create_checkpoint(self, path)
+
+    async def restore_checkpoint(self, checkpoint_id, path):
+        """
+        Restore a checkpoint.
+        """
+        await self.checkpoints.restore_checkpoint(self, checkpoint_id, path)
+
+    async def list_checkpoints(self, path):
+        return await self.checkpoints.list_checkpoints(path)
+
+    async def delete_checkpoint(self, checkpoint_id, path):
+        return await self.checkpoints.delete_checkpoint(checkpoint_id, path)
+
+
+class ContentsManager(AsyncContentsManager):
+    """Base class for serving files and directories asynchronously."""
+
+    checkpoints_class = Type(Checkpoints, config=True)
+    checkpoints = Instance(Checkpoints, config=True)
+    checkpoints_kwargs = Dict(config=True)
+
+    @default("checkpoints")
+    def _default_checkpoints(self):
+        return self.checkpoints_class(**self.checkpoints_kwargs)
+
+    @default("checkpoints_kwargs")
+    def _default_checkpoints_kwargs(self):
+        return dict(
+            parent=self,
+            log=self.log,
+        )
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "ContentsManager will become an alias for AsyncContentsManager in Jupyter Server 3.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     # ContentsManager API part 1: methods that must be
     # implemented in subclasses.
@@ -712,334 +1051,3 @@ class ContentsManager(LoggingConfigurable):
 
     def delete_checkpoint(self, checkpoint_id, path):
         return self.checkpoints.delete_checkpoint(checkpoint_id, path)
-
-
-class AsyncContentsManager(ContentsManager):
-    """Base class for serving files and directories asynchronously."""
-
-    checkpoints_class = Type(AsyncCheckpoints, config=True)
-    checkpoints = Instance(AsyncCheckpoints, config=True)
-    checkpoints_kwargs = Dict(config=True)
-
-    @default("checkpoints")
-    def _default_checkpoints(self):
-        return self.checkpoints_class(**self.checkpoints_kwargs)
-
-    @default("checkpoints_kwargs")
-    def _default_checkpoints_kwargs(self):
-        return dict(
-            parent=self,
-            log=self.log,
-        )
-
-    # ContentsManager API part 1: methods that must be
-    # implemented in subclasses.
-
-    async def dir_exists(self, path):
-        """Does a directory exist at the given path?
-
-        Like os.path.isdir
-
-        Override this method in subclasses.
-
-        Parameters
-        ----------
-        path : string
-            The path to check
-
-        Returns
-        -------
-        exists : bool
-            Whether the path does indeed exist.
-        """
-        raise NotImplementedError
-
-    async def is_hidden(self, path):
-        """Is path a hidden directory or file?
-
-        Parameters
-        ----------
-        path : string
-            The path to check. This is an API path (`/` separated,
-            relative to root dir).
-
-        Returns
-        -------
-        hidden : bool
-            Whether the path is hidden.
-
-        """
-        raise NotImplementedError
-
-    async def file_exists(self, path=""):
-        """Does a file exist at the given path?
-
-        Like os.path.isfile
-
-        Override this method in subclasses.
-
-        Parameters
-        ----------
-        path : string
-            The API path of a file to check for.
-
-        Returns
-        -------
-        exists : bool
-            Whether the file exists.
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def exists(self, path):
-        """Does a file or directory exist at the given path?
-
-        Like os.path.exists
-
-        Parameters
-        ----------
-        path : string
-            The API path of a file or directory to check for.
-
-        Returns
-        -------
-        exists : bool
-            Whether the target exists.
-        """
-        return await ensure_async(self.file_exists(path)) or await ensure_async(
-            self.dir_exists(path)
-        )
-
-    async def get(self, path, content=True, type=None, format=None):
-        """Get a file or directory model."""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def save(self, model, path):
-        """
-        Save a file or directory model to path.
-
-        Should return the saved model with no content.  Save implementations
-        should call self.run_pre_save_hook(model=model, path=path) prior to
-        writing any data.
-        """
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def delete_file(self, path):
-        """Delete the file or directory at path."""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    async def rename_file(self, old_path, new_path):
-        """Rename a file or directory."""
-        raise NotImplementedError("must be implemented in a subclass")
-
-    # ContentsManager API part 2: methods that have useable default
-    # implementations, but can be overridden in subclasses.
-
-    async def delete(self, path):
-        """Delete a file/directory and any associated checkpoints."""
-        path = path.strip("/")
-        if not path:
-            raise HTTPError(400, "Can't delete root")
-
-        await self.delete_file(path)
-        await self.checkpoints.delete_all_checkpoints(path)
-        self.emit(data={"action": "delete", "path": path})
-
-    async def rename(self, old_path, new_path):
-        """Rename a file and any checkpoints associated with that file."""
-        await self.rename_file(old_path, new_path)
-        await self.checkpoints.rename_all_checkpoints(old_path, new_path)
-        self.emit(data={"action": "rename", "path": new_path, "source_path": old_path})
-
-    async def update(self, model, path):
-        """Update the file's path
-
-        For use in PATCH requests, to enable renaming a file without
-        re-uploading its contents. Only used for renaming at the moment.
-        """
-        path = path.strip("/")
-        new_path = model.get("path", path).strip("/")
-        if path != new_path:
-            await self.rename(path, new_path)
-        model = await self.get(new_path, content=False)
-        return model
-
-    async def increment_filename(self, filename, path="", insert=""):
-        """Increment a filename until it is unique.
-
-        Parameters
-        ----------
-        filename : unicode
-            The name of a file, including extension
-        path : unicode
-            The API path of the target's directory
-        insert : unicode
-            The characters to insert after the base filename
-
-        Returns
-        -------
-        name : unicode
-            A filename that is unique, based on the input filename.
-        """
-        # Extract the full suffix from the filename (e.g. .tar.gz)
-        path = path.strip("/")
-        basename, dot, ext = filename.rpartition(".")
-        if ext != "ipynb":
-            basename, dot, ext = filename.partition(".")
-
-        suffix = dot + ext
-
-        for i in itertools.count():
-            if i:
-                insert_i = f"{insert}{i}"
-            else:
-                insert_i = ""
-            name = "{basename}{insert}{suffix}".format(
-                basename=basename, insert=insert_i, suffix=suffix
-            )
-            file_exists = await ensure_async(self.exists(f"{path}/{name}"))
-            if not file_exists:
-                break
-        return name
-
-    async def new_untitled(self, path="", type="", ext=""):
-        """Create a new untitled file or directory in path
-
-        path must be a directory
-
-        File extension can be specified.
-
-        Use `new` to create files with a fully specified path (including filename).
-        """
-        path = path.strip("/")
-        dir_exists = await ensure_async(self.dir_exists(path))
-        if not dir_exists:
-            raise HTTPError(404, "No such directory: %s" % path)
-
-        model = {}
-        if type:
-            model["type"] = type
-
-        if ext == ".ipynb":
-            model.setdefault("type", "notebook")
-        else:
-            model.setdefault("type", "file")
-
-        insert = ""
-        if model["type"] == "directory":
-            untitled = self.untitled_directory
-            insert = " "
-        elif model["type"] == "notebook":
-            untitled = self.untitled_notebook
-            ext = ".ipynb"
-        elif model["type"] == "file":
-            untitled = self.untitled_file
-        else:
-            raise HTTPError(400, "Unexpected model type: %r" % model["type"])
-
-        name = await self.increment_filename(untitled + ext, path, insert=insert)
-        path = f"{path}/{name}"
-        return await self.new(model, path)
-
-    async def new(self, model=None, path=""):
-        """Create a new file or directory and return its model with no content.
-
-        To create a new untitled entity in a directory, use `new_untitled`.
-        """
-        path = path.strip("/")
-        if model is None:
-            model = {}
-
-        if path.endswith(".ipynb"):
-            model.setdefault("type", "notebook")
-        else:
-            model.setdefault("type", "file")
-
-        # no content, not a directory, so fill out new-file model
-        if "content" not in model and model["type"] != "directory":
-            if model["type"] == "notebook":
-                model["content"] = new_notebook()
-                model["format"] = "json"
-            else:
-                model["content"] = ""
-                model["type"] = "file"
-                model["format"] = "text"
-
-        model = await self.save(model, path)
-        return model
-
-    async def copy(self, from_path, to_path=None):
-        """Copy an existing file and return its new model.
-
-        If to_path not specified, it will be the parent directory of from_path.
-        If to_path is a directory, filename will increment `from_path-Copy#.ext`.
-        Considering multi-part extensions, the Copy# part will be placed before the first dot for all the extensions except `ipynb`.
-        For easier manual searching in case of notebooks, the Copy# part will be placed before the last dot.
-
-        from_path must be a full path to a file.
-        """
-        path = from_path.strip("/")
-
-        if to_path is not None:
-            to_path = to_path.strip("/")
-
-        if "/" in path:
-            from_dir, from_name = path.rsplit("/", 1)
-        else:
-            from_dir = ""
-            from_name = path
-
-        model = await self.get(path)
-        model.pop("path", None)
-        model.pop("name", None)
-        if model["type"] == "directory":
-            raise HTTPError(400, "Can't copy directories")
-
-        is_destination_specified = to_path is not None
-        if not is_destination_specified:
-            to_path = from_dir
-        if await ensure_async(self.dir_exists(to_path)):
-            name = copy_pat.sub(".", from_name)
-            to_name = await self.increment_filename(name, to_path, insert="-Copy")
-            to_path = f"{to_path}/{to_name}"
-        elif is_destination_specified:
-            if "/" in to_path:
-                to_dir, to_name = to_path.rsplit("/", 1)
-                if not await ensure_async(self.dir_exists(to_dir)):
-                    raise HTTPError(404, "No such parent directory: %s to copy file in" % to_dir)
-        else:
-            raise HTTPError(404, "No such directory: %s" % to_path)
-
-        model = await self.save(model, to_path)
-        self.emit(data={"action": "copy", "path": to_path, "source_path": from_path})
-        return model
-
-    async def trust_notebook(self, path):
-        """Explicitly trust a notebook
-
-        Parameters
-        ----------
-        path : string
-            The path of a notebook
-        """
-        model = await self.get(path)
-        nb = model["content"]
-        self.log.warning("Trusting notebook %s", path)
-        self.notary.mark_cells(nb, True)
-        self.check_and_sign(nb, path)
-
-    # Part 3: Checkpoints API
-    async def create_checkpoint(self, path):
-        """Create a checkpoint."""
-        return await self.checkpoints.create_checkpoint(self, path)
-
-    async def restore_checkpoint(self, checkpoint_id, path):
-        """
-        Restore a checkpoint.
-        """
-        await self.checkpoints.restore_checkpoint(self, checkpoint_id, path)
-
-    async def list_checkpoints(self, path):
-        return await self.checkpoints.list_checkpoints(path)
-
-    async def delete_checkpoint(self, checkpoint_id, path):
-        return await self.checkpoints.delete_checkpoint(checkpoint_id, path)

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -438,13 +438,13 @@ class AsyncContentsManager(LoggingConfigurable):
             raise HTTPError(400, "Can't delete root")
 
         await self.delete_file(path)
-        await self.checkpoints.delete_all_checkpoints(path)
+        await ensure_async(self.checkpoints.delete_all_checkpoints(path))
         self.emit(data={"action": "delete", "path": path})
 
     async def rename(self, old_path, new_path):
         """Rename a file and any checkpoints associated with that file."""
         await self.rename_file(old_path, new_path)
-        await self.checkpoints.rename_all_checkpoints(old_path, new_path)
+        await ensure_async(self.checkpoints.rename_all_checkpoints(old_path, new_path))
         self.emit(data={"action": "rename", "path": new_path, "source_path": old_path})
 
     async def update(self, model, path):
@@ -627,19 +627,19 @@ class AsyncContentsManager(LoggingConfigurable):
     # Part 3: Checkpoints API
     async def create_checkpoint(self, path):
         """Create a checkpoint."""
-        return await self.checkpoints.create_checkpoint(self, path)
+        return await ensure_async(self.checkpoints.create_checkpoint(self, path))
 
     async def restore_checkpoint(self, checkpoint_id, path):
         """
         Restore a checkpoint.
         """
-        await self.checkpoints.restore_checkpoint(self, checkpoint_id, path)
+        await ensure_async(self.checkpoints.restore_checkpoint(self, checkpoint_id, path))
 
     async def list_checkpoints(self, path):
-        return await self.checkpoints.list_checkpoints(path)
+        return await ensure_async(self.checkpoints.list_checkpoints(path))
 
     async def delete_checkpoint(self, checkpoint_id, path):
-        return await self.checkpoints.delete_checkpoint(checkpoint_id, path)
+        return await ensure_async(self.checkpoints.delete_checkpoint(checkpoint_id, path))
 
     def info_string(self):
         return "Serving contents"

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -180,11 +180,12 @@ class SessionManager(LoggingConfigurable):
                 raise TraitError("The given file is not an SQLite database file.")
         return value
 
-    kernel_manager = Instance("jupyter_server.services.kernels.kernelmanager.MappingKernelManager")
+    kernel_manager = Instance(
+        "jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager"
+    )
     contents_manager = InstanceFromClasses(
         [
-            "jupyter_server.services.contents.manager.ContentsManager",
-            "notebook.services.contents.manager.ContentsManager",
+            "jupyter_server.services.contents.manager.AsyncContentsManager",
         ]
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "anyio>=3.1.0,<4",
     "argon2-cffi",
     "jinja2",
-    "jupyter_client>=6.1.12",
+    "jupyter_client>=7.1",
     "jupyter_core>=4.7.0",
     "jupyter_server_terminals",
     "nbconvert>=6.4.4",
@@ -136,12 +136,12 @@ testpaths = [
 ]
 timeout = 100
 # Restore this setting to debug failures
-# timeout_method = "thread"
+timeout_method = "thread"
 filterwarnings = [
   "error",
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:run_pre_save_hook is deprecated:DeprecationWarning",
-  "always:unclosed <socket.socket:ResourceWarning",
+
   "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
 ]
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import sys
+import warnings
 from base64 import decodebytes, encodebytes
 from unicodedata import normalize
 
@@ -12,6 +13,17 @@ from nbformat.v4 import new_markdown_cell, new_notebook
 from jupyter_server.utils import url_path_join
 
 from ...utils import expected_http_error
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="ContentsManager will become an alias",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 def notebooks_only(dir_model):

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -23,6 +23,11 @@ def suppress_deprecation_warnings():
             message="ContentsManager will become an alias",
             category=DeprecationWarning,
         )
+        warnings.filterwarnings(
+            "ignore",
+            message="Checkpoints will become an alias",
+            category=DeprecationWarning,
+        )
         yield
 
 

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -10,13 +10,13 @@ from jupyter_server.services.contents.manager import AsyncContentsManager
 
 @pytest.fixture(params=[AsyncGenericFileCheckpoints, GenericFileCheckpoints])
 def jp_server_config(request):
-    return {"FileContentsManager": {"checkpoints_class": request.param}}
+    return {"AsyncFileContentsManager": {"checkpoints_class": request.param}}
 
 
 def test_config_did_something(jp_server_config, jp_serverapp):
     assert isinstance(
         jp_serverapp.contents_manager.checkpoints,
-        jp_server_config["FileContentsManager"]["checkpoints_class"],
+        jp_server_config["AsyncFileContentsManager"]["checkpoints_class"],
     )
 
 
@@ -32,7 +32,7 @@ def example_post_save_hook():
     "jp_server_config",
     [
         {
-            "ContentsManager": {
+            "AsyncContentsManager": {
                 "pre_save_hook": "tests.services.contents.test_config.example_pre_save_hook",
                 "post_save_hook": "tests.services.contents.test_config.example_post_save_hook",
             },

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from jupyter_server.services.contents.checkpoints import AsyncCheckpoints
@@ -6,6 +8,22 @@ from jupyter_server.services.contents.filecheckpoints import (
     GenericFileCheckpoints,
 )
 from jupyter_server.services.contents.manager import AsyncContentsManager
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="ContentsManager will become an alias",
+            category=DeprecationWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message="Checkpoints will become an alias",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 @pytest.fixture(params=[AsyncGenericFileCheckpoints, GenericFileCheckpoints])

--- a/tests/services/contents/test_largefilemanager.py
+++ b/tests/services/contents/test_largefilemanager.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import tornado
 
@@ -8,6 +10,17 @@ from jupyter_server.services.contents.largefilemanager import (
 from jupyter_server.utils import ensure_async
 
 from ...utils import expected_http_error
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="ContentsManager will become an alias",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 @pytest.fixture(params=[LargeFileManager, AsyncLargeFileManager])

--- a/tests/services/contents/test_largefilemanager.py
+++ b/tests/services/contents/test_largefilemanager.py
@@ -20,6 +20,11 @@ def suppress_deprecation_warnings():
             message="ContentsManager will become an alias",
             category=DeprecationWarning,
         )
+        warnings.filterwarnings(
+            "ignore",
+            message="Checkpoints will become an alias",
+            category=DeprecationWarning,
+        )
         yield
 
 

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import time
+import warnings
 from itertools import combinations
 from typing import Dict, Optional, Tuple
 from unittest.mock import patch
@@ -18,6 +19,17 @@ from jupyter_server.services.contents.filemanager import (
 from jupyter_server.utils import ensure_async
 
 from ...utils import expected_http_error
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="ContentsManager will become an alias",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 @pytest.fixture(

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -29,6 +29,11 @@ def suppress_deprecation_warnings():
             message="ContentsManager will become an alias",
             category=DeprecationWarning,
         )
+        warnings.filterwarnings(
+            "ignore",
+            message="Checkpoints will become an alias",
+            category=DeprecationWarning,
+        )
         yield
 
 

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -1,10 +1,8 @@
 import asyncio
 import json
-import os
 import time
 import warnings
 
-import jupyter_client
 import pytest
 import tornado
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -7,7 +7,11 @@ from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelMana
 @pytest.fixture
 def jp_server_config():
     return Config(
-        {"ServerApp": {"MappingKernelManager": {"allowed_message_types": ["kernel_info_request"]}}}
+        {
+            "ServerApp": {
+                "AsyncMappingKernelManager": {"allowed_message_types": ["kernel_info_request"]}
+            }
+        }
     )
 
 

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -15,20 +15,6 @@ CULL_INTERVAL = 1
 @pytest.mark.parametrize(
     "jp_server_config",
     [
-        # Test the synchronous case
-        Config(
-            {
-                "ServerApp": {
-                    "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.MappingKernelManager",
-                    "MappingKernelManager": {
-                        "cull_idle_timeout": CULL_TIMEOUT,
-                        "cull_interval": CULL_INTERVAL,
-                        "cull_connected": False,
-                    },
-                }
-            }
-        ),
-        # Test the async case
         Config(
             {
                 "ServerApp": {

--- a/tests/services/sessions/test_api.py
+++ b/tests/services/sessions/test_api.py
@@ -46,11 +46,6 @@ class NewPortsMappingKernelManager(AsyncMappingKernelManager):
 configs: list = [
     {
         "ServerApp": {
-            "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.MappingKernelManager"
-        }
-    },
-    {
-        "ServerApp": {
             "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager"
         }
     },

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -6,7 +6,7 @@ from traitlets import TraitError
 
 from jupyter_server._tz import isoformat, utcnow
 from jupyter_server.services.contents.manager import ContentsManager
-from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 from jupyter_server.services.sessions.sessionmanager import (
     KernelSessionRecord,
     KernelSessionRecordConflict,
@@ -27,7 +27,7 @@ dummy_date = utcnow()
 dummy_date_s = isoformat(dummy_date)
 
 
-class MockMKM(MappingKernelManager):
+class MockMKM(AsyncMappingKernelManager):
     """MappingKernelManager interface that doesn't start kernels, for testing"""
 
     def __init__(self, *args, **kwargs):

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -5,7 +5,7 @@ from tornado import web
 from traitlets import TraitError
 
 from jupyter_server._tz import isoformat, utcnow
-from jupyter_server.services.contents.manager import ContentsManager
+from jupyter_server.services.contents.manager import AsyncContentsManager
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 from jupyter_server.services.sessions.sessionmanager import (
     KernelSessionRecord,
@@ -63,7 +63,7 @@ class SlowStartingKernelsMKM(MockMKM):
 
 @pytest.fixture
 def session_manager():
-    return SessionManager(kernel_manager=MockMKM(), contents_manager=ContentsManager())
+    return SessionManager(kernel_manager=MockMKM(), contents_manager=AsyncContentsManager())
 
 
 def test_kernel_record_equals():
@@ -387,7 +387,7 @@ async def test_bad_database_filepath(jp_runtime_dir):
     with pytest.raises(TraitError) as err:
         SessionManager(
             kernel_manager=kernel_manager,
-            contents_manager=ContentsManager(),
+            contents_manager=AsyncContentsManager(),
             database_filepath=str(path_id_directory),
         )
 
@@ -400,7 +400,7 @@ async def test_bad_database_filepath(jp_runtime_dir):
     with pytest.raises(TraitError) as err:
         SessionManager(
             kernel_manager=kernel_manager,
-            contents_manager=ContentsManager(),
+            contents_manager=AsyncContentsManager(),
             database_filepath=str(non_db_file),
         )
 
@@ -414,7 +414,7 @@ async def test_good_database_filepath(jp_runtime_dir):
 
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
-        contents_manager=ContentsManager(),
+        contents_manager=AsyncContentsManager(),
         database_filepath=str(empty_file),
     )
 
@@ -430,7 +430,7 @@ async def test_good_database_filepath(jp_runtime_dir):
     # Try writing to a file that already exists.
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
-        contents_manager=ContentsManager(),
+        contents_manager=AsyncContentsManager(),
         database_filepath=str(empty_file),
     )
 
@@ -446,7 +446,7 @@ async def test_session_persistence(jp_runtime_dir):
     # This should create the session database the first time.
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
-        contents_manager=ContentsManager(),
+        contents_manager=AsyncContentsManager(),
         database_filepath=str(session_db_path),
     )
 
@@ -468,7 +468,7 @@ async def test_session_persistence(jp_runtime_dir):
     # Get a new session_manager
     session_manager = SessionManager(
         kernel_manager=kernel_manager,
-        contents_manager=ContentsManager(),
+        contents_manager=AsyncContentsManager(),
         database_filepath=str(session_db_path),
     )
 
@@ -478,7 +478,7 @@ async def test_session_persistence(jp_runtime_dir):
 
 async def test_pending_kernel():
     session_manager = SessionManager(
-        kernel_manager=SlowStartingKernelsMKM(), contents_manager=ContentsManager()
+        kernel_manager=SlowStartingKernelsMKM(), contents_manager=AsyncContentsManager()
     )
     # Create a session with a slow starting kernel
     fut = session_manager.create_session(


### PR DESCRIPTION
Actually, changing the subclass order is a bad idea, because people targeting config with `ContentsManager` would have to update.  
