### PR TITLE
Support external kernels

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -24,6 +24,7 @@ import time
 import urllib
 import warnings
 from base64 import encodebytes
+from pathlib import Path
 
 from jupyter_client.kernelspec import KernelSpecManager
 from jupyter_client.manager import KernelManager
@@ -1638,6 +1639,13 @@ class ServerApp(JupyterApp):
         self.log.warning(_i18n("notebook_dir is deprecated, use root_dir"))
         self.root_dir = change["new"]
 
+    external_connection_dir = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help=_i18n("The directory to look at for external kernel connection files."),
+    )
+
     root_dir = Unicode(config=True, help=_i18n("The directory to use for notebooks and kernels."))
     _root_dir_set = False
 
@@ -1873,10 +1881,14 @@ class ServerApp(JupyterApp):
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,
         )
+        external_connection_dir = self.external_connection_dir
+        if external_connection_dir is None:
+            external_connection_dir = str(Path(self.runtime_dir) / "external_kernels")
         self.kernel_manager = self.kernel_manager_class(
             parent=self,
             log=self.log,
             connection_dir=self.runtime_dir,
+            external_connection_dir=external_connection_dir,
             kernel_spec_manager=self.kernel_spec_manager,
         )
         self.contents_manager = self.contents_manager_class(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1643,7 +1643,17 @@ class ServerApp(JupyterApp):
         None,
         allow_none=True,
         config=True,
-        help=_i18n("The directory to look at for external kernel connection files."),
+        help=_i18n(
+            "The directory to look at for external kernel connection files, if allow_external_kernels is True. Defaults to Jupyter runtime_dir/external_kernels."
+        ),
+    )
+
+    allow_external_kernels = Bool(
+        False,
+        config=True,
+        help=_i18n(
+            "Whether or not to allow external kernels, whose connection files are placed in external_connection_dir."
+        ),
     )
 
     root_dir = Unicode(config=True, help=_i18n("The directory to use for notebooks and kernels."))
@@ -1881,9 +1891,14 @@ class ServerApp(JupyterApp):
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,
         )
-        external_connection_dir = self.external_connection_dir
-        if external_connection_dir is None:
-            external_connection_dir = str(Path(self.runtime_dir) / "external_kernels")
+
+        if self.allow_external_kernels:
+            external_connection_dir = self.external_connection_dir
+            if external_connection_dir is None:
+                external_connection_dir = str(Path(self.runtime_dir) / "external_kernels")
+        else:
+            external_connection_dir = None
+
         self.kernel_manager = self.kernel_manager_class(
             parent=self,
             log=self.log,

--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -410,7 +410,10 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
             )
 
             # start buffering instead of closing if this was the last connection
-            if self.multi_kernel_manager._kernel_connections[self.kernel_id] == 0:
+            if (
+                self.kernel_id in self.multi_kernel_manager._kernel_connections
+                and self.multi_kernel_manager._kernel_connections[self.kernel_id] == 0
+            ):
                 self.multi_kernel_manager.start_buffering(
                     self.kernel_id, self.session_key, self.channels
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "anyio>=3.1.0",
     "argon2-cffi",
     "jinja2",
-    "jupyter_client>=7.4.4",
+    "jupyter_client@git+https://github.com/davidbrochart/jupyter_client#egg=external-kernels",
     "jupyter_core>=4.12,!=5.0.*",
     "jupyter_server_terminals",
     "nbconvert>=6.4.4",
@@ -89,6 +89,9 @@ docs = [
 
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.envs.docs]
 features = ["docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "anyio>=3.1.0",
     "argon2-cffi",
     "jinja2",
-    "jupyter_client@git+https://github.com/davidbrochart/jupyter_client#egg=external-kernels",
+    "jupyter_client>=7.4.4",
     "jupyter_core>=4.12,!=5.0.*",
     "jupyter_server_terminals",
     "nbconvert>=6.4.4",
@@ -90,9 +90,6 @@ docs = [
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.hatch.envs.docs]
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]
@@ -100,6 +97,9 @@ build = "make -C docs html SPHINXOPTS='-W'"
 api = "sphinx-apidoc -o docs/source/api -f -E jupyter_server */terminal jupyter_server/pytest_plugin.py"
 
 [tool.hatch.envs.test]
+pre-install-commands = [
+  "pip install https://github.com/davidbrochart/jupyter_client/archive/external-kernels.zip"
+]
 features = ["test"]
 [tool.hatch.envs.test.scripts]
 test = "python -m pytest -vv {args}"
@@ -112,6 +112,9 @@ dependencies = [ "mypy>=0.990" ]
 test = "mypy --install-types --non-interactive {args:.}"
 
 [tool.hatch.envs.cov]
+pre-install-commands = [
+  "pip install https://github.com/davidbrochart/jupyter_client/archive/external-kernels.zip"
+]
 features = ["test"]
 dependencies = ["coverage[toml]", "pytest-cov"]
 [tool.hatch.envs.cov.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,6 @@ build = "make -C docs html SPHINXOPTS='-W'"
 api = "sphinx-apidoc -o docs/source/api -f -E jupyter_server */terminal jupyter_server/pytest_plugin.py"
 
 [tool.hatch.envs.test]
-pre-install-commands = [
-  "pip install https://github.com/davidbrochart/jupyter_client/archive/external-kernels.zip"
-]
 features = ["test"]
 [tool.hatch.envs.test.scripts]
 test = "python -m pytest -vv {args}"
@@ -112,9 +109,6 @@ dependencies = [ "mypy>=0.990" ]
 test = "mypy --install-types --non-interactive {args:.}"
 
 [tool.hatch.envs.cov]
-pre-install-commands = [
-  "pip install https://github.com/davidbrochart/jupyter_client/archive/external-kernels.zip"
-]
 features = ["test"]
 dependencies = ["coverage[toml]", "pytest-cov"]
 [tool.hatch.envs.cov.scripts]


### PR DESCRIPTION
Needs https://github.com/jupyter/jupyter_client/pull/961.
This will make it possible for JupyterLab to connect to a kernel that it did not launch, for instance a kernel launched by Jupyter Console:

https://github.com/jupyter-server/jupyter_server/assets/4711805/1555239f-c441-4740-9e7e-376b5a9d751c
