### PR TITLE
Tweak codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,11 @@ coverage:
         threshold: 1
     patch:
       default:
-        target: 0%
+        target: 50%
+  notify:
+    wait_for_ci: true
+  range: 80..100
+  github_checks:
+    annotations: false
+  comment:
+    after_n_builds: 30


### PR DESCRIPTION
- Turn off the github annotations
- Require 50% of new code to be covered (we can still override and merge)
- Show green coverage at 80%
- Wait until most builds have finished before posting the comment
- Wait until all the other builds finish before assigning status