### PR TITLE
Raise errors on individual problematic extensions when listing extension

### DIFF
--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -323,20 +323,26 @@ class ListServerExtensionsApp(BaseExtensionApp):
         )
 
         for option in configurations:
-            config_dir, ext_manager = _get_extmanager_for_context(**option)
+            config_dir = _get_config_dir(**option)
             self.log.info(f"Config dir: {config_dir}")
-            for name, extension in ext_manager.extensions.items():
-                enabled = extension.enabled
+            write_dir = "jupyter_server_config.d"
+            config_manager = ExtensionConfigManager(
+                read_config_path=[config_dir],
+                write_config_dir=os.path.join(config_dir, write_dir),
+            )
+            jpserver_extensions = config_manager.get_jpserver_extensions()
+            for name, enabled in jpserver_extensions.items():
                 # Attempt to get extension metadata
                 self.log.info(f"    {name} {GREEN_ENABLED if enabled else RED_DISABLED}")
                 try:
                     self.log.info(f"    - Validating {name}...")
+                    extension = ExtensionPackage(name=name, enabled=enabled)
                     if not extension.validate():
                         raise ValueError("validation failed")
                     version = extension.version
                     self.log.info(f"      {name} {version} {GREEN_OK}")
                 except Exception as err:
-                    self.log.warning(f"      {RED_X} {err}")
+                    self.log.warning(f"      {RED_X} {err}", exc_info=True)
             # Add a blank line between paths.
             self.log.info("")
 

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -1,6 +1,7 @@
 """Utilities for installing extensions"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import logging
 import os
 import sys
 
@@ -342,7 +343,10 @@ class ListServerExtensionsApp(BaseExtensionApp):
                     version = extension.version
                     self.log.info(f"      {name} {version} {GREEN_OK}")
                 except Exception as err:
-                    self.log.warning(f"      {RED_X} {err}", exc_info=True)
+                    exc_info = False
+                    if self.log_level <= logging.DEBUG:
+                        exc_info = True
+                    self.log.warning(f"      {RED_X} {err}", exc_info=exc_info)
             # Add a blank line between paths.
             self.log.info("")
 

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -344,7 +344,7 @@ class ListServerExtensionsApp(BaseExtensionApp):
                     self.log.info(f"      {name} {version} {GREEN_OK}")
                 except Exception as err:
                     exc_info = False
-                    if self.log_level <= logging.DEBUG:
+                    if int(self.log_level) <= logging.DEBUG:
                         exc_info = True
                     self.log.warning(f"      {RED_X} {err}", exc_info=exc_info)
             # Add a blank line between paths.


### PR DESCRIPTION
Fixes #1134. We can backport this to 1.x once it's merged.

This no longer uses an `ExtensionManager` to load all the extensions as a bunch. Instead, it loads each extension separately, adds a try/catch clause for each individual extension validation, logs the error (if found) for each extension, and doesn't block the validation for other extensions. 

Here is an example of the new output:

```
Config dir: /Users/zsailer/.jupyter

Config dir: /Users/env/etc/jupyter
    jupyter_server_terminals enabled
    - Validating jupyter_server_terminals...
       X Jupyter Server Terminals requires Jupyter Server 2.0+
    Traceback (most recent call last):
      File "/Users/zsailer/Documents/Work/oss/internal/jupyter_server/jupyter_server/extension/serverextension.py", line 336, in list_server_extensions
        extension = ExtensionPackage(name=name, enabled=enabled)
      File "/Users/zsailer/Documents/Work/oss/internal/jupyter_server/jupyter_server/extension/manager.py", line 166, in __init__
        super().__init__(*args, **kwargs)
      File "/Users/env/lib/python3.8/site-packages/traitlets/traitlets.py", line 1238, in __init__
        super_kwargs[key] = value
      File "/Users/env/lib/python3.8/contextlib.py", line 120, in __exit__
        next(self.gen)
      File "/Users/env/lib/python3.8/site-packages/traitlets/traitlets.py", line 1348, in hold_trait_notifications
        value = trait._cross_validate(self, getattr(self, name))
      File "/Users/env/lib/python3.8/site-packages/traitlets/traitlets.py", line 729, in _cross_validate
        value = obj._trait_validators[self.name](obj, proposal)
      File "/Users/env/lib/python3.8/site-packages/traitlets/traitlets.py", line 1132, in __call__
        return self.func(*args, **kwargs)
      File "/Users/zsailer/Documents/Work/oss/internal/jupyter_server/jupyter_server/extension/manager.py", line 175, in _validate_name
        self._module, self._metadata = get_metadata(name)
      File "/Users/zsailer/Documents/Work/oss/internal/jupyter_server/jupyter_server/extension/utils.py", line 55, in get_metadata
        module = importlib.import_module(package_name)
      File "/Users/env/lib/python3.8/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
      File "<frozen importlib._bootstrap>", line 991, in _find_and_load
      File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 843, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/Users/env/lib/python3.8/site-packages/jupyter_server_terminals/__init__.py", line 9, in <module>
        raise RuntimeError("Jupyter Server Terminals requires Jupyter Server 2.0+")
    RuntimeError: Jupyter Server Terminals requires Jupyter Server 2.0+
    jupyterlab enabled
    - Validating jupyterlab...
      jupyterlab 3.5.0 OK
    nbclassic disabled
    - Validating nbclassic...
      nbclassic  OK
```
