### PR TITLE
persist userid cookie when auth is disabled

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -264,6 +264,9 @@ class IdentityProvider(LoggingConfigurable):
                 # Completely insecure! No authentication at all.
                 # No need to warn here, though; validate_security will have already done that.
                 user = self.generate_anonymous_user(handler)
+                # persist user on first request
+                # so the user data is stable for a given browser session
+                self.set_login_cookie(handler, user)
 
         return user
 

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -405,8 +405,9 @@ def jp_fetch(jp_serverapp, http_server_client, jp_auth_header, jp_base_url):
         base_path_url = url_path_join(jp_base_url, path_url)
         params_url = urllib.parse.urlencode(params)
         url = base_path_url + "?" + params_url
-        # Add auth keys to header
-        headers.update(jp_auth_header)
+        # Add auth keys to header, if not overridden
+        for key, value in jp_auth_header.items():
+            headers.setdefault(key, value)
         # Make request.
         return http_server_client.fetch(url, headers=headers, request_timeout=20, **kwargs)
 


### PR DESCRIPTION
Allows a stable anonymous user, persisted via cookie (just like a token login).

closes #1033