### PR TITLE
Fix broken link in warning message

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -243,9 +243,8 @@ class AuthenticatedHandler(web.RequestHandler):
                 "be a required key for all subclasses of `JupyterHandler`. For an "
                 "example, see the jupyter_server source code for how to "
                 "add an identity provider to the tornado settings: "
-                "https://github.com/jupyter-server/jupyter_server/blob/"
-                "aa8fd8b3faf37466eeb99689d5555314c5bf6640/jupyter_server/serverapp.py"
-                "#L253",
+                "https://github.com/jupyter-server/jupyter_server/blob/v2.0.0/"
+                "jupyter_server/serverapp.py#L242",
             )
             from jupyter_server.auth import IdentityProvider
 


### PR DESCRIPTION
The source code permalink provided in here was broken, likeley due to force pushes in the PR (#671) adding the comment.

https://github.com/jupyter-server/jupyter_server/blob/2a88e2a2c033578b7d72b440c296acbbe80fb398/jupyter_server/base/handlers.py#L229-L241

I'm updating it to reference v2.0.0 instead, which also helps the reader understand when in time this message refers to. Specifically to the first line in this code block:

https://github.com/jupyter-server/jupyter_server/blob/2a88e2a2c033578b7d72b440c296acbbe80fb398/jupyter_server/serverapp.py#L242-L249