### PR TITLE
Don't assume that resources entries are relative

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -218,13 +218,14 @@ class GatewayKernelSpecManager(KernelSpecManager):
             for resource_name in resources:
                 original_path = resources[resource_name]
                 split_eg_base_url = str.rsplit(original_path, sep="/kernelspecs/", maxsplit=1)
-                new_path = url_path_join(self.parent.base_url, "kernelspecs", split_eg_base_url[1])
-                kernel_specs["kernelspecs"][kernel_name]["resources"][resource_name] = new_path
-                if original_path != new_path:
-                    self.log.debug(
-                        f"Replaced original kernel resource path {original_path} with new "
-                        f"path {kernel_specs['kernelspecs'][kernel_name]['resources'][resource_name]}"
-                    )
+                if (len(split_eg_base_url) > 1):
+                  new_path = url_path_join(self.parent.base_url, "kernelspecs", split_eg_base_url[1])
+                  kernel_specs["kernelspecs"][kernel_name]["resources"][resource_name] = new_path
+                  if original_path != new_path:
+                      self.log.debug(
+                          f"Replaced original kernel resource path {original_path} with new "
+                          f"path {kernel_specs['kernelspecs'][kernel_name]['resources'][resource_name]}"
+                      )
         return kernel_specs
 
     def _get_kernelspecs_endpoint_url(self, kernel_name=None):

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -218,14 +218,16 @@ class GatewayKernelSpecManager(KernelSpecManager):
             for resource_name in resources:
                 original_path = resources[resource_name]
                 split_eg_base_url = str.rsplit(original_path, sep="/kernelspecs/", maxsplit=1)
-                if (len(split_eg_base_url) > 1):
-                  new_path = url_path_join(self.parent.base_url, "kernelspecs", split_eg_base_url[1])
-                  kernel_specs["kernelspecs"][kernel_name]["resources"][resource_name] = new_path
-                  if original_path != new_path:
-                      self.log.debug(
-                          f"Replaced original kernel resource path {original_path} with new "
-                          f"path {kernel_specs['kernelspecs'][kernel_name]['resources'][resource_name]}"
-                      )
+                if len(split_eg_base_url) > 1:
+                    new_path = url_path_join(
+                        self.parent.base_url, "kernelspecs", split_eg_base_url[1]
+                    )
+                    kernel_specs["kernelspecs"][kernel_name]["resources"][resource_name] = new_path
+                    if original_path != new_path:
+                        self.log.debug(
+                            f"Replaced original kernel resource path {original_path} with new "
+                            f"path {kernel_specs['kernelspecs'][kernel_name]['resources'][resource_name]}"
+                        )
         return kernel_specs
 
     def _get_kernelspecs_endpoint_url(self, kernel_name=None):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -41,7 +41,10 @@ def generate_kernelspec(name):
     kernelspec_stanza = {
         "name": name,
         "spec": spec_stanza,
-        "resources": {"logo-64x64": f"f/kernelspecs/{name}/logo-64x64.png"},
+        "resources": {
+            "logo-64x64": f"f/kernelspecs/{name}/logo-64x64.png",
+            "url": "https://example.com/example-url",
+        },
     }
     return kernelspec_stanza
 


### PR DESCRIPTION
Starting with the 2.0.2 release of jupyter_server, every entry in the `resources` field of a kernelspec reported by the kernel gateway is assumed to be a path relative to the kernel gateway URL starting with `/kernelspecs`).

However, this assumption is not documented anywhere in the REST API doc (as far as I can tell), and I have a kernel gateway server that uses the resources object to report additional URLs that are not relative to `/kernelspecs/`.

With that combination, any attempts to use this kernel gateway with a version newer than 2.0.2 results in the following failure trace:

```
   Traceback (most recent call last):                                                                                                                                            
      File "/home/ojarjur/.local/lib/python3.9/site-packages/tornado/web.py", line 1713, in _execute                                                                              
        result = await result                                                                                                                                                     
      File "/home/ojarjur/.local/lib/python3.9/site-packages/jupyter_server/services/kernelspecs/handlers.py", line 70, in get                                                    
        kspecs = await ensure_async(ksm.get_all_specs())                                                                                                                          
      File "/home/ojarjur/.local/lib/python3.9/site-packages/jupyter_core/utils/__init__.py", line 184, in ensure_async                                                           
        result = await obj                                                                                                                                                        
      File "/home/ojarjur/.local/lib/python3.9/site-packages/jupyter_server/gateway/managers.py", line 243, in get_all_specs                                                      
        fetched_kspecs = await self.list_kernel_specs()                                                                                                                           
      File "/home/ojarjur/.local/lib/python3.9/site-packages/jupyter_server/gateway/managers.py", line 267, in list_kernel_specs                                                  
        kernel_specs = self._replace_path_kernelspec_resources(kernel_specs)                                                                                                      
      File "/home/ojarjur/.local/lib/python3.9/site-packages/jupyter_server/gateway/managers.py", line 221, in _replace_path_kernelspec_resources                                 
        new_path = url_path_join(self.parent.base_url, "kernelspecs", split_eg_base_url[1])                                                                                       
    IndexError: list index out of range 
```

This change tries to remove that assumption by checking whether or not the string split actually resulted in a list of more than one element.