### PR TITLE
Log how long each extension module takes to import

### DIFF
--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -1,7 +1,7 @@
 """Extension utilities."""
 import importlib
-import warnings
 import time
+import warnings
 
 
 class ExtensionLoadingError(Exception):

--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -1,6 +1,7 @@
 """Extension utilities."""
 import importlib
 import warnings
+import time
 
 
 class ExtensionLoadingError(Exception):
@@ -62,7 +63,14 @@ def get_metadata(package_name, logger=None):
     If it doesn't exist, return a basic metadata packet given
     the module name.
     """
+    start_time = time.perf_counter()
     module = importlib.import_module(package_name)
+    end_time = time.perf_counter()
+    duration = end_time - start_time
+    # Sometimes packages can take a *while* to import, so we report how long
+    # each module took to import. This makes it much easier for users to report
+    # slow loading modules upstream, as slow loading modules will block server startup
+    logger.info(f"Package {package_name} took {duration:.4f}s to import")
 
     try:
         return module, module._jupyter_server_extension_points()

--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -70,7 +70,8 @@ def get_metadata(package_name, logger=None):
     # Sometimes packages can take a *while* to import, so we report how long
     # each module took to import. This makes it much easier for users to report
     # slow loading modules upstream, as slow loading modules will block server startup
-    logger.info(f"Package {package_name} took {duration:.4f}s to import")
+    if logger:
+        logger.info(f"Package {package_name} took {duration:.4f}s to import")
 
     try:
         return module, module._jupyter_server_extension_points()


### PR DESCRIPTION
Based on some detailed debugging in
https://github.com/2i2c-org/infrastructure/issues/2047 to figure out why a Jupyter Server *process* sometimes takes more than 30s
to start, the primary culprit was server extensions that took multiple seconds to just even import. Thanks to some ad-hoc patching (https://github.com/2i2c-org/infrastructure/issues/2047#issuecomment-1379785520), I was able to figure out which were the slow extensions. This PR emits extension import time as log messages, so this information is *much* more visible.

I also explicitly chose info instead of debug, primarily because I believe it is *very* important to surface this performance information to users, so they can go bug the appropriate extension. Otherwise, it just feels like 'jupyter server is slow!'. This is compounded by the fact that while notebook server doesn't import *disabled* extensions, jupyter_server does seem to - so it's hard to isolate this.