### PR TITLE
Force legacy ws subprotocol when using gateway

### DIFF
--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -32,7 +32,13 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
 
     # When opening ws connection to gateway, server already negotiated subprotocol with notebook client.
     # Same protocol must be used for client and gateway, so legacy ws subprotocol for client is enforced here.
-    kernel_ws_protocol = Unicode("")
+
+    kernel_ws_protocol = Unicode(
+        "",
+        allow_none=True,
+        config=True
+    )
+
 
     async def connect(self):
         """Connect to the socket."""

--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -12,7 +12,7 @@ from tornado.concurrent import Future
 from tornado.escape import json_decode, url_escape, utf8
 from tornado.httpclient import HTTPRequest
 from tornado.ioloop import IOLoop
-from traitlets import Bool, Instance, Int
+from traitlets import Bool, Instance, Int, Unicode
 
 from ..services.kernels.connection.base import BaseKernelWebsocketConnection
 from ..utils import url_path_join
@@ -29,6 +29,10 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
     disconnected = Bool(False)
 
     retry = Int(0)
+
+    # When opening ws connection to gateway, server already negotiated subprotocol with notebook client.
+    # Same protocol must be used for client and gateway, so legacy ws subprotocol for client is enforced here.
+    kernel_ws_protocol = Unicode("")
 
     async def connect(self):
         """Connect to the socket."""

--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -33,12 +33,7 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
     # When opening ws connection to gateway, server already negotiated subprotocol with notebook client.
     # Same protocol must be used for client and gateway, so legacy ws subprotocol for client is enforced here.
 
-    kernel_ws_protocol = Unicode(
-        "",
-        allow_none=True,
-        config=True
-    )
-
+    kernel_ws_protocol = Unicode("", allow_none=True, config=True)
 
     async def connect(self):
         """Connect to the socket."""


### PR DESCRIPTION
Fixes #1310 

Currently, ws subprotocols should be the same for notebook client and gateway since there is no serializer/deserializer between the 2 streams if subprotocols differ.

