### PR TITLE
Enable users to copy both files and directories

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -668,7 +668,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
     def check_folder_size(self, path):
         """
-        limit the size of folders being copied to prevent a timeout error
+        limit the size of folders being copied to be no more than the
+        trait max_copy_folder_size_mb to prevent a timeout error
         """
         limit_bytes = self.max_copy_folder_size_mb * 1024 * 1024
         size = int(self._get_dir_size(self._get_os_path(path)))
@@ -1146,10 +1147,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
     async def check_folder_size(self, path: str) -> None:
         """
         limit the size of folders being copied to be no more than the
-        trait max_copy_folder_size_mb
-
-        prevent a timeout error
-
+        trait max_copy_folder_size_mb to prevent a timeout error
         """
         limit_bytes = self.max_copy_folder_size_mb * 1024 * 1024
 

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -603,7 +603,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         parent_dir = path.rsplit("/", 1)[0] if "/" in path else ""
         return parent_dir
 
-    def copy(self, from_path: str, to_path=None):
+    def copy(self, from_path, to_path=None):
         """
         Copy an existing file or directory and return its new model.
         If to_path not specified, it will be the parent directory of from_path.
@@ -647,7 +647,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             to_path=to_path,
         )
 
-    def _copy_dir(self, from_path: str, to_path_original: str, to_name: str, to_path: str):
+    def _copy_dir(self, from_path, to_path_original, to_name, to_path):
         """
         handles copying directories
         returns the model for the copied directory
@@ -666,7 +666,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         return model
 
-    def check_folder_size(self, path: str):
+    def check_folder_size(self, path):
         """
         limit the size of folders being copied to prevent a timeout error
         """
@@ -685,7 +685,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 """,
             )
 
-    def _get_dir_size(self, path: str = "."):
+    def _get_dir_size(self, path = "."):
         """
         calls the command line program du to get the directory size
         """
@@ -716,7 +716,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             ) from err
         return size
 
-    def _human_readable_size(self, size: int):
+    def _human_readable_size(self, size):
         """
         returns folder size in a human readable format
         """
@@ -1084,7 +1084,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         parent_dir = path.rsplit("/", 1)[0] if "/" in path else ""
         return parent_dir
 
-    async def copy(self, from_path: str, to_path=None) -> dict:
+    async def copy(self, from_path, to_path=None):
         """
         Copy an existing file or directory and return its new model.
         If to_path not specified, it will be the parent directory of from_path.

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -685,7 +685,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
                 """,
             )
 
-    def _get_dir_size(self, path = "."):
+    def _get_dir_size(self, path="."):
         """
         calls the command line program du to get the directory size
         """

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -672,7 +672,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         """
         limit_mb = 100
         limit_str = f"{limit_mb}MB"
-        limit_bytes = limit_mb * 1024 * 1024
+        # limit_bytes = limit_mb * 1024 * 1024
+        limit_bytes = self.max_copy_folder_size_mb * 1024 * 1024
         size = int(self._get_dir_size(self._get_os_path(path)))
         size = size * 1024 if platform.system() == "Darwin" else size
 
@@ -1156,7 +1157,9 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         """
         limit_mb = 100
         limit_str = f"{limit_mb}MB"
-        limit_bytes = limit_mb * 1024 * 1024
+        # limit_bytes = limit_mb * 1024 * 1024
+        limit_bytes = self.max_copy_folder_size_mb * 1024 * 1024
+
         size = int(await self._get_dir_size(self._get_os_path(path)))
         size = size * 1024 if platform.system() == "Darwin" else size
         if size > limit_bytes:

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -5,6 +5,7 @@ import errno
 import math
 import mimetypes
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -673,6 +674,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         limit_str = f"{limit_mb}MB"
         limit_bytes = limit_mb * 1024 * 1024
         size = int(self._get_dir_size(self._get_os_path(path)))
+        size = size * 1024 if platform.system() == "Darwin" else size
+
         if size > limit_bytes:
             raise web.HTTPError(
                 400,
@@ -687,9 +690,19 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         calls the command line program du to get the directory size
         """
         try:
-            result = subprocess.run(
-                ["du", "-s", "--block-size=1", path], capture_output=True
-            ).stdout.split()
+            # result = subprocess.run(
+            #     ["du", "-s", "--block-size=1", path], capture_output=True
+            # ).stdout.split()
+            # self.log.info(f"current status of du command {result}")
+            # size = result[0].decode("utf-8")
+            if platform.system() == "Darwin":
+                result = subprocess.run(["du", "-sk", path], capture_output=True).stdout.split()
+
+            else:
+                result = subprocess.run(
+                    ["du", "-s", "--block-size=1", path], capture_output=True
+                ).stdout.split()
+
             self.log.info(f"current status of du command {result}")
             size = result[0].decode("utf-8")
         except Exception as err:
@@ -1145,6 +1158,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         limit_str = f"{limit_mb}MB"
         limit_bytes = limit_mb * 1024 * 1024
         size = int(await self._get_dir_size(self._get_os_path(path)))
+        size = size * 1024 if platform.system() == "Darwin" else size
         if size > limit_bytes:
             raise web.HTTPError(
                 400,
@@ -1159,9 +1173,18 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         calls the command line program du to get the directory size
         """
         try:
-            result = subprocess.run(
-                ["du", "-s", "--block-size=1", path], capture_output=True
-            ).stdout.split()
+            # result = subprocess.run(
+            #     ["du", "-s", "--block-size=1", path], capture_output=True
+            # ).stdout.split()
+
+            if platform.system() == "Darwin":
+                result = subprocess.run(["du", "-sk", path], capture_output=True).stdout.split()
+
+            else:
+                result = subprocess.run(
+                    ["du", "-s", "--block-size=1", path], capture_output=True
+                ).stdout.split()
+
             self.log.info(f"current status of du command {result}")
             size = result[0].decode("utf-8")
         except Exception as err:

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -19,7 +19,7 @@ from anyio.to_thread import run_sync
 from jupyter_core.paths import exists, is_file_hidden, is_hidden
 from send2trash import send2trash
 from tornado import web
-from traitlets import Bool, TraitError, Unicode, default, validate
+from traitlets import Bool, Int, TraitError, Unicode, default, validate
 
 from jupyter_server import _tz as tz
 from jupyter_server.base.handlers import AuthenticatedFileHandler
@@ -43,6 +43,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     """A file contents manager."""
 
     root_dir = Unicode(config=True)
+
+    max_copy_folder_size_mb = Int(500, config=True, help="The max folder size that can be copied")
 
     @default("root_dir")
     def _default_root_dir(self):

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -1147,7 +1147,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         """
         limit the size of folders being copied to be no more than the
         trait max_copy_folder_size_mb
-        
+
         prevent a timeout error
 
         """

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -15,7 +15,19 @@ from nbformat import ValidationError, sign
 from nbformat import validate as validate_nb
 from nbformat.v4 import new_notebook
 from tornado.web import HTTPError, RequestHandler
-from traitlets import Any, Bool, Dict, Instance, List, TraitError, Type, Unicode, default, validate
+from traitlets import (
+    Any,
+    Bool,
+    Dict,
+    Instance,
+    Int,
+    List,
+    TraitError,
+    Type,
+    Unicode,
+    default,
+    validate,
+)
 from traitlets.config.configurable import LoggingConfigurable
 
 from jupyter_server import DEFAULT_EVENTS_SCHEMA_PATH, JUPYTER_SERVER_EVENTS_URI
@@ -120,6 +132,8 @@ class ContentsManager(LoggingConfigurable):
         Glob patterns to hide in file and directory listings.
     """,
     )
+
+    max_copy_folder_size_mb = Int(500, config=True, help="The max folder size that can be copied")
 
     untitled_notebook = Unicode(
         _i18n("Untitled"),

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -20,7 +20,6 @@ from traitlets import (
     Bool,
     Dict,
     Instance,
-    Int,
     List,
     TraitError,
     Type,
@@ -132,8 +131,6 @@ class ContentsManager(LoggingConfigurable):
         Glob patterns to hide in file and directory listings.
     """,
     )
-
-    max_copy_folder_size_mb = Int(500, config=True, help="The max folder size that can be copied")
 
     untitled_notebook = Unicode(
         _i18n("Untitled"),

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -494,6 +494,27 @@ async def test_copy(jp_fetch, contents, contents_dir, _check_created):
     _check_created(r, str(contents_dir), path, copy3, type="notebook")
 
 
+async def test_copy_dir(jp_fetch, contents, contents_dir, _check_created):
+    # created a nest copy of a the original folder
+    dest_dir = "foo"
+    path = "parent"
+    response = await jp_fetch(
+        "api", "contents", path, method="POST", body=json.dumps({"copy_from": dest_dir})
+    )
+
+    _check_created(response, str(contents_dir), path, dest_dir, type="directory")
+
+    # copy to a folder where a similar name exists
+    dest_dir = "foo"
+    path = "parent"
+    copy_dir = f"{dest_dir}-Copy1"
+    response = await jp_fetch(
+        "api", "contents", path, method="POST", body=json.dumps({"copy_from": dest_dir})
+    )
+
+    _check_created(response, str(contents_dir), path, copy_dir, type="directory")
+
+
 async def test_copy_path(jp_fetch, contents, contents_dir, _check_created):
     path1 = "foo"
     path2 = "å b"
@@ -573,18 +594,6 @@ async def test_copy_put_400_hidden(
             "old.txt",
             method="PUT",
             body=json.dumps({"copy_from": ".hidden.txt"}),
-        )
-    assert expected_http_error(e, 400)
-
-
-async def test_copy_dir_400(jp_fetch, contents, contents_dir, _check_created):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await jp_fetch(
-            "api",
-            "contents",
-            "foo",
-            method="POST",
-            body=json.dumps({"copy_from": "å b"}),
         )
     assert expected_http_error(e, 400)
 

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -92,10 +92,10 @@ def _make_big_dir(contents_manager, api_path):
         # the file size of the copied file ends up being smaller than the original
         # we only want to increase the number of folder if the tests is being run on
         # windows,
-        big_dir_size = contents_manager.max_copy_folder_size_mb * 3
-        print(f"the size of the big folder for testing is {big_dir_size}")
-        num_sub_folders = big_dir_size if platform.system() != "Windows" else big_dir_size * 3
-
+        # big_dir_size = contents_manager.max_copy_folder_size_mb * 3
+        # print(f"the size of the big folder for testing is {big_dir_size}")
+        # num_sub_folders = big_dir_size if platform.system() != "Windows" else big_dir_size * 3
+        num_sub_folders = contents_manager.max_copy_folder_size_mb * 10
         for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")
             for j in range(200):

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -91,9 +91,10 @@ def _make_big_dir(contents_manager, api_path):
         # since shutil.copy in Windows can't copy the metadata for files
         # the file size of the copied file ends up being smaller than the original
         # we only want to increase the number of folder if the tests is being run on
-        # windows, otherwise the for loop doesn't need to run as long as this
-        # function is already slow enough
-        num_sub_folders = 500 if platform.system() == "Windows" else 200
+        # windows,
+        big_dir_size = contents_manager.max_copy_folder_size_mb * 3
+        print(f"the size of the big folder for testing is {big_dir_size}")
+        num_sub_folders = big_dir_size if platform.system() == "Windows" else big_dir_size * 3
 
         for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")
@@ -905,10 +906,12 @@ async def test_copy_dir(jp_contents_manager):
 
 
 async def test_copy_big_dir(jp_contents_manager):
-    # this tests how the Content API limits prevents copying folders that more than 100MB in size
+    # this tests how the Content API limits preventing copying folders that are more than
+    # the size limit specified in max_copy_folder_size_mb trait
     cm = jp_contents_manager
     destDir = "Untitled Folder 1"
     sourceDir = "Morningstar Notebooks"
+    cm.max_copy_folder_size_mb = 5
     _make_dir(cm, destDir)
     _make_big_dir(contents_manager=cm, api_path=sourceDir)
     with pytest.raises(HTTPError) as exc_info:

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -93,10 +93,7 @@ def _make_big_dir(contents_manager, api_path):
         # we only want to increase the number of folder if the tests is being run on
         # windows, otherwise the for loop doesn't need to run as long as this
         # function is already slow enough
-        if platform.system() == "Windows":
-            num_sub_folders = 500
-        else:
-            num_sub_folders = 200
+        num_sub_folders = 500 if platform.system() == "Windows" else 200
 
         for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import shutil
 import sys
 import time
@@ -87,7 +88,17 @@ def _make_big_dir(contents_manager, api_path):
             """
             )
 
-        for i in range(200):
+        # since shutil.copy in Windows can't copy the metadata for files
+        # the file size of the copied file ends up being smaller than the original
+        # we only want to increase the number of folder if the tests is being run on
+        # windows, otherwise the for loop doesn't need to run as long as this
+        # function is already slow enough
+        if platform.system() == "Windows":
+            num_sub_folders = 500
+        else:
+            num_sub_folders = 200
+
+        for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")
             for j in range(200):
                 shutil.copy(

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import shutil
 import sys
 import time
@@ -59,20 +58,6 @@ def _make_big_dir(contents_manager, api_path):
     os_path = contents_manager._get_os_path(api_path)
     try:
         os.makedirs(os_path)
-        # textFile = open(f"{os_path}/demofile.txt", "a")
-        # textFile.write(
-        #     """
-        # Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-        # sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        # Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        # laboris nisi ut aliquip ex ea commodo consequat.
-        #  Duis aute irure dolor in reprehenderit in voluptate
-        #  velit esse cillum dolore eu fugiat nulla pariatur.
-        #  Excepteur sint occaecat cupidatat non proident,
-        #  sunt in culpa qui officia deserunt mollit anim id est laborum.
-        # """
-        # )
-        # textFile.close()
 
         with open(f"{os_path}/demofile.txt", "a") as textFile:
             textFile.write(
@@ -88,13 +73,6 @@ def _make_big_dir(contents_manager, api_path):
             """
             )
 
-        # since shutil.copy in Windows can't copy the metadata for files
-        # the file size of the copied file ends up being smaller than the original
-        # we only want to increase the number of folder if the tests is being run on
-        # windows,
-        # big_dir_size = contents_manager.max_copy_folder_size_mb * 3
-        # print(f"the size of the big folder for testing is {big_dir_size}")
-        # num_sub_folders = big_dir_size if platform.system() != "Windows" else big_dir_size * 3
         num_sub_folders = contents_manager.max_copy_folder_size_mb * 10
         for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -94,7 +94,7 @@ def _make_big_dir(contents_manager, api_path):
         # windows,
         big_dir_size = contents_manager.max_copy_folder_size_mb * 3
         print(f"the size of the big folder for testing is {big_dir_size}")
-        num_sub_folders = big_dir_size if platform.system() == "Windows" else big_dir_size * 3
+        num_sub_folders = big_dir_size if platform.system() != "Windows" else big_dir_size * 3
 
         for i in range(num_sub_folders):
             os.makedirs(f"{os_path}/subfolder-{i}")


### PR DESCRIPTION
# Objective
Enable users to copy both files and directories
Currently, if users try copying a directory, an error will thrown backing saying "Can't Copy directories". 
## jupyterlab
- The copy option in the right click menu, was enabled for directories. 
- 
## jupter_server

- The copy directory functionality has been added to both the FileContentsManager and AsyncFileContentsManager
- Users can copy folders up to 100 MB,
	- The actual limit for copying directories before a timeout occurs is 500MB, but without a loading indicator, if a user tries to copy a folder that is near 500MB, jupyterlab  will seem like its frozen, since its not clear whether the copy operation is complete or in progress. 
	- if we can add a loading indicator in the future to jupyterlab, then we would be able to increase the limit of copying folders to 500 MB

## How to test
Create a virtual environment with venv (you can use what ever viritual environment tool you like)
```sh
python3 -m venv jupyter-connected
source jupyter-connected/bin/activate
pip install --upgrade pip
# install the jupyter_server package into the environment
git clone https://github.com/kenyaachon/jupyter_server.git
cd jupyter_server
git checkout copy-folder-functionality
pip install -e ".[test]"
# verify the dev version (i.e 2.1.0.dev0) of the package is in the environment
pip list | grep jupyter
# install the jupyterlab in development mode with latest changes
cd ..
git clone https://github.com/kenyaachon/jupyterlab.git
cd jupyterlab
git checkout develop
pip install -e .
jlpm install
jlpm run build 
jupyter lab --dev-mode
```

## Limitations
- We were not able to find a suitable solution yet for being able to copy folders above 500MB in size without having a timeout issue

- Users, cannot easily know if the folder they are copying is above 100MB before they try and copy
	- We did attempt in adding the folder size to the preview info that users get when hovering over a file or folder. But this ended up making the filebrowser-extension very slow when loading the correct directory. Since it would have to recalculate the size of the folders in the given directory each time a new path was loaded. 