### PR TITLE
accessing API version should not count as activity

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -1016,6 +1016,8 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
 class APIVersionHandler(APIHandler):
     """An API handler for the server version."""
 
+    _track_activity = False
+
     def get(self):
         """Get the server version info."""
         # not authenticated, so give as few info as possible


### PR DESCRIPTION
reported by @rcthomas


otherwise, using `GET /api/` as a healthcheck will cause the server to never appear idle.