### PR TITLE
MAINT: wrote API errors to console.

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -724,7 +724,7 @@ class APIHandler(JupyterHandler):
                 reply["message"] = "Unhandled error"
                 reply["reason"] = None
                 reply["traceback"] = "".join(traceback.format_exception(*exc_info))
-        self.log.warning("wrote error: %r", reply["message"])
+        self.log.error("wrote error: %r", reply["message"], exec_info=True)
         self.finish(json.dumps(reply))
 
     def get_login_url(self):


### PR DESCRIPTION
Sending the error to the frontend does not preclude to writing it to the console. When the frontend does not work the error is logged nowhere, and therefore having it persisted in the log can be helpful.