### PR TITLE
fix Content-Type header set for SVG files

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -773,7 +773,9 @@ class APIHandler(JupyterHandler):
     def finish(self, *args, **kwargs):
         """Finish an API response."""
         self.update_api_activity()
-        self.set_header("Content-Type", "application/json")
+        # prevent overriding Content-Type set in GatewayResourceHandler
+        if "Content-Type" not in self._headers:
+            self.set_header("Content-Type", "application/json")
         return super().finish(*args, **kwargs)
 
     def options(self, *args, **kwargs):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -422,9 +422,10 @@ async def test_gateway_get_named_kernelspec(init_gateway, jp_fetch):
         kspec_foo = json.loads(r.body.decode("utf-8"))
         assert kspec_foo.get("name") == "kspec_foo"
 
-        r = await jp_fetch("kernelspecs", "kspec_foo", "hi", method="GET")
+        r = await jp_fetch("kernelspecs", "kspec_foo", "logo-64x64.png", method="GET")
         assert r.code == 200
         assert r.body == b"foo"
+        assert r.headers["content-type"] == "image/png"
 
         with pytest.raises(tornado.httpclient.HTTPClientError) as e:
             await jp_fetch("api", "kernelspecs", "no_such_spec", method="GET")


### PR DESCRIPTION
Content-Type for SVG icon is properly set in [GatewayResourceHandler](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/gateway/handlers.py#L293) but overridden in the base handler to `application/json`. This change prevents overriding Content-Type if previously set.

Fixes https://github.com/jupyter-server/jupyter_server/issues/1216