### PR TITLE
remove upper bound on anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "anyio>=3.1.0,<4",
+    "anyio>=3.1.0",
     "argon2-cffi",
     "jinja2",
     "jupyter_client>=7.4.4",


### PR DESCRIPTION
upper-bound pin added during dependency sorting in #675, for no reason I can see. Perhaps by accident, since there is no anyio 4, and there's no reason to suspect it would break our use.

It's generally desirable to avoid upper bounds in Python because they tend to create far more problems than they solve (in packages, self-contained applications have different needs).

Upper bounds should generally only be added in packages:

- if a known incompatibility has been identified, and
- with an immediate issue/pr to revert the pin flagging that it's a pressing issue to fix, because upper bounds _themselves_ are a problem that needs fixing if it excludes the latest version of something.