### PR TITLE
Write server list to stdout

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -677,20 +677,19 @@ class JupyterServerListApp(JupyterApp):
 
     def start(self):
         """Start the server list application."""
-        info = self.log.info
         serverinfo_list = list(list_running_servers(self.runtime_dir, log=self.log))
         if self.jsonlist:
-            info(json.dumps(serverinfo_list, indent=2))
+            print(json.dumps(serverinfo_list, indent=2))
         elif self.json:
             for serverinfo in serverinfo_list:
-                info(json.dumps(serverinfo))
+                print(json.dumps(serverinfo))
         else:
-            info("Currently running servers:")
+            print("Currently running servers:")
             for serverinfo in serverinfo_list:
                 url = serverinfo["url"]
                 if serverinfo.get("token"):
                     url = url + "?token=%s" % serverinfo["token"]
-                info("%s :: %s", url, serverinfo["root_dir"])
+                print(url, "::", serverinfo["root_dir"])
 
 
 # -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,8 @@ unfixable = [
 # S108 Probable insecure usage of temporary file or directory
 # PLC1901 `ext_pkg.version == ""` can be simplified to `not ext_pkg.version` as an empty string is falsey
 "tests/*" = ["B011", "F841", "C408", "E402", "T201", "EM101", "EM102", "EM103", "PLR2004", "S108", "PLC1901"]
+# print should be used in applications
+"**/*app.py" = ["T201"]
 # Ignore flake 8 errors from shimmed imports
 "jupyter_server/base/zmqhandlers.py" = ["F401"]
 # PLR2004 Magic value used in comparison

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -1,7 +1,9 @@
 import getpass
+import json
 import logging
 import os
 import pathlib
+import sys
 import warnings
 from unittest.mock import patch
 
@@ -14,6 +16,7 @@ from traitlets.tests.utils import check_help_all_output
 from jupyter_server.auth.security import passwd_check
 from jupyter_server.serverapp import (
     JupyterPasswordApp,
+    JupyterServerListApp,
     ServerApp,
     ServerWebApplication,
     list_running_servers,
@@ -34,6 +37,49 @@ def jp_file_contents_manager_class(request, tmp_path):
 def test_help_output():
     """jupyter server --help-all works"""
     check_help_all_output("jupyter_server")
+
+
+@pytest.mark.parametrize(
+    "format",
+    [
+        "json",
+        "jsonlist",
+        "",
+    ],
+)
+def test_server_list(jp_configurable_serverapp, capsys, format):
+    app = jp_configurable_serverapp(log=logging.getLogger())
+
+    app.write_server_info_file()
+
+    capsys.readouterr()
+    listapp = JupyterServerListApp(
+        parent=app,
+    )
+    if format:
+        setattr(listapp, format, True)
+    listapp.start()
+    captured = capsys.readouterr()
+    sys.stdout.write(captured.out)
+    sys.stderr.write(captured.err)
+    out = captured.out.strip()
+
+    if not format:
+        assert "Currently running servers:" in out
+        assert app.connection_url in out
+        assert len(out.splitlines()) == 2
+        return
+
+    if format == "jsonlist":
+        servers = json.loads(out)
+    elif format == "json":
+        servers = [json.loads(line) for line in out.splitlines()]
+    assert len(servers) == 1
+    sinfo = servers[0]
+
+    assert sinfo["port"] == app.port
+    assert sinfo["url"] == app.connection_url
+    assert sinfo["version"] == app.version
 
 
 def test_server_info_file(tmp_path, jp_configurable_serverapp):


### PR DESCRIPTION
instead of logging, which goes to stderr and is often prefixed and/or filtered by log levels

regression introduced in #1114 because the linter gave some bad advice.

I added an ignore for the print lint in app files, since print's the right way to produce output on stdout in general, not logging. I'd probably choose disabling it globally, but didn't want to go that far here.

closes #1273