### PR TITLE
Fix italics in operators security sections

### DIFF
--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -78,8 +78,8 @@ Automatic Password setup
 As of notebook 5.3, the first time you log-in using a token, the server should
 give you the opportunity to setup a password from the user interface.
 
-You will be presented with a form asking for the current _token_, as well as
-your _new_ _password_ ; enter both and click on ``Login and setup new password``.
+You will be presented with a form asking for the current *token*, as well as
+your *new password*; enter both and click on ``Login and setup new password``.
 
 Next time you need to log in you'll be able to use the new password instead of
 the login token, otherwise follow the procedure to set a password from the

--- a/docs/source/operators/security.rst
+++ b/docs/source/operators/security.rst
@@ -91,7 +91,7 @@ as the information returned by the IdentityProvider is given to the Authorizer w
 
 Authentication always takes precedence because if no user is authenticated,
 no authorization checks need to be made,
-as all requests requiring _authorization_ must first complete _authentication_.
+as all requests requiring *authorization* must first complete *authentication*.
 
 Identity Providers
 ******************
@@ -118,11 +118,11 @@ This User object will be available as `self.current_user` in any request handler
 Request methods decorated with tornado's `@web.authenticated` decorator
 will only be allowed if this method returns something.
 
-The User object will be a Python :py:class:`dataclasses.dataclass`, `jupyter_server.auth.User`:
+The User object will be a Python :py:class:`dataclasses.dataclass` - `jupyter_server.auth.User`:
 
 .. autoclass:: jupyter_server.auth.User
 
-A custom IdentityProvider _may_ return a custom subclass.
+A custom IdentityProvider *may* return a custom subclass.
 
 
 The next method an identity provider has is :meth:`~jupyter_server.auth.IdentityProvider.identity_model`.
@@ -183,7 +183,7 @@ Authorization
 *************
 
 Authorization is the second step in allowing an action,
-after a user has been _authenticated_ by the IdentityProvider.
+after a user has been *authenticated* by the IdentityProvider.
 
 Authorization in Jupyter Server serves to provide finer grained control of access to its
 API resources. With authentication, requests are accepted if the current user is known by


### PR DESCRIPTION
While reading up on identity providers and authorizers (great information btw!), I found a few words that were meant to be italicized but the markdown character (`_`) was used instead of the rST character (`*`).  This PR merely fixes those.  I grepped the rest of the docs and found a couple of other instances in the public-server doc.