### PR TITLE
Register websocket handler from same module as kernel handlers

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -164,7 +164,6 @@ JUPYTER_SERVICE_HANDLERS = {
     "files": ["jupyter_server.files.handlers"],
     "kernels": [
         "jupyter_server.services.kernels.handlers",
-        "jupyter_server.services.kernels.websocket",
     ],
     "kernelspecs": [
         "jupyter_server.kernelspecs.handlers",

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -19,6 +19,7 @@ from jupyter_server.auth import authorized
 from jupyter_server.utils import url_escape, url_path_join
 
 from ...base.handlers import APIHandler
+from .websocket import KernelWebsocketHandler
 
 AUTH_RESOURCE = "kernels"
 
@@ -121,4 +122,5 @@ default_handlers = [
         rf"/api/kernels/{_kernel_id_regex}/{_kernel_action_regex}",
         KernelActionHandler,
     ),
+    (r"/api/kernels/%s/channels" % _kernel_id_regex, KernelWebsocketHandler),
 ]

--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -8,8 +8,6 @@ from tornado.websocket import WebSocketHandler
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.base.websocket import WebSocketMixin
 
-from .handlers import _kernel_id_regex
-
 AUTH_RESOURCE = "kernels"
 
 
@@ -94,8 +92,3 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
         selected_subprotocol = preferred_protocol if preferred_protocol in subprotocols else None
         # None is the default, "legacy" protocol
         return selected_subprotocol
-
-
-default_handlers = [
-    (r"/api/kernels/%s/channels" % _kernel_id_regex, KernelWebsocketHandler),
-]


### PR DESCRIPTION
During the [2.x refactor of kernel websocket management](https://github.com/jupyter-server/jupyter_server/pull/1047), the file from which the websocket handler is registered changed.  The presents problems for applications that extend or leverage services and handlers from Jupyter Server (like Kernel Gateway and Enterprise Gateway, and perhaps other third-party applications).  As a result, those applications must account for this this file which presents problems for supporting both JupyterServer 1.x and 2.x.

This change moves the websocket handler registration back to the `services/kernels/handlers.py` file so that "extending applications" don't require changes  in their registration code to use JS 2.