### PR TITLE
Added error propagation to gateway_request function

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -728,9 +728,20 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
     # NOTE: We do this here since this handler is called during the server's startup and subsequent refreshes
     # of the tree view.
     except HTTPClientError as e:
+        try:
+            error_payload = json.loads(e.response.body)
+            error_reason = (
+                error_payload.get("reason")
+                or f"Exception while attempting to connect to Gateway server url '{GatewayClient.instance().url}'"
+            )
+            error_message = error_payload.get("message") or e.message
+        except json.decoder.JSONDecodeError:
+            error_reason = e.response.body.decode()
+            error_message = e.message
+
         raise web.HTTPError(
             e.code,
-            f"Error attempting to connect to Gateway server url '{GatewayClient.instance().url}'.  "
+            f"Error from Gateway: [{error_message}] {error_reason}. "
             "Ensure gateway url is valid and the Gateway instance is running.",
         ) from e
     except ConnectionError as e:

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -728,16 +728,15 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
     # NOTE: We do this here since this handler is called during the server's startup and subsequent refreshes
     # of the tree view.
     except HTTPClientError as e:
-        try:
-            error_payload = json.loads(e.response.body)
-            error_reason = (
-                error_payload.get("reason")
-                or f"Exception while attempting to connect to Gateway server url '{GatewayClient.instance().url}'"
-            )
-            error_message = error_payload.get("message") or e.message
-        except json.decoder.JSONDecodeError:
-            error_reason = e.response.body.decode()
-            error_message = e.message
+        error_reason = f"Exception while attempting to connect to Gateway server url '{GatewayClient.instance().url}'"
+        error_message = e.message
+        if e.response:
+            try:
+                error_payload = json.loads(e.response.body)
+                error_reason = error_payload.get("reason") or error_reason
+                error_message = error_payload.get("message") or error_message
+            except json.decoder.JSONDecodeError:
+                error_reason = e.response.body.decode()
 
         raise web.HTTPError(
             e.code,


### PR DESCRIPTION
## Summary

Feature for https://github.com/jupyter-server/jupyter_server/issues/1231. With this change, error messages from Enterprise Gateway will be propagated through Jupyter Server to the frontend. Looking through the Enterprise Gateway code, it seems that the JSON payload returned should only contain a `reason` field or a `message` field (or both possibly). See the code for the `log_and_raise` method of the processproxy [here](https://github.com/jupyter-server/enterprise_gateway/blob/7effcb59d3e8c13cb4b95b9f6f0f22cbf08f93c0/enterprise_gateway/services/processproxies/processproxy.py#L998-L1020) where the `reason` field is populated, and also see the [swagger spec](https://github.com/jupyter-server/enterprise_gateway/blob/7effcb59d3e8c13cb4b95b9f6f0f22cbf08f93c0/enterprise_gateway/services/api/swagger.json#L399-L412) that lists only `reason` and `message` as possible properties. However, in my own testing, I've noticed the `message` and `reason` fields might not be in the body of the error (it's usually only one of them), so I've added logic to account for the fields missing or non-JSON payloads being returned.  See relevant discussion on the Jupyter community forum [here](https://discourse.jupyter.org/t/propagating-enterprise-gateway-error-messages-to-the-frontend-e-g-jupyter-lab/18293).

## Screenshots
The following screenshots show the before and after error messages displayed on Jupyter lab when kernel creation times out.

#### Before
![image](https://user-images.githubusercontent.com/30425158/223514552-1a625ae1-6409-41dd-b958-a80f69dfaebf.png)
Error message in text: `HTTP 500: Internal Server Error (Error attempting to connect to Gateway server url 'https://mygatewayurl'. Ensure gateway url is valid and the Gateway instance is running.)`

#### After
![image](https://user-images.githubusercontent.com/30425158/223514255-97138eba-5679-4c17-aafb-65be97432d60.png)
Error message: `HTTP 500: Internal Server Error (Error from Gateway: [Internal Server Error] KernelID: '094f5160-163a-4025-94cf-5d8922808dd3' launch timeout due to: Waited too long (40.0s) to get connection file.  Ensure gateway url is valid and the Gateway instance is running.)`

## Tests

No test cases were modified, and it doesn't seem that any have failed. I noticed that the `gateway_request` function is mocked in testing and doesn't seem to be directly used in the tests. Let me know if you'd like any tests to be added for this error propagation.