### PR TITLE
Logging message used to list sessions fails with template error

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -683,7 +683,7 @@ class JupyterServerListApp(JupyterApp):
                 url = serverinfo["url"]
                 if serverinfo.get("token"):
                     url = url + "?token=%s" % serverinfo["token"]
-                info(url, "::", serverinfo["root_dir"])
+                info("%s :: %s", url, serverinfo["root_dir"])
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
`jupyter lab list` command failed with error:

```
TypeError: not all arguments converted during string formatting
Call stack:
  File "/path/bin/jupyter-lab", line 8, in <module>
    sys.exit(main())
  File "/path/lib/python3.9/site-packages/jupyter_server/extension/application.py", line 611, in launch_instance
    serverapp.start()
  File "/path/lib/python3.9/site-packages/jupyter_server/serverapp.py", line 2884, in start
    self.start_app()
  File "/path/lib/python3.9/site-packages/jupyter_server/serverapp.py", line 2775, in start_app
    super().start()
  File "/path/lib/python3.9/site-packages/jupyter_core/application.py", line 265, in start
    self.subapp.start()
  File "/path/lib/python3.9/site-packages/jupyter_server/serverapp.py", line 686, in start
    info(url, "::", serverinfo["root_dir"])

```