### PR TITLE
Allows immutable cache for static files in a directory

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -951,8 +951,15 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
     def set_headers(self):
         """Set the headers."""
         super().set_headers()
+
+        immutable_paths = self.settings["static_immutable_cache"] or []
+
+        # allow immutable cache for files
+        if any(self.request.path.startswith(path) for path in immutable_paths):
+            self.set_header("Cache-Control", "public, max-age=31536000, immutable")
+
         # disable browser caching, rely on 304 replies for savings
-        if "v" not in self.request.arguments or any(
+        elif "v" not in self.request.arguments or any(
             self.request.path.startswith(path) for path in self.no_cache_paths
         ):
             self.set_header("Cache-Control", "no-cache")

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -942,7 +942,13 @@ HTTPError = web.HTTPError
 
 
 class FileFindHandler(JupyterHandler, web.StaticFileHandler):
-    """subclass of StaticFileHandler for serving files from a search path"""
+    """subclass of StaticFileHandler for serving files from a search path
+
+    The setting "static_immutable_cache" can be set up to serve some static
+    file as immutable (e.g. file name containing a hash). The setting is a
+    list of base URL, every static file URL starting with one of those will
+    be immutable.
+    """
 
     # cache search results, don't search for files more than once
     _static_paths: dict = {}
@@ -952,7 +958,7 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
         """Set the headers."""
         super().set_headers()
 
-        immutable_paths = self.settings["static_immutable_cache"] or []
+        immutable_paths = self.settings.get("static_immutable_cache", [])
 
         # allow immutable cache for files
         if any(self.request.path.startswith(path) for path in immutable_paths):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1812,6 +1812,17 @@ class ServerApp(JupyterApp):
         config=True,
     )
 
+    static_immutable_cache = List(
+        Unicode(),
+        help="""
+        Paths to set up static files as immutable.
+
+        This allow setting up the cache control of static files as immutable.
+        It should be used for static file named with a hash for instance.
+        """,
+        config=True,
+    )
+
     _starter_app = Instance(
         default_value=None,
         allow_none=True,
@@ -1989,6 +2000,9 @@ class ServerApp(JupyterApp):
             "get_secure_cookie_kwargs"
         ] = self.identity_provider.get_secure_cookie_kwargs
         self.tornado_settings["token"] = self.identity_provider.token
+
+        if self.static_immutable_cache:
+            self.tornado_settings["static_immutable_cache"] = self.static_immutable_cache
 
         # ensure default_url starts with base_url
         if not self.default_url.startswith(self.base_url):

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -561,3 +561,13 @@ def test_deprecated_notebook_dir_priority(jp_configurable_serverapp, tmp_path):
     cfg.ServerApp.notebook_dir = str(notebook_dir)
     app.update_config(cfg)
     assert app.root_dir == str(cli_dir)
+
+
+def test_immutable_cache_trait():
+    # Verify we're working with a clean instance.
+    ServerApp.clear_instance()
+    kwargs = {"static_immutable_cache": "/test/immutable"}
+    serverapp = ServerApp.instance(**kwargs)
+    serverapp.init_configurables()
+    serverapp.init_webapp()
+    assert serverapp.web_app.settings["static_immutable_cache"] == ["/test/immutable"]


### PR DESCRIPTION
As mentioned in https://github.com/jupyterlab/jupyterlab/issues/10273 and https://github.com/jupyterlab/jupyterlab/issues/14124, JupyterLab now uses hashes for the javascript assets.

This PR allows to serve static files as immutable to avoid server requests (when the static files have `no-cache` header), by setting up the setting _"static_immutable_cache"_.

*Additional context:*
Discussed in weekly meeting https://github.com/jupyter-server/team-compass/issues/45#issuecomment-1525993398