### PR TITLE
Fix check release by ignoring duplicate file name in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,3 +289,6 @@ ignore-nested-functions=true
 ignore-nested-classes=true
 fail-under=95
 exclude = ["docs", "test"]
+
+[tool.check-wheel-contents]
+ignore = ["W002"]


### PR DESCRIPTION
Handles:

```
installing check-wheel-contents...
dist/jupyter_server-2.0.7-py3-none-any.whl: W002: Wheel contains duplicate files:
  jupyter_server/static/favicon.ico
  jupyter_server/static/favicons/favicon.ico
```