### PR TITLE
Add root `/api/` endpoint to REST spec

### DIFF
--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -63,6 +63,22 @@ parameters:
     type: string
 
 paths:
+  /api/:
+    get:
+      summary: Get the Jupyter Server version
+      description: |
+        This endpoint returns only the Jupyter Server version.
+        It does not require any authentication.
+      responses:
+        200:
+          description: Jupyter Server version information
+          schema:
+            type: object
+            properties:
+              version:
+                type: string
+                description: The Jupyter Server version number as a string.
+
   /api/contents/{path}:
     parameters:
       - $ref: "#/parameters/path"


### PR DESCRIPTION
we've had it [since IPython 3.0](https://github.com/ipython/ipython/pull/6654), might as well mention it.