### PR TITLE
Support IPV6 in _find_http_port()

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2404,9 +2404,14 @@ class ServerApp(JupyterApp):
 
     def _find_http_port(self):
         """Find an available http port."""
+        pat = re.compile("([a-f0-9:]+:+)+[a-f0-9]*")
         success = None
         for port in random_ports(self.port, self.port_retries + 1):
-            tmp_sock = socket.socket()
+            tmp_sock = (
+                socket.socket()
+                if pat.match(self.ip) is None
+                else socket.socket(family=socket.AF_INET6)
+            )
             try:
                 tmp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b"\0" * 8)
                 tmp_sock.bind((self.ip, port))


### PR DESCRIPTION
When I try to deploy the jupyterlab server in an environment with IPV6 address, the server fail to start with stack trace like:

```
Traceback (most recent call last):
  File "/opt/conda/bin/jupyter-lab", line 10, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/jupyter_server/extension/application.py", line 607, in launch_instance
    serverapp = cls.initialize_server(argv=args)
  File "/opt/conda/lib/python3.10/site-packages/jupyter_server/extension/application.py", line 577, in initialize_server
    serverapp.initialize(
  File "/opt/conda/lib/python3.10/site-packages/traitlets/config/application.py", line 113, in inner
    return method(app, *args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/jupyter_server/serverapp.py", line 2550, in initialize
    self.init_httpserver()
  File "/opt/conda/lib/python3.10/site-packages/jupyter_server/serverapp.py", line 2371, in init_httpserver
    self._find_http_port()
  File "/opt/conda/lib/python3.10/site-packages/jupyter_server/serverapp.py", line 2419, in _find_http_port
    tmp_sock.bind((self.ip, port))
socket.gaierror: [Errno -9] Address family for hostname not supported
```

This pull request is to solve the problem by detect if the address to listen to is an IPV6 address, if so it construct a socket object with family set to AF_INET6. Otherwise, it fails back to the original code path.

Please consider accepting this patch to make user on IPV6 happier.
Thanks for your attention!