### PR TITLE
Fix lint rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.165
+    rev: v0.0.176
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.176
+    rev: v0.0.177
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -16,7 +16,6 @@ from jupyter_server.utils import is_namespace_package, url_path_join
 
 from .handler import ExtensionHandlerMixin
 
-
 # -----------------------------------------------------------------------------
 # Util functions and classes.
 # -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ test = [
 lint = [
   "black>=22.6.0",
   "mdformat>0.7",
-  "ruff>=0.0.156",
+  "ruff>=0.0.176",
 ]
 docs = [
     # needed because m2r uses deprecated APIs
@@ -108,6 +108,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test", "typing"]
+detached = true
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args:.}"
 
@@ -174,7 +175,7 @@ ignore = [
   # Line too long
   "E501",
   # Relative imports are banned
-  "I252",
+  "TID252",
   # Boolean ... in function definition
   "FBT001",
   "FBT002",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ detached = true
 dependencies = [
   "black>=22.10.0",
   "mdformat>0.7",
-  "ruff>=0.0.176",
+  "ruff==0.0.177",
 ]
 [tool.hatch.envs.lint.scripts]
 style = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,6 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test", "typing"]
-detached = true
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args:.}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,6 @@ test = [
     "requests",
     "pre-commit"
 ]
-lint = [
-  "black>=22.10.0",
-  "mdformat>0.7",
-  "ruff>=0.0.176",
-]
 docs = [
     # needed because m2r uses deprecated APIs
     # m2r is depended on by sphinxcontrib-openapi
@@ -88,9 +83,6 @@ docs = [
     "sphinxemoji",
     "tornado",
 ]
-typing = [
-    "mypy>=0.990"
-]
 
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
@@ -107,7 +99,8 @@ test = "python -m pytest -vv {args}"
 nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
-features = ["test", "typing"]
+features = ["test"]
+dependencies = [ "mypy>=0.990" ]
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args:.}"
 
@@ -120,7 +113,12 @@ nowarn = "test -W default {args}"
 integration = "test --integration_tests=true {args}"
 
 [tool.hatch.envs.lint]
-features = ["lint"]
+detached = true
+dependencies = [
+  "black>=22.10.0",
+  "mdformat>0.7",
+  "ruff>=0.0.176",
+]
 [tool.hatch.envs.lint.scripts]
 style = [
   "ruff {args:.}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ test = [
     "pre-commit"
 ]
 lint = [
-  "black>=22.6.0",
+  "black>=22.10.0",
   "mdformat>0.7",
   "ruff>=0.0.176",
 ]

--- a/tests/services/events/mockextension/__init__.py
+++ b/tests/services/events/mockextension/__init__.py
@@ -1,6 +1,5 @@
 from .mock_extension import _load_jupyter_server_extension  # noqa: F401
 
-
 # Function that makes these extensions discoverable
 # by the test functions.
 


### PR DESCRIPTION
Addresses ```warning: `I252` has been remapped to `TID252` ``` error seen in CI.