### PR TITLE
Fix coverage upload

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
           hatch run cov:integration
       - name: Coverage
         run: |
-          pip install codecov
+          pip install codecov coverage[toml]
           codecov
 
   integration_check: # This job does nothing and is only used for the branch protection

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: hatch run cov:nowarn -s || hatch run cov:nowarn --lf
       - name: Coverage
         run: |
-          pip install codecov
+          pip install codecov coverage[toml]
           codecov
 
   pre_commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.cov]
 features = ["test"]
-dependencies = ["coverage", "pytest-cov"]
+dependencies = ["coverage[toml]", "pytest-cov"]
 [tool.hatch.envs.cov.scripts]
 test = "python -m pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered {args}"
 nowarn = "test -W default {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.cov]
 features = ["test"]
-dependencies = ["coverage[toml]", "pytest-cov"]
+dependencies = ["coverage", "pytest-cov"]
 [tool.hatch.envs.cov.scripts]
 test = "python -m pytest -vv --cov jupyter_server --cov-branch --cov-report term-missing:skip-covered {args}"
 nowarn = "test -W default {args}"


### PR DESCRIPTION
We were getting the error:

```
==> Detecting CI provider
GitHub Actions CI Detected
Fixing merge commit SHA
==> Preparing upload
==> Processing gcov (disable by -X gcov)
==> Collecting reports
Generating coverage xml reports for Python
Error running `['/Users/runner/hostedtoolcache/Python/3.8.14/x64/bin/python', '-m', 'coverage', 'xml', '-i']`: returncode=1, output=b"Can't read 'pyproject.toml' without TOML support. Install with [toml] extra\n"
- Ignored: [Errno 2] No such file or directory: '/Users/runner/work/jupyter_server/jupyter_server/coverage.xml'
Error: No coverage report found
Tip: See all example repositories: https://github.com/codecov?query=example
```

https://github.com/jupyter-server/jupyter_server/actions/runs/3536103578/jobs/5934829302