### PR TITLE
Reference current_user to detect auth

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -771,7 +771,7 @@ class APIHandler(JupyterHandler):
         # record activity of authenticated requests
         if (
             self._track_activity
-            and getattr(self, "_user_cache", None)
+            and getattr(self, "_jupyter_current_user", None)
             and self.get_argument("no_track_activity", None) is None
         ):
             self.settings["api_last_activity"] = utcnow()


### PR DESCRIPTION
Proposed fix for https://github.com/jupyter-server/jupyter_server/issues/1293

Use the newer format for checking authenticated user. `_user_cache` no longer exists, so api_last_activity is never being updated.