### PR TITLE
Add debug log statements for file path

### DIFF
--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -50,6 +50,7 @@ class FilesHandler(JupyterHandler, web.StaticFileHandler):
 
         if not cm.allow_hidden and await ensure_async(cm.is_hidden(path)):
             self.log.info("Refusing to serve hidden file, via 404 Error")
+            self.log.debug("Path requested: %r", path)
             raise web.HTTPError(404)
 
         path = path.strip("/")


### PR DESCRIPTION
Solved issue titled Log on disk path of files served when using --debug 857 
issue link :https://github.com/jupyter/notebook/issues/857
issue 857
Changes made: added   self.log.debug("Path requested: %r", path) in handlers.py in jupyter_server
Please review these changes and provide feedback. Thank you!