### PR TITLE
Use Python 3.9 for the readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3.9
+    python: "3.9"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,11 @@
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3.9
 sphinx:
   configuration: docs/source/conf.py
 python:
-  version: 3.9
   install:
     # install itself with pip install .
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 python:
-  version: 3.8
+  version: 3.9
   install:
     # install itself with pip install .
     - method: pip


### PR DESCRIPTION
Version 2.0 of urllib3 was just released which fails if used against any version of python built against a version of the OpenSSL library older than 1.1.1 (see discussion [here](https://github.com/urllib3/urllib3/issues/2168))

That seems to include all versions of Python older than 3.9.

That change triggers the read the docs builds to fail when running sphinx with a message of the form:

```
Running Sphinx v6.2.1

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-server/envs/1267/lib/python3.8/site-packages/sphinx/registry.py", line 442, in load_extension
    mod = import_module(extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-server/envs/1267/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-server/envs/1267/lib/python3.8/site-packages/sphinx/builders/linkcheck.py", line 20, in <module>
    from requests import Response
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-server/envs/1267/lib/python3.8/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/docs/checkouts/readthedocs.org/user_builds/jupyter-server/envs/1267/lib/python3.8/site-packages/urllib3/__init__.py", line 38, in <module>
    raise ImportError(
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168
```

This change attempts to fix that by upgrading the Python version used for the read the docs build from 3.8 to 3.9