### PR TITLE
Clean up handling of synchronous managers

### DIFF
--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -26,8 +26,8 @@ from traitlets.config import Config, re
 from jupyter_server.auth import Authorizer
 from jupyter_server.extension import serverextension
 from jupyter_server.serverapp import JUPYTER_SERVICE_HANDLERS, ServerApp
-from jupyter_server.services.contents.filemanager import FileContentsManager
-from jupyter_server.services.contents.largefilemanager import LargeFileManager
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
 from jupyter_server.utils import url_path_join
 
 # List of dependencies needed for this plugin.
@@ -488,14 +488,14 @@ def jp_kernelspecs(jp_data_dir):
 
 @pytest.fixture(params=[True, False])
 def jp_contents_manager(request, tmp_path):
-    """Returns a FileContentsManager instance based on the use_atomic_writing parameter value."""
-    return FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=request.param)
+    """Returns an AsyncFileContentsManager instance based on the use_atomic_writing parameter value."""
+    return AsyncFileContentsManager(root_dir=str(tmp_path), use_atomic_writing=request.param)
 
 
 @pytest.fixture
 def jp_large_contents_manager(tmp_path):
-    """Returns a LargeFileManager instance."""
-    return LargeFileManager(root_dir=str(tmp_path))
+    """Returns an AsyncLargeFileManager instance."""
+    return AsyncLargeFileManager(root_dir=str(tmp_path))
 
 
 @pytest.fixture

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -6,7 +6,6 @@ import errno
 import gettext
 import hashlib
 import hmac
-import inspect
 import ipaddress
 import json
 import logging
@@ -133,7 +132,6 @@ from jupyter_server.services.kernels.kernelmanager import (
     MappingKernelManager,
 )
 from jupyter_server.services.sessions.sessionmanager import SessionManager
-from jupyter_server.traittypes import TypeFromClasses
 from jupyter_server.utils import (
     check_pid,
     fetch,
@@ -1435,36 +1433,12 @@ class ServerApp(JupyterApp):
         help="""If True, display controls to shut down the Jupyter server, such as menu items or buttons.""",
     )
 
-    # Temporarily allow content managers to inherit from the 'notebook'
-    # package. We will deprecate this in the next major release.
-    contents_manager_class = TypeFromClasses(
+    contents_manager_class = Type(
         default_value=AsyncLargeFileManager,
-        klasses=[
-            "jupyter_server.services.contents.manager.ContentsManager",
-            "notebook.services.contents.manager.ContentsManager",
-        ],
+        klass=ContentsManager,
         config=True,
         help=_i18n("The content manager class to use."),
     )
-
-    # Throws a deprecation warning to notebook based contents managers.
-    @observe("contents_manager_class")
-    def _observe_contents_manager_class(self, change):
-        new = change["new"]
-        # If 'new' is a class, get a string representing the import
-        # module path.
-        if inspect.isclass(new):
-            new = new.__module__
-
-        if new.startswith("notebook"):
-            self.log.warning(
-                "The specified 'contents_manager_class' class inherits a manager from the "
-                "'notebook' package. This is not guaranteed to work in future "
-                "releases of Jupyter Server. Instead, consider switching the "
-                "manager to inherit from the 'jupyter_server' managers. "
-                "Jupyter Server will temporarily allow 'notebook' managers "
-                "until its next major release (3.x)."
-            )
 
     kernel_manager_class = Type(
         klass=MappingKernelManager,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -6,7 +6,6 @@ import errno
 import gettext
 import hashlib
 import hmac
-import inspect
 import ipaddress
 import json
 import logging
@@ -123,10 +122,7 @@ from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
     FileContentsManager,
 )
-from jupyter_server.services.contents.largefilemanager import (
-    AsyncLargeFileManager,
-    LargeFileManager,
-)
+from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
 from jupyter_server.services.contents.manager import (
     AsyncContentsManager,
     ContentsManager,
@@ -136,7 +132,6 @@ from jupyter_server.services.kernels.kernelmanager import (
     MappingKernelManager,
 )
 from jupyter_server.services.sessions.sessionmanager import SessionManager
-from jupyter_server.traittypes import TypeFromClasses
 from jupyter_server.utils import (
     check_pid,
     fetch,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -57,7 +57,7 @@ if not sys.platform.startswith("win"):
     from tornado.netutil import bind_unix_socket
 
 from jupyter_client.kernelspec import KernelSpecManager
-from jupyter_client.manager import AsyncKernelManager, KernelManager
+from jupyter_client.manager import KernelManager
 from jupyter_client.session import Session
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.paths import jupyter_runtime_dir

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -122,7 +122,7 @@ from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
     FileContentsManager,
 )
-from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
+from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.services.contents.manager import (
     AsyncContentsManager,
     ContentsManager,
@@ -1434,7 +1434,7 @@ class ServerApp(JupyterApp):
     )
 
     contents_manager_class = Type(
-        default_value=AsyncLargeFileManager,
+        default_value=LargeFileManager,
         klass=ContentsManager,
         config=True,
         help=_i18n("The content manager class to use."),

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -122,7 +122,7 @@ from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
     FileContentsManager,
 )
-from jupyter_server.services.contents.largefilemanager import LargeFileManager
+from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
 from jupyter_server.services.contents.manager import (
     AsyncContentsManager,
     ContentsManager,
@@ -1434,7 +1434,7 @@ class ServerApp(JupyterApp):
     )
 
     contents_manager_class = Type(
-        default_value=LargeFileManager,
+        default_value=AsyncLargeFileManager,
         klass=ContentsManager,
         config=True,
         help=_i18n("The content manager class to use."),

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -57,8 +57,8 @@ from tornado.log import LogFormatter, access_log, app_log, gen_log
 if not sys.platform.startswith("win"):
     from tornado.netutil import bind_unix_socket
 
-from jupyter_client import KernelManager
 from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.manager import AsyncKernelManager, KernelManager
 from jupyter_client.session import Session
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.paths import jupyter_runtime_dir
@@ -123,7 +123,10 @@ from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
     FileContentsManager,
 )
-from jupyter_server.services.contents.largefilemanager import LargeFileManager
+from jupyter_server.services.contents.largefilemanager import (
+    AsyncLargeFileManager,
+    LargeFileManager,
+)
 from jupyter_server.services.contents.manager import (
     AsyncContentsManager,
     ContentsManager,
@@ -1164,7 +1167,7 @@ class ServerApp(JupyterApp):
         config=True,
         help="""Disable cross-site-request-forgery protection
 
-        Jupyter notebook 4.3.1 introduces protection from cross-site request forgeries,
+        Jupyter server includes protection from cross-site request forgeries,
         requiring API requests to either:
 
         - originate from pages served by this server (validated with XSRF cookie and token), or
@@ -1435,37 +1438,12 @@ class ServerApp(JupyterApp):
         help="""If True, display controls to shut down the Jupyter server, such as menu items or buttons.""",
     )
 
-    # REMOVE in VERSION 2.0
-    # Temporarily allow content managers to inherit from the 'notebook'
-    # package. We will deprecate this in the next major release.
-    contents_manager_class = TypeFromClasses(
-        default_value=LargeFileManager,
-        klasses=[
-            "jupyter_server.services.contents.manager.ContentsManager",
-            "notebook.services.contents.manager.ContentsManager",
-        ],
+    contents_manager_class = Type(
+        default_value=AsyncLargeFileManager,
+        klass=ContentsManager,
         config=True,
         help=_i18n("The content manager class to use."),
     )
-
-    # Throws a deprecation warning to notebook based contents managers.
-    @observe("contents_manager_class")
-    def _observe_contents_manager_class(self, change):
-        new = change["new"]
-        # If 'new' is a class, get a string representing the import
-        # module path.
-        if inspect.isclass(new):
-            new = new.__module__
-
-        if new.startswith("notebook"):
-            self.log.warning(
-                "The specified 'contents_manager_class' class inherits a manager from the "
-                "'notebook' package. This is not guaranteed to work in future "
-                "releases of Jupyter Server. Instead, consider switching the "
-                "manager to inherit from the 'jupyter_server' managers. "
-                "Jupyter Server will temporarily allow 'notebook' managers "
-                "until its next major release (2.x)."
-            )
 
     kernel_manager_class = Type(
         klass=MappingKernelManager,
@@ -1864,6 +1842,20 @@ class ServerApp(JupyterApp):
         # If gateway server is configured, replace appropriate managers to perform redirection.  To make
         # this determination, instantiate the GatewayClient config singleton.
         self.gateway_config = GatewayClient.instance(parent=self)
+
+        if not issubclass(self.kernel_manager_class, AsyncMappingKernelManager):
+            warnings.warn(
+                "The synchronous MappingKernelManager class is deprecated and will not be supported in Jupyter Server 3.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if not issubclass(self.contents_manager_class, AsyncContentsManager):
+            warnings.warn(
+                "The synchronous ContentsManager classes are deprecated and will not be supported in Jupyter Server 3.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -755,7 +755,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         """Save the file model and return the model with no content."""
         path = path.strip("/")
 
-        self.run_pre_save_hook(model=model, path=path)
+        self.run_pre_save_hooks(model=model, path=path)
 
         if "type" not in model:
             raise web.HTTPError(400, "No file type provided")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ filterwarnings = [
   "error",
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:run_pre_save_hook is deprecated:DeprecationWarning",
-
+  "always:unclosed <socket.socket:ResourceWarning",
   "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
 ]
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import sys
+import warnings
 from base64 import decodebytes, encodebytes
 from unicodedata import normalize
 
@@ -12,6 +13,17 @@ from nbformat.v4 import new_markdown_cell, new_notebook
 from jupyter_server.utils import url_path_join
 
 from ...utils import expected_http_error
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The synchronous ContentsManager",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 def notebooks_only(dir_model):

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -2,13 +2,13 @@ import pytest
 
 from jupyter_server.services.contents.checkpoints import AsyncCheckpoints
 from jupyter_server.services.contents.filecheckpoints import (
+    AsyncFileCheckpoints,
     AsyncGenericFileCheckpoints,
-    GenericFileCheckpoints,
 )
 from jupyter_server.services.contents.manager import AsyncContentsManager
 
 
-@pytest.fixture(params=[AsyncGenericFileCheckpoints, GenericFileCheckpoints])
+@pytest.fixture(params=[AsyncGenericFileCheckpoints, AsyncFileCheckpoints])
 def jp_server_config(request):
     return {"FileContentsManager": {"checkpoints_class": request.param}}
 

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import time
+import warnings
 
 import jupyter_client
 import pytest
@@ -14,6 +15,17 @@ from jupyter_server.utils import url_path_join
 from ...utils import expected_http_error
 
 TEST_TIMEOUT = 60
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The synchronous MappingKernelManager",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 @pytest.fixture

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import platform
+import warnings
 
 import jupyter_client
 import pytest
@@ -10,6 +11,17 @@ from traitlets.config import Config
 
 CULL_TIMEOUT = 30 if platform.python_implementation() == "PyPy" else 5
 CULL_INTERVAL = 1
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The synchronous MappingKernelManager",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 @pytest.mark.parametrize(

--- a/tests/services/sessions/test_api.py
+++ b/tests/services/sessions/test_api.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import time
+import warnings
 from typing import Any
 
 import jupyter_client
@@ -20,6 +21,17 @@ from jupyter_server.utils import url_path_join
 from ...utils import expected_http_error
 
 TEST_TIMEOUT = 60
+
+
+@pytest.fixture(autouse=True)
+def suppress_deprecation_warnings():
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The synchronous MappingKernelManager",
+            category=DeprecationWarning,
+        )
+        yield
 
 
 def j(r):


### PR DESCRIPTION
Make the async contents manager the default, and add deprecation warning when using synchronous contents or kernel managers.