### PR TITLE
Use repr in logging for exception.

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -363,8 +363,9 @@ class ExtensionManager(LoggingConfigurable):
             except Exception as e:
                 if self.serverapp and self.serverapp.reraise_server_extension_failures:
                     raise
-                self.log.warning("%s | extension failed loading with message: %s", name, e)
-                self.log.exception("%s | stack trace", name)
+                self.log.warning(
+                    "%s | extension failed loading with message: %r", name, e, exc_info=True
+                )
             else:
                 self.log.info("%s | extension was successfully loaded.", name)
 

--- a/jupyter_server/nbconvert/handlers.py
+++ b/jupyter_server/nbconvert/handlers.py
@@ -135,7 +135,7 @@ class NbconvertFileHandler(JupyterHandler):
                 lambda: exporter.from_notebook_node(nb, resources=resource_dict)
             )
         except Exception as e:
-            self.log.exception("nbconvert failed: %s", e)
+            self.log.exception("nbconvert failed: %r", e)
             raise web.HTTPError(500, "nbconvert failed: %s" % e) from e
 
         if respond_zip(self, name, output, resources):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2618,7 +2618,7 @@ class ServerApp(JupyterApp):
             with secure_write(self.info_file) as f:
                 json.dump(self.server_info(), f, indent=2, sort_keys=True)
         except OSError as e:
-            self.log.error(_i18n("Failed to write server-info to %s: %s"), self.info_file, e)
+            self.log.error(_i18n("Failed to write server-info to %s: %r"), self.info_file, e)
 
     def remove_server_info_file(self):
         """Remove the jpserver-<pid>.json file created for this server.
@@ -2760,7 +2760,7 @@ class ServerApp(JupyterApp):
         try:
             browser = webbrowser.get(self.browser or None)
         except webbrowser.Error as e:
-            self.log.warning(_i18n("No web browser found: %s.") % e)
+            self.log.warning(_i18n("No web browser found: %r.") % e)
             browser = None
 
         if not browser:

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -287,7 +287,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 try:
                     os_path = os.path.join(os_dir, name)
                 except UnicodeDecodeError as e:
-                    self.log.warning("failed to decode filename '%s': %s", name, e)
+                    self.log.warning("failed to decode filename '%s': %r", name, e)
                     continue
 
                 try:
@@ -297,7 +297,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                     if e.errno == errno.ENOENT:
                         self.log.warning("%s doesn't exist", os_path)
                     elif e.errno != errno.EACCES:  # Don't provide clues about protected files
-                        self.log.warning("Error stat-ing %s: %s", os_path, e)
+                        self.log.warning("Error stat-ing %s: %r", os_path, e)
                     continue
 
                 if (
@@ -636,7 +636,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
                 try:
                     os_path = os.path.join(os_dir, name)
                 except UnicodeDecodeError as e:
-                    self.log.warning("failed to decode filename '%s': %s", name, e)
+                    self.log.warning("failed to decode filename '%s': %r", name, e)
                     continue
 
                 try:
@@ -646,7 +646,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
                     if e.errno == errno.ENOENT:
                         self.log.warning("%s doesn't exist", os_path)
                     elif e.errno != errno.EACCES:  # Don't provide clues about protected files
-                        self.log.warning("Error stat-ing %s: %s", os_path, e)
+                        self.log.warning("Error stat-ing %s: %r", os_path, e)
                     continue
 
                 if (


### PR DESCRIPTION
And use exc_info=True instead of a separate log.exception to make sure the tb is attached to the right log message.

Using `%s` can have issue when logging error as it may hide informations like the type of exception. If for example you have an assertion error, %s will give you the empty string, which is not informative.

On the other hand, %r will _at least_ give you `AssertionError()`, which is a start.