### PR TITLE
Re-enable websocket ping/pong from the server

### DIFF
--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -68,6 +68,9 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
 
     async def open(self, kernel_id):
         """Open a kernel websocket."""
+        # Need to call super here to make sure we
+        # begin a ping-pong loop with the client.
+        super().open()
         # Wait for the kernel to emit an idle status.
         self.log.info(f"Connecting to kernel {self.kernel_id}.")
         await self.connection.connect()


### PR DESCRIPTION
Looks like a minor regression was introduced by https://github.com/jupyter-server/jupyter_server/pull/1047

The server-side ping/pong on the kernel websockets as dropped when I refactored the websocket API.