### PR TITLE
Delete the extra "or" in front of the second url

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2147,7 +2147,7 @@ class ServerApp(JupyterApp):
         """Human readable string with URLs for interacting
         with the running Jupyter Server
         """
-        url = self.public_url + "\n or " + self.local_url
+        url = self.public_url + "\n    " + self.local_url
         return url
 
     @property


### PR DESCRIPTION
This change was made in #460, but somehow it was not here.