### PR TITLE
Don't instantiate an unused Future in gateway connection trait

### DIFF
--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -24,7 +24,7 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
 
     ws = Instance(klass=tornado_websocket.WebSocketClientConnection, allow_none=True)
 
-    ws_future = Instance(default_value=Future(), klass=Future)
+    ws_future = Instance(klass=Future, allow_none=True)
 
     disconnected = Bool(False)
 


### PR DESCRIPTION
instantiating Future at import will often not work because no event loop is running