### PR TITLE
Import ensure-sync directly from dependence.

### DIFF
--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -5,11 +5,11 @@ import mimetypes
 from base64 import decodebytes
 from typing import List
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
 from jupyter_server.base.handlers import JupyterHandler
-from jupyter_server.utils import ensure_async
 
 AUTH_RESOURCE = "contents"
 

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -16,6 +16,7 @@ from jupyter_client.clientabc import KernelClientABC
 from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.manager import AsyncKernelManager
 from jupyter_client.managerabc import KernelManagerABC
+from jupyter_core.utils import ensure_async
 from tornado import web
 from tornado.escape import json_decode, json_encode, url_escape, utf8
 from traitlets import DottedObjectName, Instance, Type, default
@@ -23,7 +24,7 @@ from traitlets import DottedObjectName, Instance, Type, default
 from .._tz import UTC
 from ..services.kernels.kernelmanager import AsyncMappingKernelManager
 from ..services.sessions.sessionmanager import SessionManager
-from ..utils import ensure_async, url_path_join
+from ..utils import url_path_join
 from .gateway_client import GatewayClient, gateway_request
 
 

--- a/jupyter_server/nbconvert/handlers.py
+++ b/jupyter_server/nbconvert/handlers.py
@@ -7,12 +7,12 @@ import sys
 import zipfile
 
 from anyio.to_thread import run_sync
+from jupyter_core.utils import ensure_async
 from nbformat import from_dict
 from tornado import web
 from tornado.log import app_log
 
 from jupyter_server.auth import authorized
-from jupyter_server.utils import ensure_async
 
 from ..base.handlers import FilesRedirectHandler, JupyterHandler, path_regex
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -124,9 +124,10 @@ except ImportError:
 
 from jinja2 import Environment, FileSystemLoader
 from jupyter_core.paths import secure_write
+from jupyter_core.utils import ensure_async
 
 from jupyter_server.transutils import _i18n, trans
-from jupyter_server.utils import ensure_async, pathname2url, urljoin
+from jupyter_server.utils import pathname2url, urljoin
 
 # the minimum viable tornado version: needs to be kept in sync with setup.py
 MIN_TORNADO = (6, 1, 0)

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -5,11 +5,11 @@ import json
 import os
 from typing import Dict, List
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server._tz import isoformat, utcfromtimestamp
 from jupyter_server.auth import authorized
-from jupyter_server.utils import ensure_async
 
 from ...base.handlers import APIHandler, JupyterHandler
 

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -11,11 +11,12 @@ try:
 except ImportError:
     from jupyter_client.jsonutil import date_default as json_default
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
 from jupyter_server.base.handlers import APIHandler, JupyterHandler, path_regex
-from jupyter_server.utils import ensure_async, url_escape, url_path_join
+from jupyter_server.utils import url_escape, url_path_join
 
 AUTH_RESOURCE = "contents"
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -7,6 +7,7 @@ import re
 import warnings
 from fnmatch import fnmatch
 
+from jupyter_core.utils import ensure_async
 from jupyter_events import EventLogger
 from nbformat import ValidationError, sign
 from nbformat import validate as validate_nb
@@ -17,7 +18,7 @@ from traitlets.config.configurable import LoggingConfigurable
 
 from jupyter_server import DEFAULT_EVENTS_SCHEMA_PATH, JUPYTER_SERVER_EVENTS_URI
 from jupyter_server.transutils import _i18n
-from jupyter_server.utils import ensure_async, import_item
+from jupyter_server.utils import import_item
 
 from ...files.handlers import FilesHandler
 from .checkpoints import AsyncCheckpoints, Checkpoints

--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from jupyter_client.jsonutil import date_default as json_default
 
-from jupyter_client.utils import ensure_async
+from jupyter_core.utils import ensure_async
 
 from jupyter_server.transutils import _i18n
 

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -12,10 +12,11 @@ try:
 except ImportError:
     from jupyter_client.jsonutil import date_default as json_default
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
-from jupyter_server.utils import ensure_async, url_escape, url_path_join
+from jupyter_server.utils import url_escape, url_path_join
 
 from ...base.handlers import APIHandler
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -16,6 +16,7 @@ from jupyter_client.ioloop.manager import AsyncIOLoopKernelManager
 from jupyter_client.multikernelmanager import AsyncMultiKernelManager, MultiKernelManager
 from jupyter_client.session import Session
 from jupyter_core.paths import exists
+from jupyter_core.utils import ensure_async
 from tornado import web
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -35,7 +36,7 @@ from traitlets import (
 
 from jupyter_server._tz import isoformat, utcnow
 from jupyter_server.prometheus.metrics import KERNEL_CURRENTLY_RUNNING_TOTAL
-from jupyter_server.utils import ensure_async, import_item, to_os_path
+from jupyter_server.utils import import_item, to_os_path
 
 
 class MappingKernelManager(MultiKernelManager):

--- a/jupyter_server/services/kernelspecs/handlers.py
+++ b/jupyter_server/services/kernelspecs/handlers.py
@@ -10,12 +10,13 @@ import os
 
 pjoin = os.path.join
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
 
 from ...base.handlers import APIHandler
-from ...utils import ensure_async, url_path_join, url_unescape
+from ...utils import url_path_join, url_unescape
 
 AUTH_RESOURCE = "kernelspecs"
 

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -13,10 +13,11 @@ except ImportError:
     from jupyter_client.jsonutil import date_default as json_default
 
 from jupyter_client.kernelspec import NoSuchKernel
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
-from jupyter_server.utils import ensure_async, url_path_join
+from jupyter_server.utils import url_path_join
 
 from ...base.handlers import APIHandler
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -14,12 +14,12 @@ except ImportError:
 from dataclasses import dataclass, fields
 from typing import Union
 
+from jupyter_core.utils import ensure_async
 from tornado import web
 from traitlets import Instance, TraitError, Unicode, validate
 from traitlets.config.configurable import LoggingConfigurable
 
 from jupyter_server.traittypes import InstanceFromClasses
-from jupyter_server.utils import ensure_async
 
 
 class KernelSessionRecordConflict(Exception):

--- a/jupyter_server/view/handlers.py
+++ b/jupyter_server/view/handlers.py
@@ -1,12 +1,13 @@
 """Tornado handlers for viewing HTML files."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
 
 from ..base.handlers import JupyterHandler, path_regex
-from ..utils import ensure_async, url_escape, url_path_join
+from ..utils import url_escape, url_path_join
 
 AUTH_RESOURCE = "contents"
 

--- a/tests/services/contents/test_checkpoints.py
+++ b/tests/services/contents/test_checkpoints.py
@@ -1,5 +1,5 @@
 import pytest
-from jupyter_client.utils import ensure_async
+from jupyter_core.utils import ensure_async
 from nbformat import from_dict
 from nbformat.v4 import new_markdown_cell
 

--- a/tests/services/contents/test_largefilemanager.py
+++ b/tests/services/contents/test_largefilemanager.py
@@ -1,11 +1,11 @@
 import pytest
 import tornado
+from jupyter_core.utils import ensure_async
 
 from jupyter_server.services.contents.largefilemanager import (
     AsyncLargeFileManager,
     LargeFileManager,
 )
-from jupyter_server.utils import ensure_async
 
 from ...utils import expected_http_error
 

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, Tuple
 from unittest.mock import patch
 
 import pytest
+from jupyter_core.utils import ensure_async
 from nbformat import ValidationError
 from nbformat import v4 as nbformat
 from tornado.web import HTTPError
@@ -15,7 +16,6 @@ from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
     FileContentsManager,
 )
-from jupyter_server.utils import ensure_async
 
 from ...utils import expected_http_error
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import tornado
+from jupyter_core.utils import ensure_async
 from tornado.httpclient import HTTPRequest, HTTPResponse
 from tornado.web import HTTPError
 from traitlets import Int, Unicode
@@ -21,7 +22,6 @@ from traitlets.config import Config
 
 from jupyter_server.gateway.gateway_client import GatewayTokenRenewerBase, NoOpTokenRenewer
 from jupyter_server.gateway.managers import ChannelQueue, GatewayClient, GatewayKernelManager
-from jupyter_server.utils import ensure_async
 
 from .utils import expected_http_error
 


### PR DESCRIPTION
It seem to me that hiding the fact that ensure_async is from a dependency is counter productive as it adds an unnecessary level of indirection and hide the jupyter_core dependency.