### PR TITLE
Pass in a logger to get_metadata

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -147,7 +147,7 @@ class ExtensionPoint(HasTraits):
         return loader(serverapp)
 
 
-class ExtensionPackage(HasTraits):
+class ExtensionPackage(LoggingConfigurable):
     """An API for interfacing with a Jupyter Server extension package.
 
     Usage:
@@ -172,7 +172,7 @@ class ExtensionPackage(HasTraits):
         name = proposed["value"]
         self._extension_points = {}
         try:
-            self._module, self._metadata = get_metadata(name)
+            self._module, self._metadata = get_metadata(name, self.log)
         except ImportError as e:
             msg = (
                 f"The module '{name}' could not be found ({e}). Are you "


### PR DESCRIPTION
Without this, the log messages printed in
https://github.com/jupyter-server/jupyter_server/pull/1171 don't actually make it out. Whoops!

LoggingConfigurable inherits from HasTraits, and sets up Logging appropriately so we can have a log passed through.