### PR TITLE
Fix DeprecationWarning from pytest-console-scripts

### DIFF
--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -6,9 +6,11 @@ pytestmark = pytest.mark.script_launch_mode("subprocess")
 
 def test_server_extension_list(jp_environ, script_runner):
     ret = script_runner.run(
-        "jupyter",
-        "server",
-        "extension",
-        "list",
+        [
+            "jupyter",
+            "server",
+            "extension",
+            "list",
+        ]
     )
     assert ret.success


### PR DESCRIPTION
DeprecationWarning: script_runner commands should be passed as a single sequence, not as multiple arguments.
Replace `script_runner.run(a, b, c)` calls with
`script_runner.run([a, b, c])`