### PR TITLE
Prevent load of disabled (or disabling) extension modules

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -163,6 +163,10 @@ class ExtensionPackage(LoggingConfigurable):
         """Initialize an extension package."""
         # Store extension points that have been linked.
         self._linked_points = {}
+        self._extension_points = {}
+        self._module = None
+        self._metadata = []
+        self._action = kwargs.pop("action", "")
         super().__init__(*args, **kwargs)
 
     _linked_points: dict = {}
@@ -172,7 +176,9 @@ class ExtensionPackage(LoggingConfigurable):
         name = proposed["value"]
         self._extension_points = {}
         try:
-            self._module, self._metadata = get_metadata(name, self.log)
+            # Perform load if we're enabling, or it's already enabled and not disabling the module
+            if (self.enabled and self._action != "disabling") or self._action == "enabling":
+                self._module, self._metadata = get_metadata(name, self.log)
         except ImportError as e:
             msg = (
                 f"The module '{name}' could not be found ({e}). Are you "

--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -71,7 +71,7 @@ def get_metadata(package_name, logger=None):
     # each module took to import. This makes it much easier for users to report
     # slow loading modules upstream, as slow loading modules will block server startup
     if logger:
-        logger.info(f"Package {package_name} took {duration:.4f}s to import")
+        logger.info(f"    - Package {package_name} took {duration:.4f}s to import")
 
     try:
         return module, module._jupyter_server_extension_points()


### PR DESCRIPTION
This pull request addresses the issue raised in #1177 by skipping the load of extension modules that are disabled **or are in the process of being disabled** via the tooling.

There were some _display_ decisions that I took the liberty to apply, but we can discuss them further if necessary.
1. the `- Writing config:` entry has been indented to align with the other entries.
2. The `Package xxx took yyys to import` message has also been indented to align with the other entries the tool produces.  Since this entry is also displayed at application startup, it appears indented.  (I personally find that indentation stands out more in the startup console and would prefer that and the nicer tool alignment than having it left justified.)
3. I print that validation is NOT happening when the extension is disabled or getting disabled - so that users won't ask why they don't see the validation.

There are two test failures that are the result of the tests not being sensitive to the current state of the module.  I will address these but wanted to get a consensus on this approach first.

Also, can a given module contain multiple extensions?  It seems like the tooling is only enabling/disabling at the module level, but I may be missing something.

<details>
  <summary>Here are some outputs of the various commands:</summary>

List extensions:
```
$ jupyter server extension list                         
Config dir: /Users/kbates/.jupyter

Config dir: /opt/miniconda3/envs/server-dev/etc/jupyter
    jupyter_server_mathjax enabled
    - Validating jupyter_server_mathjax...
    - Package jupyter_server_mathjax took 0.0010s to import
      jupyter_server_mathjax  OK
    jupyter_server_terminals enabled
    - Validating jupyter_server_terminals...
    - Package jupyter_server_terminals took 0.0075s to import
      jupyter_server_terminals 0.4.3 OK
    nbdime enabled
    - Validating nbdime...
    - Package nbdime took 0.0152s to import
      nbdime 3.1.1 OK

Config dir: /usr/local/etc/jupyter
```

Disable mathjax:
```
$ jupyter server extension disable jupyter_server_mathjax
    - Package jupyter_server_mathjax took 0.0012s to import
    - Package jupyter_server_terminals took 0.0081s to import
    - Package nbdime took 0.0150s to import
Disabling: jupyter_server_mathjax
    - Writing config: /opt/miniconda3/envs/server-dev/etc/jupyter
    - Validation of jupyter_server_mathjax skipped due to acton to disable.
    - Extension successfully disabled.
 ```

List extensions, post-disable:
```
$ jupyter server extension list                          
Config dir: /Users/kbates/.jupyter

Config dir: /opt/miniconda3/envs/server-dev/etc/jupyter
    jupyter_server_mathjax disabled
    - Validation of jupyter_server_mathjax skipped.
    jupyter_server_terminals enabled
    - Validating jupyter_server_terminals...
    - Package jupyter_server_terminals took 0.0083s to import
      jupyter_server_terminals 0.4.3 OK
    nbdime enabled
    - Validating nbdime...
    - Package nbdime took 0.0150s to import
      nbdime 3.1.1 OK

Config dir: /usr/local/etc/jupyter
```

Start server (with disabled):
```
$ jupyter server               
[I 2023-01-15 08:56:11.331 ServerApp]     - Package jupyter_server_terminals took 0.0074s to import
[I 2023-01-15 08:56:11.347 ServerApp]     - Package nbdime took 0.0150s to import
[I 2023-01-15 08:56:11.350 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2023-01-15 08:56:11.350 ServerApp] nbdime | extension was successfully linked.
[I 2023-01-15 08:56:11.680 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2023-01-15 08:56:11.830 ServerApp] nbdime | extension was successfully loaded.
[I 2023-01-15 08:56:11.834 ServerApp] Serving notebooks from local directory: /Users/kbates/repos/oss/jupyter/jupyter_server
[I 2023-01-15 08:56:11.834 ServerApp] Jupyter Server 2.2.0.dev0 is running at:
[I 2023-01-15 08:56:11.834 ServerApp] http://localhost:8888/?token=dffea54d162b7d3704002136bc52219efde8ab72ad7ac850
```

Enable mathjax:
```
$ jupyter server extension enable jupyter_server_mathjax
    - Package jupyter_server_terminals took 0.0080s to import
    - Package nbdime took 0.0149s to import
Enabling: jupyter_server_mathjax
    - Writing config: /opt/miniconda3/envs/server-dev/etc/jupyter
    - Validating jupyter_server_mathjax...
    - Package jupyter_server_mathjax took 0.0010s to import
      jupyter_server_mathjax  OK
    - Extension successfully enabled.
```

Start server (with enabled):
```
$ jupyter server                                        
[I 2023-01-15 08:57:12.792 ServerApp]     - Package jupyter_server_mathjax took 0.0011s to import
[I 2023-01-15 08:57:12.799 ServerApp]     - Package jupyter_server_terminals took 0.0069s to import
[I 2023-01-15 08:57:12.815 ServerApp]     - Package nbdime took 0.0157s to import
[I 2023-01-15 08:57:12.819 ServerApp] jupyter_server_mathjax | extension was successfully linked.
[I 2023-01-15 08:57:12.822 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2023-01-15 08:57:12.822 ServerApp] nbdime | extension was successfully linked.
[I 2023-01-15 08:57:13.145 ServerApp] jupyter_server_mathjax | extension was successfully loaded.
[I 2023-01-15 08:57:13.147 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2023-01-15 08:57:13.274 ServerApp] nbdime | extension was successfully loaded.
[I 2023-01-15 08:57:13.277 ServerApp] Serving notebooks from local directory: /Users/kbates/repos/oss/jupyter/jupyter_server
[I 2023-01-15 08:57:13.277 ServerApp] Jupyter Server 2.2.0.dev0 is running at:
[I 2023-01-15 08:57:13.278 ServerApp] http://localhost:8888/?token=b72021ad41800ad853ec431adeda7bacd1e852281f610078
```
</details>

Resolves: #1177