### PR TITLE
docs: fix broken hyperlink to Tornado

### DIFF
--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -37,7 +37,7 @@ This document describes how you can
 
 .. _ZeroMQ: https://zeromq.org/
 
-.. _Tornado: with Found to http://www.tornadoweb.org/en/stable/
+.. _Tornado: http://www.tornadoweb.org/en/stable/
 
 .. _JupyterHub: https://jupyterhub.readthedocs.io/en/latest/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,8 @@ filterwarnings = [
   "ignore:jupyter_server.base.zmqhandlers module is deprecated in Jupyter Server 2.0:DeprecationWarning",
   "ignore:datetime.utcfromtimestamp:DeprecationWarning",
   "ignore:datetime.utcnow:DeprecationWarning",
+  # from nbformat
+  "ignore:Importing ErrorTree directly from the jsonschema package:DeprecationWarning",
   # ignore pytest warnings.
   "ignore:::_pytest",
 ]


### PR DESCRIPTION
**PR Summary**:
The PR contains a simple fix to broken hyperlink pointing to Tornado. Relevant docs can be found [here](https://jupyter-server.readthedocs.io/en/latest/operators/public-server.html). As you might see, it points to:
> withfoundtohttp://www.tornadoweb.org/en/stable/