### PR TITLE
Assert return value of `expected_http_error`

### DIFF
--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -110,6 +110,8 @@ class EventHandler(APIHandler):
             )
             self.set_status(204)
             self.finish()
+        except web.HTTPError:
+            raise
         except Exception as e:
             raise web.HTTPError(500, str(e)) from e
 

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -448,19 +448,19 @@ async def test_escape_root(jp_file_contents_manager_class, tmp_path):
 
     with pytest.raises(HTTPError) as e:
         await ensure_async(cm.get(".."))
-    expected_http_error(e, 404)
+    assert expected_http_error(e, 404)
 
     with pytest.raises(HTTPError) as e:
         await ensure_async(cm.get("foo/../../../bar"))
-    expected_http_error(e, 404)
+    assert expected_http_error(e, 404)
 
     with pytest.raises(HTTPError) as e:
         await ensure_async(cm.delete("../foo"))
-    expected_http_error(e, 404)
+    assert expected_http_error(e, 404)
 
     with pytest.raises(HTTPError) as e:
         await ensure_async(cm.rename("../foo", "../bar"))
-    expected_http_error(e, 404)
+    assert expected_http_error(e, 404)
 
     with pytest.raises(HTTPError) as e:
         await ensure_async(
@@ -473,7 +473,7 @@ async def test_escape_root(jp_file_contents_manager_class, tmp_path):
                 path="../foo",
             )
         )
-    expected_http_error(e, 404)
+    assert expected_http_error(e, 404)
 
 
 async def test_new_untitled(jp_contents_manager):

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -123,7 +123,7 @@ async def test_post_event_400(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)
 
-    expected_http_error(e, 400)
+    assert expected_http_error(e, 400)
 
 
 payload_7 = """\
@@ -152,4 +152,4 @@ async def test_post_event_500(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)
 
-    expected_http_error(e, 500)
+    assert expected_http_error(e, 500)


### PR DESCRIPTION
`expected_http_error` returns `bool | None` to be tested.
https://github.com/jupyter-server/jupyter_server/blob/c5dc0f696f376e1db5a9a0cbcebb40a0bf98875c/tests/utils.py#L24-L45