### PR TITLE
Restore default writing of browser open redirect file, add opt-in to skip

### DIFF
--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -18,6 +18,7 @@ from jupyter_server.serverapp import (
     list_running_servers,
     random_ports,
 )
+from jupyter_server.utils import pathname2url, urljoin
 
 
 def test_help_output():
@@ -484,3 +485,12 @@ async def test_shutdown_no_activity(jp_serverapp):
 def test_running_server_info(jp_serverapp):
     app: ServerApp = jp_serverapp
     app.running_server_info(True)
+
+
+@pytest.mark.parametrize("should_exist", [True, False])
+def test_browser_open_files(jp_configurable_serverapp, should_exist, caplog):
+    app = jp_configurable_serverapp(no_browser_open_file=not should_exist)
+    assert os.path.exists(app.browser_open_file) == should_exist
+    url = urljoin("file:", pathname2url(app.browser_open_file))
+    url_messages = [rec.message for rec in caplog.records if url in rec.message]
+    assert url_messages if should_exist else not url_messages


### PR DESCRIPTION
## Elevator Pitch

Make skipping the browser open files opt-in.

## References

- fixes #1143

## Changes
- [x] add `ServerApp.no_browser_open_file`, defaulting to `False`
- [x] gate writing of the browser redirect file behind this setting
- [x] update printed message to not show the message if the file was not written
  - [x] add a little `i18n` to the text
- [x] add test of `no_browser_open_file` and false, check for file creation and log message 

## Alternatives
- make `browser_open_file` `allow_none=True`
  - this is probably clearer, and wouldn't introduce a new config variable, but `None`s do weird things