### PR TITLE
Fix get_loader returning None when load_jupyter_server_extension is not found (#1193)Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>

### DIFF
--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -38,7 +38,7 @@ def get_loader(obj, logger=None):
     try:
         func = getattr(obj, "_load_jupyter_server_extension")  # noqa B009
     except AttributeError:
-        func = getattr(obj, "load_jupyter_server_extension", None)
+        func = getattr(obj, "load_jupyter_server_extension")  # noqa B009
         warnings.warn(
             "A `_load_jupyter_server_extension` function was not "
             "found in {name!s}. Instead, a `load_jupyter_server_extension` "

--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -36,20 +36,24 @@ def get_loader(obj, logger=None):
     underscore prefix.
     """
     try:
-        func = getattr(obj, "_load_jupyter_server_extension")  # noqa B009
+        return getattr(obj, "_load_jupyter_server_extension")  # noqa B009
     except AttributeError:
+        pass
+
+    try:
         func = getattr(obj, "load_jupyter_server_extension")  # noqa B009
-        warnings.warn(
-            "A `_load_jupyter_server_extension` function was not "
-            "found in {name!s}. Instead, a `load_jupyter_server_extension` "
-            "function was found and will be used for now. This function "
-            "name will be deprecated in future releases "
-            "of Jupyter Server.".format(name=obj),
-            DeprecationWarning,
-        )
-    except Exception:
+    except AttributeError:
         msg = "_load_jupyter_server_extension function was not found."
         raise ExtensionLoadingError(msg) from None
+
+    warnings.warn(
+        "A `_load_jupyter_server_extension` function was not "
+        "found in {name!s}. Instead, a `load_jupyter_server_extension` "
+        "function was found and will be used for now. This function "
+        "name will be deprecated in future releases "
+        "of Jupyter Server.".format(name=obj),
+        DeprecationWarning,
+    )
     return func
 
 

--- a/tests/extension/mockextensions/mockext_deprecated.py
+++ b/tests/extension/mockextensions/mockext_deprecated.py
@@ -1,0 +1,12 @@
+"""A mock extension named `mockext_py` for testing purposes.
+"""
+# Function that makes these extensions discoverable
+# by the test functions.
+
+
+def _jupyter_server_extension_paths():
+    return [{"module": "tests.extension.mockextensions.mockext_deprecated"}]
+
+
+def load_jupyter_server_extension(serverapp):
+    pass

--- a/tests/extension/test_utils.py
+++ b/tests/extension/test_utils.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import pytest
 

--- a/tests/extension/test_utils.py
+++ b/tests/extension/test_utils.py
@@ -3,8 +3,13 @@ import warnings
 
 import pytest
 
-from jupyter_server.extension.utils import get_loader, get_metadata, validate_extension, ExtensionLoadingError
-from tests.extension.mockextensions import mockext_sys, mockext_deprecated
+from jupyter_server.extension.utils import (
+    ExtensionLoadingError,
+    get_loader,
+    get_metadata,
+    validate_extension,
+)
+from tests.extension.mockextensions import mockext_deprecated, mockext_sys
 
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
@@ -29,6 +34,7 @@ def test_get_loader():
         assert get_loader(mockext_deprecated) == mockext_deprecated.load_jupyter_server_extension
     with pytest.raises(ExtensionLoadingError):
         get_loader(object())
+
 
 def test_get_metadata():
     _, ext_points = get_metadata("tests.extension.mockextensions.mockext_sys")

--- a/tests/extension/test_utils.py
+++ b/tests/extension/test_utils.py
@@ -3,8 +3,8 @@ import warnings
 
 import pytest
 
-from jupyter_server.extension.utils import get_loader, get_metadata, validate_extension
-from tests.extension.mockextensions import mockext_sys
+from jupyter_server.extension.utils import get_loader, get_metadata, validate_extension, ExtensionLoadingError
+from tests.extension.mockextensions import mockext_sys, mockext_deprecated
 
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
@@ -24,11 +24,11 @@ def test_validate_extension():
 
 
 def test_get_loader():
-    get_loader(mockext_sys)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert get_loader(object()) is None
-
+    assert get_loader(mockext_sys) == mockext_sys._load_jupyter_server_extension
+    with pytest.deprecated_call():
+        assert get_loader(mockext_deprecated) == mockext_deprecated.load_jupyter_server_extension
+    with pytest.raises(ExtensionLoadingError):
+        get_loader(object())
 
 def test_get_metadata():
     _, ext_points = get_metadata("tests.extension.mockextensions.mockext_sys")


### PR DESCRIPTION
## Description

The function `extension.utils.get_loader` returns `None` instead of raising an exception when an extension does not define`_load_jupyter_server_extension` nor `load_jupyter_server_extension`.

## Reproduce

1. Install an extension that does not define `load_jupyter_server_extension` nor `_load_jupyter_server_extension`, for example [jupyterlab-nvdashboard](https://github.com/rapidsai/jupyterlab-nvdashboard)
2. Launch jupyter lab
The following exception appears in the log:
```
     Traceback (most recent call last):
      File "/opt/jupyterhub/lib64/python3.9/site-packages/jupyter_server/extension/manager.py", line 355, in load_extension
        extension.load_all_points(self.serverapp)
      File "/opt/jupyterhub/lib64/python3.9/site-packages/jupyter_server/extension/manager.py", line 229, in load_all_points
        return [self.load_point(point_name, serverapp) for point_name in self.extension_points]
      File "/opt/jupyterhub/lib64/python3.9/site-packages/jupyter_server/extension/manager.py", line 229, in <listcomp>
        return [self.load_point(point_name, serverapp) for point_name in self.extension_points]
      File "/opt/jupyterhub/lib64/python3.9/site-packages/jupyter_server/extension/manager.py", line 222, in load_point
        return point.load(serverapp)
      File "/opt/jupyterhub/lib64/python3.9/site-packages/jupyter_server/extension/manager.py", line 148, in load
        return loader(serverapp)
    TypeError: 'NoneType' object is not callable
```

## Expected behavior

The user should get an AttributeError exception instead of a TypeError, making it clear that `_load_jupyter_server_extension` is missing for the extension being loaded.

## Context

The problem was introduced by PR #742, when a default value of `None` was configured if `gettattr` could not find `load_jupyter_server_extension`. The change was made to satisfy Flake8.

## Fix implemented in this PR

Remove the default value for `gettatr` in get_loader and set the comment `# noqa B009` to keep Flake8 satisfied.

