### PR TITLE
Fix priority of deprecated NotebookApp.notebook_dir behind ServerApp.root_dir (#1223

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1675,6 +1675,13 @@ class ServerApp(JupyterApp):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
         return value
 
+    @observe("root_dir")
+    def _root_dir_changed(self, change):
+        # record that root_dir is set,
+        # which affects loading of deprecated notebook_dir
+        self._root_dir_set = True
+        pass
+
     preferred_dir = Unicode(
         config=True,
         help=trans.gettext("Preferred starting directory to use for notebooks and kernels."),


### PR DESCRIPTION
The `_root_dir_set` flag prevents deprecated `notebook_dir` config from being loaded at a higher priority than newer `root_dir` config.

This config is relatively likely to be set, as `notebook_shim` means that legacy config, which should not be removed, is still loaded into ServerApp, so anyone who still has notebook config present for working with the older server will still get this config set on the new server, and it should be ignored in favor of newer config.