### PR TITLE
Enable JS 2.0 (authenticated) extensions to work with classic notebook servers

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -236,7 +236,8 @@ class IdentityProvider(LoggingConfigurable):
         _token_user: User | None | Awaitable[User | None] = self.get_user_token(handler)
         if isinstance(_token_user, Awaitable):
             _token_user = await _token_user
-        token_user: User | None = _token_user  # need second variable name to collapse type
+        # need second variable name to collapse type
+        token_user: User | None = _token_user
         _cookie_user = self.get_user_cookie(handler)
         if isinstance(_cookie_user, Awaitable):
             _cookie_user = await _cookie_user


### PR DESCRIPTION
Fixes #1038

If a server extension inherits from `JupyterHandler` in Jupyter Server 2.0, it won't currently work with the classic notebook server (from jupyter/notebook) because they use different+competing authentication logic. 

**Why?** The extension looks for an identity provider that doesn't exist, so it creates a default one. Meanwhile, all other endpoints use the old/classic way of authenticating requests. The main reason this fails is that the classic auth flow and the identity provider over-write one another's login cookie because they are using the same cookie name by default. (Further, other issues arise if folks try to configure other settings on the login cookie...).

This PR allows both auth flows to coexist and ensures their settings+results are consistent. There are two key changes here
1. The identity provider's cookie name is prefixed with `model-`. I can't think of any particular reason why this would be problematic...
2. All other cookie settings are fetched from the classic server's webapp settings if they exist; otherwise, fall back to the defaults.

cc @fcollonval  