### PR TITLE
Add typings to commonly used APIs

### DIFF
--- a/examples/simple/simple_ext1/handlers.py
+++ b/examples/simple/simple_ext1/handlers.py
@@ -36,7 +36,7 @@ class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):
 
     def get(self, matched_part=None, *args, **kwargs):
         """Handle a get with parameters."""
-        var1 = self.get_argument("var1", default=None)
+        var1 = self.get_argument("var1", default="")
         components = [x for x in self.request.path.split("/") if x]
         self.write("<h1>Hello Simple App 1 from Handler.</h1>")
         self.write(f"<p>matched_part: {url_escape(matched_part)}</p>")

--- a/examples/simple/simple_ext2/handlers.py
+++ b/examples/simple/simple_ext2/handlers.py
@@ -9,7 +9,7 @@ class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):
 
     def get(self, matched_part=None, *args, **kwargs):
         """Get a parameterized response."""
-        var1 = self.get_argument("var1", default=None)
+        var1 = self.get_argument("var1", default="")
         components = [x for x in self.request.path.split("/") if x]
         self.write("<h1>Hello Simple App 2 from Handler.</h1>")
         self.write(f"<p>matched_part: {url_escape(matched_part)}</p>")

--- a/jupyter_server/_tz.py
+++ b/jupyter_server/_tz.py
@@ -5,6 +5,8 @@ Just UTC-awareness right now
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 from datetime import datetime, timedelta, tzinfo
 from typing import Callable
 

--- a/jupyter_server/_tz.py
+++ b/jupyter_server/_tz.py
@@ -6,6 +6,7 @@ Just UTC-awareness right now
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from datetime import datetime, timedelta, tzinfo
+from typing import Callable
 
 # constant for zero offset
 ZERO = timedelta(0)
@@ -14,11 +15,11 @@ ZERO = timedelta(0)
 class tzUTC(tzinfo):  # noqa
     """tzinfo object for UTC (zero offset)"""
 
-    def utcoffset(self, d):
+    def utcoffset(self, d: datetime | None) -> timedelta:
         """Compute utcoffset."""
         return ZERO
 
-    def dst(self, d):
+    def dst(self, d: datetime | None) -> timedelta:
         """Compute dst."""
         return ZERO
 
@@ -26,7 +27,7 @@ class tzUTC(tzinfo):  # noqa
 UTC = tzUTC()  # type:ignore[abstract]
 
 
-def utc_aware(unaware):
+def utc_aware(unaware: Callable[..., datetime]) -> Callable[..., datetime]:
     """decorator for adding UTC tzinfo to datetime's utcfoo methods"""
 
     def utc_method(*args, **kwargs):
@@ -40,7 +41,7 @@ utcfromtimestamp = utc_aware(datetime.utcfromtimestamp)
 utcnow = utc_aware(datetime.utcnow)
 
 
-def isoformat(dt):
+def isoformat(dt: datetime) -> str:
     """Return iso-formatted timestamp
 
     Like .isoformat(), but uses Z for UTC instead of +00:00

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -3,19 +3,21 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from functools import wraps
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 from tornado.log import app_log
 from tornado.web import HTTPError
 
 from .utils import HTTP_METHOD_TO_AUTH_ACTION
 
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
 
 def authorized(
-    action: Optional[Union[str, Callable]] = None,
+    action: Optional[Union[str, FuncT]] = None,
     resource: Optional[str] = None,
     message: Optional[str] = None,
-) -> Callable:
+) -> FuncT:
     """A decorator for tornado.web.RequestHandler methods
     that verifies whether the current user is authorized
     to make the following request.
@@ -73,4 +75,4 @@ def authorized(
         # no-arguments `@authorized` decorator called
         return wrapper(method)
 
-    return wrapper
+    return cast(FuncT, wrapper)

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -123,9 +123,10 @@ class LegacyLoginHandler(LoginFormHandler):
                 if new_password and getattr(self.identity_provider, "allow_password_change", False):
                     config_dir = self.settings.get("config_dir", "")
                     config_file = os.path.join(config_dir, "jupyter_server_config.json")
-                    self.identity_provider.hashed_password = self.settings[
-                        "password"
-                    ] = set_password(new_password, config_file=config_file)
+                    if hasattr(self.identity_provider, "hashed_password"):
+                        self.identity_provider.hashed_password = self.settings[
+                            "password"
+                        ] = set_password(new_password, config_file=config_file)
                     self.log.info("Wrote hashed password to %s" % config_file)
             else:
                 self.set_status(401)

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -863,9 +863,9 @@ class AuthenticatedFileHandler(JupyterHandler, web.StaticFileHandler):
 
     @web.authenticated
     @authorized
-    def get(
+    def get(  # type:ignore[override]
         self, path: str, include_body: bool = False
-    ) -> Awaitable[None]:  # type:ignore[override]
+    ) -> Awaitable[None]:
         """Get a file by path."""
         self.check_xsrf_cookie()
         if os.path.splitext(path)[1] == ".ipynb" or self.get_argument("download", None):

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -14,7 +14,8 @@ import traceback
 import types
 import warnings
 from http.client import responses
-from typing import TYPE_CHECKING, Awaitable
+from logging import Logger
+from typing import TYPE_CHECKING, Any, Awaitable, Sequence, cast
 from urllib.parse import urlparse
 
 import prometheus_client
@@ -42,7 +43,17 @@ from jupyter_server.utils import (
 )
 
 if TYPE_CHECKING:
-    from jupyter_server.auth.identity import User
+    from jupyter_client.kernelspec import KernelSpecManager
+    from jupyter_server_terminals.terminalmanager import TerminalManager
+    from tornado.concurrent import Future
+
+    from jupyter_server.auth.authorizer import Authorizer
+    from jupyter_server.auth.identity import IdentityProvider, User
+    from jupyter_server.serverapp import ServerApp
+    from jupyter_server.services.config.manager import ConfigManager
+    from jupyter_server.services.contents.manager import ContentsManager
+    from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+    from jupyter_server.services.sessions.sessionmanager import SessionManager
 
 # -----------------------------------------------------------------------------
 # Top-level handlers
@@ -59,7 +70,7 @@ def json_sys_info():
     return _sys_info_cache
 
 
-def log():
+def log() -> Logger:
     """Get the application log."""
     if Application.initialized():
         return Application.instance().log
@@ -75,7 +86,7 @@ class AuthenticatedHandler(web.RequestHandler):
         return self.settings.get("base_url", "/")
 
     @property
-    def content_security_policy(self):
+    def content_security_policy(self) -> str:
         """The default Content-Security-Policy header
 
         Can be overridden by defining Content-Security-Policy in settings['headers']
@@ -93,7 +104,7 @@ class AuthenticatedHandler(web.RequestHandler):
             ]
         )
 
-    def set_default_headers(self):
+    def set_default_headers(self) -> None:
         """Set the default headers."""
         headers = {}
         headers["X-Content-Type-Options"] = "nosniff"
@@ -114,7 +125,7 @@ class AuthenticatedHandler(web.RequestHandler):
                 )
 
     @property
-    def cookie_name(self):
+    def cookie_name(self) -> str:
         warnings.warn(
             """JupyterHandler.login_handler is deprecated in 2.0,
             use JupyterHandler.identity_provider.
@@ -124,7 +135,7 @@ class AuthenticatedHandler(web.RequestHandler):
         )
         return self.identity_provider.get_cookie_name(self)
 
-    def force_clear_cookie(self, name, path="/", domain=None):
+    def force_clear_cookie(self, name: str, path: str = "/", domain: str | None = None) -> None:
         """Force a cookie clear."""
         warnings.warn(
             """JupyterHandler.login_handler is deprecated in 2.0,
@@ -133,9 +144,9 @@ class AuthenticatedHandler(web.RequestHandler):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.identity_provider._force_clear_cookie(self, name, path=path, domain=domain)
+        self.identity_provider._force_clear_cookie(self, name, path=path, domain=domain)
 
-    def clear_login_cookie(self):
+    def clear_login_cookie(self) -> None:
         """Clear a login cookie."""
         warnings.warn(
             """JupyterHandler.login_handler is deprecated in 2.0,
@@ -144,9 +155,9 @@ class AuthenticatedHandler(web.RequestHandler):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.identity_provider.clear_login_cookie(self)
+        self.identity_provider.clear_login_cookie(self)
 
-    def get_current_user(self):
+    def get_current_user(self) -> str:
         """Get the current user."""
         clsname = self.__class__.__name__
         msg = (
@@ -164,7 +175,7 @@ class AuthenticatedHandler(web.RequestHandler):
         # haven't called get_user in prepare, raise
         raise RuntimeError(msg)
 
-    def skip_check_origin(self):
+    def skip_check_origin(self) -> bool:
         """Ask my login_handler if I should skip the origin_check
 
         For example: in the default LoginHandler, if a request is token-authenticated,
@@ -176,18 +187,18 @@ class AuthenticatedHandler(web.RequestHandler):
         return not self.identity_provider.should_check_origin(self)
 
     @property
-    def token_authenticated(self):
+    def token_authenticated(self) -> bool:
         """Have I been authenticated with a token?"""
         return self.identity_provider.is_token_authenticated(self)
 
     @property
-    def logged_in(self):
+    def logged_in(self) -> bool:
         """Is a user currently logged in?"""
         user = self.current_user
         return user and user != "anonymous"
 
     @property
-    def login_handler(self):
+    def login_handler(self) -> Any:
         """Return the login handler for this application, if any."""
         warnings.warn(
             """JupyterHandler.login_handler is deprecated in 2.0,
@@ -199,12 +210,12 @@ class AuthenticatedHandler(web.RequestHandler):
         return self.identity_provider.login_handler_class
 
     @property
-    def token(self):
+    def token(self) -> str | None:
         """Return the login token for this application, if any."""
         return self.identity_provider.token
 
     @property
-    def login_available(self):
+    def login_available(self) -> bool:
         """May a user proceed to log in?
 
         This returns True if login capability is available, irrespective of
@@ -214,7 +225,7 @@ class AuthenticatedHandler(web.RequestHandler):
         return self.identity_provider.login_available
 
     @property
-    def authorizer(self):
+    def authorizer(self) -> Authorizer:
         if "authorizer" not in self.settings:
             warnings.warn(
                 "The Tornado web application does not have an 'authorizer' defined "
@@ -234,10 +245,10 @@ class AuthenticatedHandler(web.RequestHandler):
                 identity_provider=self.identity_provider,
             )
 
-        return self.settings.get("authorizer")
+        return cast(Authorizer, self.settings.get("authorizer"))
 
     @property
-    def identity_provider(self):
+    def identity_provider(self) -> IdentityProvider:
         if "identity_provider" not in self.settings:
             warnings.warn(
                 "The Tornado web application does not have an 'identity_provider' defined "
@@ -265,21 +276,21 @@ class JupyterHandler(AuthenticatedHandler):
     """
 
     @property
-    def config(self):
+    def config(self) -> dict[str, Any] | None:
         return self.settings.get("config", None)
 
     @property
-    def log(self):
+    def log(self) -> Logger:
         """use the Jupyter log by default, falling back on tornado's logger"""
         return log()
 
     @property
-    def jinja_template_vars(self):
+    def jinja_template_vars(self) -> dict[str, Any]:
         """User-supplied values to supply to jinja templates."""
         return self.settings.get("jinja_template_vars", {})
 
     @property
-    def serverapp(self):
+    def serverapp(self) -> ServerApp | None:
         return self.settings["serverapp"]
 
     # ---------------------------------------------------------------
@@ -287,31 +298,31 @@ class JupyterHandler(AuthenticatedHandler):
     # ---------------------------------------------------------------
 
     @property
-    def version_hash(self):
+    def version_hash(self) -> str:
         """The version hash to use for cache hints for static files"""
         return self.settings.get("version_hash", "")
 
     @property
-    def mathjax_url(self):
+    def mathjax_url(self) -> str:
         url = self.settings.get("mathjax_url", "")
         if not url or url_is_absolute(url):
             return url
         return url_path_join(self.base_url, url)
 
     @property
-    def mathjax_config(self):
+    def mathjax_config(self) -> str:
         return self.settings.get("mathjax_config", "TeX-AMS-MML_HTMLorMML-full,Safe")
 
     @property
-    def default_url(self):
+    def default_url(self) -> str:
         return self.settings.get("default_url", "")
 
     @property
-    def ws_url(self):
+    def ws_url(self) -> str:
         return self.settings.get("websocket_url", "")
 
     @property
-    def contents_js_source(self):
+    def contents_js_source(self) -> str:
         self.log.debug(
             "Using contents: %s",
             self.settings.get("contents_js_source", "services/contents"),
@@ -323,27 +334,27 @@ class JupyterHandler(AuthenticatedHandler):
     # ---------------------------------------------------------------
 
     @property
-    def kernel_manager(self):
+    def kernel_manager(self) -> MappingKernelManager:
         return self.settings["kernel_manager"]
 
     @property
-    def contents_manager(self):
+    def contents_manager(self) -> ContentsManager:
         return self.settings["contents_manager"]
 
     @property
-    def session_manager(self):
+    def session_manager(self) -> SessionManager:
         return self.settings["session_manager"]
 
     @property
-    def terminal_manager(self):
+    def terminal_manager(self) -> TerminalManager:
         return self.settings["terminal_manager"]
 
     @property
-    def kernel_spec_manager(self):
+    def kernel_spec_manager(self) -> KernelSpecManager:
         return self.settings["kernel_spec_manager"]
 
     @property
-    def config_manager(self):
+    def config_manager(self) -> ConfigManager:
         return self.settings["config_manager"]
 
     @property
@@ -355,25 +366,25 @@ class JupyterHandler(AuthenticatedHandler):
     # ---------------------------------------------------------------
 
     @property
-    def allow_origin(self):
+    def allow_origin(self) -> str:
         """Normal Access-Control-Allow-Origin"""
         return self.settings.get("allow_origin", "")
 
     @property
-    def allow_origin_pat(self):
+    def allow_origin_pat(self) -> str:
         """Regular expression version of allow_origin"""
         return self.settings.get("allow_origin_pat", None)
 
     @property
-    def allow_credentials(self):
+    def allow_credentials(self) -> bool:
         """Whether to set Access-Control-Allow-Credentials"""
         return self.settings.get("allow_credentials", False)
 
-    def set_default_headers(self):
+    def set_default_headers(self) -> None:
         """Add CORS headers, if defined"""
         super().set_default_headers()
 
-    def set_cors_headers(self):
+    def set_cors_headers(self) -> None:
         """Add CORS headers, if defined
 
         Now that current_user is async (jupyter-server 2.0),
@@ -395,7 +406,7 @@ class JupyterHandler(AuthenticatedHandler):
         if self.allow_credentials:
             self.set_header("Access-Control-Allow-Credentials", "true")
 
-    def set_attachment_header(self, filename):
+    def set_attachment_header(self, filename: str) -> None:
         """Set Content-Disposition: attachment header
 
         As a method to ensure handling of filename encoding
@@ -406,7 +417,7 @@ class JupyterHandler(AuthenticatedHandler):
             f"attachment; filename*=utf-8''{escaped_filename}",
         )
 
-    def get_origin(self):
+    def get_origin(self) -> str | None:
         # Handle WebSocket Origin naming convention differences
         # The difference between version 8 and 13 is that in 8 the
         # client sends a "Sec-Websocket-Origin" header and in 13 it's
@@ -419,7 +430,7 @@ class JupyterHandler(AuthenticatedHandler):
 
     # origin_to_satisfy_tornado is present because tornado requires
     # check_origin to take an origin argument, but we don't use it
-    def check_origin(self, origin_to_satisfy_tornado=""):
+    def check_origin(self, origin_to_satisfy_tornado: str = "") -> bool:
         """Check Origin for cross-site API requests, including websockets
 
         Copied from WebSocket with changes:
@@ -466,7 +477,7 @@ class JupyterHandler(AuthenticatedHandler):
             )
         return allow
 
-    def check_referer(self):
+    def check_referer(self) -> bool:
         """Check Referer for cross-site requests.
         Disables requests to certain endpoints with
         external or missing Referer.
@@ -512,7 +523,7 @@ class JupyterHandler(AuthenticatedHandler):
             )
         return allow
 
-    def check_xsrf_cookie(self):
+    def check_xsrf_cookie(self) -> None:
         """Bypass xsrf cookie checks when token-authenticated"""
         if not hasattr(self, "_jupyter_current_user"):
             # Called too early, will be checked later
@@ -536,7 +547,7 @@ class JupyterHandler(AuthenticatedHandler):
             else:
                 raise
 
-    def check_host(self):
+    def check_host(self) -> bool:
         """Check the host header if remote access disallowed.
 
         Returns True if the request should continue, False otherwise.
@@ -578,7 +589,7 @@ class JupyterHandler(AuthenticatedHandler):
             )
         return allow
 
-    async def prepare(self):
+    async def prepare(self) -> None:
         """Prepare a response."""
         # Set the current Jupyter Handler context variable.
         CallContext.set(CallContext.JUPYTER_HANDLER, self)
@@ -603,7 +614,7 @@ class JupyterHandler(AuthenticatedHandler):
                 DeprecationWarning
                 # stacklevel not useful here
             )
-            user = self.get_current_user()
+            user = User(self.get_current_user())
         else:
             _user = self.identity_provider.get_user(self)
             if isinstance(_user, Awaitable):
@@ -619,7 +630,9 @@ class JupyterHandler(AuthenticatedHandler):
         self.set_cors_headers()
         if self.request.method not in {"GET", "HEAD", "OPTIONS"}:
             self.check_xsrf_cookie()
-        return super().prepare()
+        prep = super().prepare()
+        if isinstance(prep, Awaitable):
+            await prep
 
     # ---------------------------------------------------------------
     # template rendering
@@ -636,7 +649,7 @@ class JupyterHandler(AuthenticatedHandler):
         return template.render(**ns)
 
     @property
-    def template_namespace(self):
+    def template_namespace(self) -> dict[str, Any]:
         return dict(
             base_url=self.base_url,
             default_url=self.default_url,
@@ -659,7 +672,7 @@ class JupyterHandler(AuthenticatedHandler):
             **self.jinja_template_vars,
         )
 
-    def get_json_body(self):
+    def get_json_body(self) -> dict[str, Any] | None:
         """Return the body of the request as JSON data."""
         if not self.request.body:
             return None
@@ -673,7 +686,7 @@ class JupyterHandler(AuthenticatedHandler):
             raise web.HTTPError(400, "Invalid JSON in body of request") from e
         return model
 
-    def write_error(self, status_code, **kwargs):
+    def write_error(self, status_code: int, **kwargs: Any) -> None:
         """render custom error pages"""
         exc_info = kwargs.get("exc_info")
         message = ""
@@ -715,13 +728,13 @@ class JupyterHandler(AuthenticatedHandler):
 class APIHandler(JupyterHandler):
     """Base class for API handlers"""
 
-    async def prepare(self):
+    async def prepare(self) -> None:
         """Prepare an API response."""
         await super().prepare()
         if not self.check_origin():
             raise web.HTTPError(404)
 
-    def write_error(self, status_code, **kwargs):
+    def write_error(self, status_code: int, **kwargs: Any) -> None:
         """APIHandler errors are JSON, not human pages"""
         self.set_header("Content-Type", "application/json")
         message = responses.get(status_code, "Unknown HTTP Error")
@@ -741,7 +754,7 @@ class APIHandler(JupyterHandler):
         self.log.warning("wrote error: %r", reply["message"], exc_info=True)
         self.finish(json.dumps(reply))
 
-    def get_login_url(self):
+    def get_login_url(self) -> str:
         """Get the login url."""
         # if get_login_url is invoked in an API handler,
         # that means @web.authenticated is trying to trigger a redirect.
@@ -751,7 +764,7 @@ class APIHandler(JupyterHandler):
         return super().get_login_url()
 
     @property
-    def content_security_policy(self):
+    def content_security_policy(self) -> str:
         csp = "; ".join(
             [
                 super().content_security_policy,
@@ -763,7 +776,7 @@ class APIHandler(JupyterHandler):
     # set _track_activity = False on API handlers that shouldn't track activity
     _track_activity = True
 
-    def update_api_activity(self):
+    def update_api_activity(self) -> None:
         """Update last_activity of API requests"""
         # record activity of authenticated requests
         if (
@@ -773,7 +786,7 @@ class APIHandler(JupyterHandler):
         ):
             self.settings["api_last_activity"] = utcnow()
 
-    def finish(self, *args, **kwargs):
+    def finish(self, *args: Any, **kwargs: Any) -> Future[Any]:
         """Finish an API response."""
         self.update_api_activity()
         # Allow caller to indicate content-type...
@@ -781,7 +794,7 @@ class APIHandler(JupyterHandler):
         self.set_header("Content-Type", set_content_type)
         return super().finish(*args, **kwargs)
 
-    def options(self, *args, **kwargs):
+    def options(self, *args: Any, **kwargs: Any) -> None:
         """Get the options."""
         if "Access-Control-Allow-Headers" in self.settings.get("headers", {}):
             self.set_header(
@@ -824,7 +837,7 @@ class APIHandler(JupyterHandler):
 class Template404(JupyterHandler):
     """Render our 404 template"""
 
-    async def prepare(self):
+    async def prepare(self) -> None:
         """Prepare a 404 response."""
         await super().prepare()
         raise web.HTTPError(404)
@@ -836,30 +849,32 @@ class AuthenticatedFileHandler(JupyterHandler, web.StaticFileHandler):
     auth_resource = "contents"
 
     @property
-    def content_security_policy(self):
+    def content_security_policy(self) -> str:
         # In case we're serving HTML/SVG, confine any Javascript to a unique
         # origin so it can't interact with the Jupyter server.
         return super().content_security_policy + "; sandbox allow-scripts"
 
     @web.authenticated
     @authorized
-    def head(self, path):
+    def head(self, path: str) -> Awaitable[None]:  # type:ignore[override]
         """Get the head response for a path."""
         self.check_xsrf_cookie()
         return super().head(path)
 
     @web.authenticated
     @authorized
-    def get(self, path, **kwargs):
+    def get(
+        self, path: str, include_body: bool = False
+    ) -> Awaitable[None]:  # type:ignore[override]
         """Get a file by path."""
         self.check_xsrf_cookie()
         if os.path.splitext(path)[1] == ".ipynb" or self.get_argument("download", None):
             name = path.rsplit("/", 1)[-1]
             self.set_attachment_header(name)
 
-        return web.StaticFileHandler.get(self, path, **kwargs)
+        return web.StaticFileHandler.get(self, path, include_body=include_body)
 
-    def get_content_type(self):
+    def get_content_type(self) -> str:
         """Get the content type."""
         assert self.absolute_path is not None
         path = self.absolute_path.strip("/")
@@ -876,18 +891,18 @@ class AuthenticatedFileHandler(JupyterHandler, web.StaticFileHandler):
             else:
                 return super().get_content_type()
 
-    def set_headers(self):
+    def set_headers(self) -> None:
         """Set the headers."""
         super().set_headers()
         # disable browser caching, rely on 304 replies for savings
         if "v" not in self.request.arguments:
             self.add_header("Cache-Control", "no-cache")
 
-    def compute_etag(self):
+    def compute_etag(self) -> str | None:
         """Compute the etag."""
         return None
 
-    def validate_absolute_path(self, root, absolute_path):
+    def validate_absolute_path(self, root: str, absolute_path: str) -> str:
         """Validate and return the absolute path.
 
         Requires tornado 3.1
@@ -905,7 +920,7 @@ class AuthenticatedFileHandler(JupyterHandler, web.StaticFileHandler):
         return abs_path
 
 
-def json_errors(method):  # pragma: no cover
+def json_errors(method: Any) -> Any:  # pragma: no cover
     """Decorate methods with this to return GitHub style JSON errors.
 
     This should be used on any JSON API on any handler method that can raise HTTPErrors.
@@ -949,10 +964,10 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
     """
 
     # cache search results, don't search for files more than once
-    _static_paths: dict = {}
-    root: tuple  # type:ignore[assignment]
+    _static_paths: dict[str, Any] = {}
+    root: tuple[str]  # type:ignore[assignment]
 
-    def set_headers(self):
+    def set_headers(self) -> None:
         """Set the headers."""
         super().set_headers()
 
@@ -968,22 +983,29 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
         ):
             self.set_header("Cache-Control", "no-cache")
 
-    def initialize(self, path, default_filename=None, no_cache_paths=None):
+    def initialize(
+        self,
+        path: str | list[str],
+        default_filename: str | None = None,
+        no_cache_paths: list[str] | None = None,
+    ) -> None:
         """Initialize the file find handler."""
         self.no_cache_paths = no_cache_paths or []
 
         if isinstance(path, str):
             path = [path]
 
-        self.root = tuple(os.path.abspath(os.path.expanduser(p)) + os.sep for p in path)
+        self.root = tuple(
+            os.path.abspath(os.path.expanduser(p)) + os.sep for p in path
+        )  # type:ignore[assignment]
         self.default_filename = default_filename
 
-    def compute_etag(self):
+    def compute_etag(self) -> str | None:
         """Compute the etag."""
         return None
 
     @classmethod
-    def get_absolute_path(cls, roots, path):
+    def get_absolute_path(cls, roots: Sequence[str], path: str) -> str:
         """locate a file to serve on our static file search path"""
         with cls._lock:
             if path in cls._static_paths:
@@ -999,7 +1021,7 @@ class FileFindHandler(JupyterHandler, web.StaticFileHandler):
             log().debug(f"Path {path} served from {abspath}")
             return abspath
 
-    def validate_absolute_path(self, root, absolute_path):
+    def validate_absolute_path(self, root: str, absolute_path: str) -> str | None:
         """check if the file should be served (raises 404, 403, etc.)"""
         if not absolute_path:
             raise web.HTTPError(404)
@@ -1016,7 +1038,7 @@ class APIVersionHandler(APIHandler):
 
     _track_activity = False
 
-    def get(self):
+    def get(self) -> None:
         """Get the server version info."""
         # not authenticated, so give as few info as possible
         self.finish(json.dumps({"version": jupyter_server.__version__}))
@@ -1028,7 +1050,7 @@ class TrailingSlashHandler(web.RequestHandler):
     This should be the first, highest priority handler.
     """
 
-    def get(self):
+    def get(self) -> None:
         """Handle trailing slashes in a get."""
         assert self.request.uri is not None
         path, *rest = self.request.uri.partition("?")
@@ -1044,7 +1066,7 @@ class TrailingSlashHandler(web.RequestHandler):
 class MainHandler(JupyterHandler):
     """Simple handler for base_url."""
 
-    def get(self):
+    def get(self) -> None:
         """Get the main template."""
         html = self.render_template("main.html")
         self.write(html)
@@ -1056,7 +1078,7 @@ class FilesRedirectHandler(JupyterHandler):
     """Handler for redirecting relative URLs to the /files/ handler"""
 
     @staticmethod
-    async def redirect_to_files(self, path):
+    async def redirect_to_files(self: Any, path: str) -> None:
         """make redirect logic a reusable static method
 
         so it can be called from other handlers.
@@ -1084,19 +1106,19 @@ class FilesRedirectHandler(JupyterHandler):
         self.log.debug("Redirecting %s to %s", self.request.path, url)
         self.redirect(url)
 
-    def get(self, path=""):
+    def get(self, path: str = "") -> Awaitable:
         return self.redirect_to_files(self, path)
 
 
 class RedirectWithParams(web.RequestHandler):
     """Sam as web.RedirectHandler, but preserves URL parameters"""
 
-    def initialize(self, url, permanent=True):
+    def initialize(self, url: str, permanent: bool = True) -> None:
         """Initialize a redirect handler."""
         self._url = url
         self._permanent = permanent
 
-    def get(self):
+    def get(self) -> None:
         """Get a redirect."""
         sep = "&" if "?" in self._url else "?"
         url = sep.join([self._url, self.request.query])
@@ -1108,7 +1130,7 @@ class PrometheusMetricsHandler(JupyterHandler):
     Return prometheus metrics for this server
     """
 
-    def get(self):
+    def get(self) -> None:
         """Get prometheus metrics."""
         if self.settings["authenticate_prometheus"] and not self.logged_in:
             raise web.HTTPError(403)

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -245,7 +245,7 @@ class AuthenticatedHandler(web.RequestHandler):
                 identity_provider=self.identity_provider,
             )
 
-        return cast(Authorizer, self.settings.get("authorizer"))
+        return cast("Authorizer", self.settings.get("authorizer"))
 
     @property
     def identity_provider(self) -> IdentityProvider:

--- a/jupyter_server/config_manager.py
+++ b/jupyter_server/config_manager.py
@@ -1,17 +1,22 @@
 """Manager to read and modify config data in JSON files."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 import copy
 import errno
 import glob
 import json
 import os
+import typing as t
 
 from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import Bool, Unicode
 
+StrDict = t.Dict[str, t.Any]
 
-def recursive_update(target, new):
+
+def recursive_update(target: StrDict, new: StrDict) -> None:
     """Recursively update one dictionary using another.
 
     None values will delete their keys.
@@ -32,7 +37,7 @@ def recursive_update(target, new):
             target[k] = v
 
 
-def remove_defaults(data, defaults):
+def remove_defaults(data: StrDict, defaults: StrDict) -> None:
     """Recursively remove items from dict that are already in defaults"""
     # copy the iterator, since data will be modified
     for key, value in list(data.items()):
@@ -55,7 +60,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
     config_dir = Unicode(".")
     read_directory = Bool(True)
 
-    def ensure_config_dir_exists(self):
+    def ensure_config_dir_exists(self) -> None:
         """Will try to create the config_dir directory."""
         try:
             os.makedirs(self.config_dir, 0o755)
@@ -63,15 +68,15 @@ class BaseJSONConfigManager(LoggingConfigurable):
             if e.errno != errno.EEXIST:
                 raise
 
-    def file_name(self, section_name):
+    def file_name(self, section_name: str) -> str:
         """Returns the json filename for the section_name: {config_dir}/{section_name}.json"""
         return os.path.join(self.config_dir, section_name + ".json")
 
-    def directory(self, section_name):
+    def directory(self, section_name: str) -> str:
         """Returns the directory name for the section name: {config_dir}/{section_name}.d"""
         return os.path.join(self.config_dir, section_name + ".d")
 
-    def get(self, section_name, include_root=True):
+    def get(self, section_name: str, include_root: bool = True) -> t.Any:
         """Retrieve the config data for the specified section.
 
         Returns the data as a dictionary, or an empty dictionary if the file
@@ -101,7 +106,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
                     recursive_update(data, json.load(f))
         return data
 
-    def set(self, section_name, data):
+    def set(self, section_name: str, data: t.Any) -> None:
         """Store the given config data."""
         filename = self.file_name(section_name)
         self.ensure_config_dir_exists()
@@ -118,7 +123,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
         with open(filename, "w", encoding="utf-8") as f:
             f.write(json_content)
 
-    def update(self, section_name, new_data):
+    def update(self, section_name: str, new_data: t.Any) -> None:
         """Modify the config section by recursively updating it with new_data.
 
         Returns the modified config data as a dictionary.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -550,7 +550,7 @@ class ExtensionApp(JupyterApp):
     serverapp_class = ServerApp
 
     @classmethod
-    def make_serverapp(cls, **kwargs):
+    def make_serverapp(cls, **kwargs: t.Any) -> ServerApp:
         """Instantiate the ServerApp
 
         Override to customize the ServerApp before it loads any configuration
@@ -573,7 +573,7 @@ class ExtensionApp(JupyterApp):
             cls.serverapp_config["jpserver_extensions"] = jpserver_extensions
             find_extensions = False
         serverapp = cls.make_serverapp(jpserver_extensions=jpserver_extensions, **kwargs)
-        serverapp.aliases.update(cls.aliases)
+        serverapp.aliases.update(cls.aliases)  # type:ignore[has-type]
         serverapp.initialize(
             argv=argv or [],
             starter_extension=cls.name,

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,9 +1,19 @@
 """An extension handler."""
-from typing import no_type_check
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from jinja2.exceptions import TemplateNotFound
 
 from jupyter_server.base.handlers import FileFindHandler
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from traitlets.config import Config
+
+    from jupyter_server.extension.application import ExtensionApp
+    from jupyter_server.serverapp import ServerApp
 
 
 class ExtensionHandlerJinjaMixin:
@@ -11,14 +21,13 @@ class ExtensionHandlerJinjaMixin:
     template rendering.
     """
 
-    @no_type_check
-    def get_template(self, name):
+    def get_template(self, name: str) -> str:
         """Return the jinja template object for a given name"""
         try:
-            env = f"{self.name}_jinja2_env"
-            return self.settings[env].get_template(name)
+            env = f"{self.name}_jinja2_env"  # type:ignore[attr-defined]
+            return self.settings[env].get_template(name)  # type:ignore[attr-defined]
         except TemplateNotFound:
-            return super().get_template(name)
+            return super().get_template(name)  # type:ignore[misc]
 
 
 class ExtensionHandlerMixin:
@@ -32,7 +41,7 @@ class ExtensionHandlerMixin:
     other extensions.
     """
 
-    def initialize(self, name, *args, **kwargs):
+    def initialize(self, name: str, *args: Any, **kwargs: Any) -> None:
         self.name = name
         try:
             super().initialize(*args, **kwargs)  # type:ignore[misc]
@@ -40,16 +49,16 @@ class ExtensionHandlerMixin:
             pass
 
     @property
-    def extensionapp(self):
+    def extensionapp(self) -> ExtensionApp:
         return self.settings[self.name]  # type:ignore[attr-defined]
 
     @property
-    def serverapp(self):
+    def serverapp(self) -> ServerApp:
         key = "serverapp"
         return self.settings[key]  # type:ignore[attr-defined]
 
     @property
-    def log(self):
+    def log(self) -> Logger:
         if not hasattr(self, "name"):
             return super().log  # type:ignore[misc]
         # Attempt to pull the ExtensionApp's log, otherwise fall back to ServerApp.
@@ -59,11 +68,11 @@ class ExtensionHandlerMixin:
             return self.serverapp.log
 
     @property
-    def config(self):
+    def config(self) -> Config:
         return self.settings[f"{self.name}_config"]  # type:ignore[attr-defined]
 
     @property
-    def server_config(self):
+    def server_config(self) -> Config:
         return self.settings["config"]  # type:ignore[attr-defined]
 
     @property
@@ -71,14 +80,14 @@ class ExtensionHandlerMixin:
         return self.settings.get("base_url", "/")  # type:ignore[attr-defined]
 
     @property
-    def static_url_prefix(self):
+    def static_url_prefix(self) -> str:
         return self.extensionapp.static_url_prefix
 
     @property
-    def static_path(self):
+    def static_path(self) -> str:
         return self.settings[f"{self.name}_static_paths"]  # type:ignore[attr-defined]
 
-    def static_url(self, path, include_host=None, **kwargs):
+    def static_url(self, path: str, include_host: bool | None = None, **kwargs: Any) -> str:
         """Returns a static URL for the given relative static file path.
         This method requires you set the ``{name}_static_path``
         setting in your extension (which specifies the root directory

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -1,9 +1,12 @@
 """Utilities for installing extensions"""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 import logging
 import os
 import sys
+import typing as t
 
 from jupyter_core.application import JupyterApp
 from jupyter_core.paths import ENV_CONFIG_PATH, SYSTEM_CONFIG_PATH, jupyter_config_dir
@@ -15,7 +18,7 @@ from jupyter_server.extension.config import ExtensionConfigManager
 from jupyter_server.extension.manager import ExtensionManager, ExtensionPackage
 
 
-def _get_config_dir(user=False, sys_prefix=False):
+def _get_config_dir(user: bool = False, sys_prefix: bool = False) -> str:
     """Get the location of config files for the current context
 
     Returns the string to the environment
@@ -38,7 +41,9 @@ def _get_config_dir(user=False, sys_prefix=False):
     return extdir
 
 
-def _get_extmanager_for_context(write_dir="jupyter_server_config.d", user=False, sys_prefix=False):
+def _get_extmanager_for_context(
+    write_dir: str = "jupyter_server_config.d", user: bool = False, sys_prefix: bool = False
+) -> tuple[str, ExtensionManager]:
     """Get an extension manager pointing at the current context
 
     Returns the path to the current context and an ExtensionManager object.
@@ -67,8 +72,8 @@ class ArgumentConflict(ValueError):
     pass
 
 
-_base_flags = {}
-_base_flags.update(JupyterApp.flags)
+_base_flags: dict[str, t.Any] = {}
+_base_flags.update(JupyterApp.flags)  # type:ignore[has-type]
 _base_flags.pop("y", None)
 _base_flags.pop("generate-config", None)
 _base_flags.update(
@@ -110,28 +115,28 @@ _base_flags.update(
 )
 _base_flags["python"] = _base_flags["py"]
 
-_base_aliases = {}
-_base_aliases.update(JupyterApp.aliases)
+_base_aliases: dict[str, t.Any] = {}
+_base_aliases.update(JupyterApp.aliases)  # type:ignore[has-type]
 
 
 class BaseExtensionApp(JupyterApp):
     """Base extension installer app"""
 
     _log_formatter_cls = LogFormatter  # type:ignore[assignment]
-    flags = _base_flags
-    aliases = _base_aliases
+    flags = _base_flags  # type:ignore[assignment]
+    aliases = _base_aliases  # type:ignore[assignment]
     version = __version__
 
     user = Bool(False, config=True, help="Whether to do a user install")
     sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
     python = Bool(False, config=True, help="Install from a Python package")
 
-    def _log_format_default(self):
+    def _log_format_default(self) -> str:
         """A default format for messages"""
         return "%(message)s"
 
     @property
-    def config_dir(self):
+    def config_dir(self) -> str:  # type:ignore[override]
         return _get_config_dir(user=self.user, sys_prefix=self.sys_prefix)
 
 
@@ -148,8 +153,12 @@ RED_X = "\033[31m X\033[0m" if os.name != "nt" else " X"
 
 
 def toggle_server_extension_python(
-    import_name, enabled=None, parent=None, user=False, sys_prefix=True
-):
+    import_name: str,
+    enabled: bool | None = None,
+    parent: t.Any = None,
+    user: bool = False,
+    sys_prefix: bool = True,
+) -> None:
     """Toggle the boolean setting for a given server extension
     in a Jupyter config file.
     """
@@ -170,7 +179,7 @@ def toggle_server_extension_python(
 # ----------------------------------------------------------------------
 
 flags = {}
-flags.update(BaseExtensionApp.flags)
+flags.update(BaseExtensionApp.flags)  # type:ignore[has-type]
 flags.pop("y", None)
 flags.pop("generate-config", None)
 flags.update(
@@ -228,7 +237,7 @@ class ToggleServerExtensionApp(BaseExtensionApp):
     _toggle_pre_message = ""
     _toggle_post_message = ""
 
-    def toggle_server_extension(self, import_name):
+    def toggle_server_extension(self, import_name: str) -> None:
         """Change the status of a named server extension.
 
         Uses the value of `self._toggle_value`.
@@ -257,17 +266,18 @@ class ToggleServerExtensionApp(BaseExtensionApp):
 
             # Toggle extension config.
             config = extension_manager.config_manager
-            if self._toggle_value is True:
-                config.enable(import_name)
-            else:
-                config.disable(import_name)
+            if config:
+                if self._toggle_value is True:
+                    config.enable(import_name)
+                else:
+                    config.disable(import_name)
 
             # If successful, let's log.
             self.log.info(f"    - Extension successfully {self._toggle_post_message}.")
         except Exception as err:
             self.log.info(f"     {RED_X} Validation failed: {err}")
 
-    def start(self):
+    def start(self) -> None:
         """Perform the App's actions as configured"""
         if not self.extra_args:
             sys.exit("Please specify a server extension/package to enable or disable")
@@ -312,7 +322,7 @@ class ListServerExtensionsApp(BaseExtensionApp):
     version = __version__
     description = "List all server extensions known by the configuration system"
 
-    def list_server_extensions(self):
+    def list_server_extensions(self) -> None:
         """List all enabled and disabled server extensions, by config path
 
         Enabled extensions are validated, potentially generating warnings.
@@ -351,7 +361,7 @@ class ListServerExtensionsApp(BaseExtensionApp):
             # Add a blank line between paths.
             self.log.info("")
 
-    def start(self):
+    def start(self) -> None:
         """Perform the App's actions as configured"""
         self.list_server_extensions()
 
@@ -377,7 +387,7 @@ class ServerExtensionApp(BaseExtensionApp):
         "list": (ListServerExtensionsApp, "List server extensions"),
     }
 
-    def start(self):
+    def start(self) -> None:
         """Perform the App's actions as configured"""
         super().start()
 

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -73,7 +73,7 @@ class ArgumentConflict(ValueError):
 
 
 _base_flags: dict[str, t.Any] = {}
-_base_flags.update(JupyterApp.flags)  # type:ignore[has-type]
+_base_flags.update(JupyterApp.flags)
 _base_flags.pop("y", None)
 _base_flags.pop("generate-config", None)
 _base_flags.update(
@@ -116,15 +116,15 @@ _base_flags.update(
 _base_flags["python"] = _base_flags["py"]
 
 _base_aliases: dict[str, t.Any] = {}
-_base_aliases.update(JupyterApp.aliases)  # type:ignore[has-type]
+_base_aliases.update(JupyterApp.aliases)
 
 
 class BaseExtensionApp(JupyterApp):
     """Base extension installer app"""
 
     _log_formatter_cls = LogFormatter  # type:ignore[assignment]
-    flags = _base_flags  # type:ignore[assignment]
-    aliases = _base_aliases  # type:ignore[assignment]
+    flags = _base_flags
+    aliases = _base_aliases
     version = __version__
 
     user = Bool(False, config=True, help="Whether to do a user install")
@@ -179,7 +179,7 @@ def toggle_server_extension_python(
 # ----------------------------------------------------------------------
 
 flags = {}
-flags.update(BaseExtensionApp.flags)  # type:ignore[has-type]
+flags.update(BaseExtensionApp.flags)
 flags.pop("y", None)
 flags.pop("generate-config", None)
 flags.update(

--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -1,9 +1,11 @@
 """Serve files directly from the ContentsManager."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 import mimetypes
 from base64 import decodebytes
-from typing import List
+from typing import Awaitable
 
 from jupyter_core.utils import ensure_async
 from tornado import web
@@ -34,11 +36,13 @@ class FilesHandler(JupyterHandler, web.StaticFileHandler):
 
     @web.authenticated
     @authorized
-    def head(self, path):
+    async def head(self, path: str) -> None:  # type:ignore[override]
         """The head response."""
         self.get(path, include_body=False)
         self.check_xsrf_cookie()
-        return self.get(path, include_body=False)
+        resp = self.get(path, include_body=False)
+        if isinstance(resp, Awaitable):
+            await resp
 
     @web.authenticated
     @authorized
@@ -91,4 +95,4 @@ class FilesHandler(JupyterHandler, web.StaticFileHandler):
             self.flush()
 
 
-default_handlers: List[JupyterHandler] = []
+default_handlers: list[JupyterHandler] = []

--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -36,13 +36,11 @@ class FilesHandler(JupyterHandler, web.StaticFileHandler):
 
     @web.authenticated
     @authorized
-    async def head(self, path: str) -> None:  # type:ignore[override]
+    def head(self, path: str) -> Awaitable[None] | None:  # type:ignore[override]
         """The head response."""
         self.get(path, include_body=False)
         self.check_xsrf_cookie()
-        resp = self.get(path, include_body=False)
-        if isinstance(resp, Awaitable):
-            await resp
+        return self.get(path, include_body=False)
 
     @web.authenticated
     @authorized

--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -35,7 +35,7 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
         # websocket is initialized before connection
         self.ws = None
         ws_url = url_path_join(
-            GatewayClient.instance().ws_url,
+            GatewayClient.instance().ws_url or "",
             GatewayClient.instance().kernels_endpoint,
             url_escape(self.kernel_id),
             "channels",

--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -168,15 +168,18 @@ class GatewayWebSocketClient(LoggingConfigurable):
         # websocket is initialized before connection
         self.ws = None
         self.kernel_id = kernel_id
+        client = GatewayClient.instance()
+        assert client.ws_url is not None
+
         ws_url = url_path_join(
-            GatewayClient.instance().ws_url,
-            GatewayClient.instance().kernels_endpoint,
+            client.ws_url,
+            client.kernels_endpoint,
             url_escape(kernel_id),
             "channels",
         )
         self.log.info(f"Connecting to {ws_url}")
         kwargs: dict = {}
-        kwargs = GatewayClient.instance().load_connection_args(**kwargs)
+        kwargs = client.load_connection_args(**kwargs)
 
         request = HTTPRequest(ws_url, **kwargs)
         self.ws_future = cast(Future, websocket_connect(request))

--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -289,7 +289,9 @@ class GatewayResourceHandler(APIHandler):
         """Get a gateway resource by name and path."""
         mimetype: Optional[str] = None
         ksm = self.kernel_spec_manager
-        kernel_spec_res = await ksm.get_kernel_spec_resource(kernel_name, path)
+        kernel_spec_res = await ksm.get_kernel_spec_resource(  # type:ignore[attr-defined]
+            kernel_name, path
+        )
         if kernel_spec_res is None:
             self.log.warning(
                 "Kernelspec resource '{}' for '{}' not found.  Gateway may not support"

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -50,7 +50,7 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
         """Initialize a gateway mapping kernel manager."""
         super().__init__(**kwargs)
         self.kernels_url = url_path_join(
-            GatewayClient.instance().url, GatewayClient.instance().kernels_endpoint
+            GatewayClient.instance().url or "", GatewayClient.instance().kernels_endpoint or ""
         )
 
     def remove_kernel(self, kernel_id):
@@ -214,12 +214,12 @@ class GatewayKernelSpecManager(KernelSpecManager):
         """Initialize a gateway kernel spec manager."""
         super().__init__(**kwargs)
         base_endpoint = url_path_join(
-            GatewayClient.instance().url, GatewayClient.instance().kernelspecs_endpoint
+            GatewayClient.instance().url or "", GatewayClient.instance().kernelspecs_endpoint
         )
 
         self.base_endpoint = GatewayKernelSpecManager._get_endpoint_for_user_filter(base_endpoint)
         self.base_resource_endpoint = url_path_join(
-            GatewayClient.instance().url,
+            GatewayClient.instance().url or "",
             GatewayClient.instance().kernelspecs_resource_endpoint,
         )
 
@@ -386,7 +386,7 @@ class GatewayKernelManager(ServerKernelManager):
         """Initialize the gateway kernel manager."""
         super().__init__(**kwargs)
         self.kernels_url = url_path_join(
-            GatewayClient.instance().url, GatewayClient.instance().kernels_endpoint
+            GatewayClient.instance().url or "", GatewayClient.instance().kernels_endpoint
         )
         self.kernel_url: str
         self.kernel = self.kernel_id = None
@@ -420,7 +420,7 @@ class GatewayKernelManager(ServerKernelManager):
 
         # add kwargs last, for manual overrides
         kw.update(kwargs)
-        return self.client_factory(**kw)  # type:ignore[operator]
+        return self.client_factory(**kw)
 
     async def refresh_model(self, model=None):
         """Refresh the kernel model.
@@ -485,7 +485,7 @@ class GatewayKernelManager(ServerKernelManager):
 
             # Let KERNEL_USERNAME take precedent over http_user config option.
             if os.environ.get("KERNEL_USERNAME") is None and GatewayClient.instance().http_user:
-                os.environ["KERNEL_USERNAME"] = GatewayClient.instance().http_user
+                os.environ["KERNEL_USERNAME"] = GatewayClient.instance().http_user or ""
 
             payload_envs = os.environ.copy()
             payload_envs.update(kwargs.get("env", {}))  # Add any env entries in this request
@@ -739,7 +739,7 @@ class GatewayKernelClient(AsyncKernelClient):
         """
 
         ws_url = url_path_join(
-            GatewayClient.instance().ws_url,
+            GatewayClient.instance().ws_url or "",
             GatewayClient.instance().kernels_endpoint,
             url_escape(self.kernel_id),
             "channels",

--- a/jupyter_server/nbconvert/handlers.py
+++ b/jupyter_server/nbconvert/handlers.py
@@ -167,6 +167,7 @@ class NbconvertPostHandler(JupyterHandler):
         exporter = get_exporter(format, config=self.config)
 
         model = self.get_json_body()
+        assert model is not None
         name = model.get("name", "notebook.ipynb")
         nbnode = from_dict(model["content"])
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1902,7 +1902,7 @@ class ServerApp(JupyterApp):
                 stacklevel=2,
             )
 
-        self.kernel_spec_manager = self.kernel_spec_manager_class(  # type:ignore[operator]
+        self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,
         )
 
@@ -1932,13 +1932,13 @@ class ServerApp(JupyterApp):
         # Trigger a default/validation here explicitly while we still support the
         # deprecated trait on ServerApp (FIXME remove when deprecation finalized)
         self.contents_manager.preferred_dir  # noqa
-        self.session_manager = self.session_manager_class(  # type:ignore[operator]
+        self.session_manager = self.session_manager_class(
             parent=self,
             log=self.log,
             kernel_manager=self.kernel_manager,
             contents_manager=self.contents_manager,
         )
-        self.config_manager = self.config_manager_class(  # type:ignore[operator]
+        self.config_manager = self.config_manager_class(
             parent=self,
             log=self.log,
         )

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -21,6 +21,7 @@ import stat
 import sys
 import threading
 import time
+import typing as t
 import urllib
 import warnings
 from base64 import encodebytes
@@ -149,6 +150,9 @@ except ImportError:
     # Windows
     resource = None  # type:ignore[assignment]
 
+if t.TYPE_CHECKING:
+    from jupyter_server.extension.application import ExtensionApp
+
 # -----------------------------------------------------------------------------
 # Module globals
 # -----------------------------------------------------------------------------
@@ -191,7 +195,7 @@ DEFAULT_SERVER_PORT = DEFAULT_JUPYTER_SERVER_PORT
 # -----------------------------------------------------------------------------
 
 
-def random_ports(port, n):
+def random_ports(port: int, n: int) -> t.Generator[int, None, None]:
     """Generate a list of n random ports near the given port.
 
     The first 5 ports will be sequential, and the remaining n-5 will be
@@ -203,7 +207,7 @@ def random_ports(port, n):
         yield max(1, port + random.randint(-2 * n, 2 * n))  # noqa
 
 
-def load_handlers(name):
+def load_handlers(name: str) -> t.Any:
     """Load the (URL pattern, handler) tuples for each component."""
     mod = __import__(name, fromlist=["default_handlers"])
     return mod.default_handlers
@@ -836,11 +840,11 @@ class ServerApp(JupyterApp):
     _stopping = Bool(False, help="Signal that we've begun stopping.")
 
     @default("log_level")
-    def _default_log_level(self):
+    def _default_log_level(self) -> int:
         return logging.INFO
 
     @default("log_format")
-    def _default_log_format(self):
+    def _default_log_format(self) -> str:
         """override default log format to include date & time"""
         return (
             "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s]%(end_color)s %(message)s"
@@ -909,7 +913,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("ip")
-    def _default_ip(self):
+    def _default_ip(self) -> str:
         """Return localhost if available, 127.0.0.1 otherwise.
 
         On some (horribly broken) systems, localhost cannot be bound.
@@ -927,7 +931,7 @@ class ServerApp(JupyterApp):
             return "localhost"
 
     @validate("ip")
-    def _validate_ip(self, proposal):
+    def _validate_ip(self, proposal: t.Any) -> str:
         value = proposal["value"]
         if value == "*":
             value = ""
@@ -959,7 +963,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("port")
-    def _port_default(self):
+    def _port_default(self) -> int:
         return int(os.getenv(self.port_env, self.port_default_value))
 
     port_retries_env = "JUPYTER_PORT_RETRIES"
@@ -974,7 +978,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("port_retries")
-    def _port_retries_default(self):
+    def _port_retries_default(self) -> int:
         return int(os.getenv(self.port_retries_env, self.port_retries_default_value))
 
     sock = Unicode("", config=True, help="The UNIX socket the Jupyter server will listen on.")
@@ -986,7 +990,7 @@ class ServerApp(JupyterApp):
     )
 
     @validate("sock_mode")
-    def _validate_sock_mode(self, proposal):
+    def _validate_sock_mode(self, proposal: t.Any) -> int:
         value = proposal["value"]
         try:
             converted_value = int(value.encode(), 8)
@@ -1034,7 +1038,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("cookie_secret_file")
-    def _default_cookie_secret_file(self):
+    def _default_cookie_secret_file(self) -> str:
         return os.path.join(self.runtime_dir, "jupyter_cookie_secret")
 
     cookie_secret = Bytes(
@@ -1050,7 +1054,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("cookie_secret")
-    def _default_cookie_secret(self):
+    def _default_cookie_secret(self) -> bytes:
         if os.path.exists(self.cookie_secret_file):
             with open(self.cookie_secret_file, "rb") as f:
                 key = f.read()
@@ -1061,7 +1065,7 @@ class ServerApp(JupyterApp):
         h.update(self.password.encode())
         return h.digest()
 
-    def _write_cookie_secret_file(self, secret):
+    def _write_cookie_secret_file(self, secret: bytes) -> None:
         """write my secret to my secret_file"""
         self.log.info(_i18n("Writing Jupyter server cookie secret to %s"), self.cookie_secret_file)
         try:
@@ -1081,11 +1085,11 @@ class ServerApp(JupyterApp):
     )
 
     @observe("token")
-    def _deprecated_token(self, change):
+    def _deprecated_token(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "IdentityProvider")
 
     @default("token")
-    def _deprecated_token_access(self):
+    def _deprecated_token_access(self) -> None:
         warnings.warn(
             "ServerApp.token config is deprecated in jupyter-server 2.0. Use IdentityProvider.token",
             DeprecationWarning,
@@ -1105,7 +1109,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("min_open_files_limit")
-    def _default_min_open_files_limit(self):
+    def _default_min_open_files_limit(self) -> t.Optional[int]:
         if resource is None:
             # Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)
             return None  # type:ignore[unreachable]
@@ -1164,7 +1168,9 @@ class ServerApp(JupyterApp):
         help="""DEPRECATED in 2.0. Use PasswordIdentityProvider.allow_password_change""",
     )
 
-    def _warn_deprecated_config(self, change, clsname, new_name=None):
+    def _warn_deprecated_config(
+        self, change: t.Any, clsname: str, new_name: t.Optional[str] = None
+    ) -> None:
         """Warn on deprecated config."""
         if new_name is None:
             new_name = change.name
@@ -1184,11 +1190,11 @@ class ServerApp(JupyterApp):
             )
 
     @observe("password")
-    def _deprecated_password(self, change):
+    def _deprecated_password(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "PasswordIdentityProvider", new_name="hashed_password")
 
     @observe("password_required", "allow_password_change")
-    def _deprecated_password_config(self, change):
+    def _deprecated_password_config(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "PasswordIdentityProvider")
 
     disable_check_xsrf = Bool(
@@ -1227,7 +1233,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("allow_remote_access")
-    def _default_allow_remote(self):
+    def _default_allow_remote(self) -> bool:
         """Disallow remote access if we're listening only on loopback addresses"""
 
         # if blank, self.ip was configured to "*" meaning bind to all interfaces,
@@ -1367,7 +1373,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("cookie_options", "get_secure_cookie_kwargs")
-    def _deprecated_cookie_config(self, change):
+    def _deprecated_cookie_config(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "IdentityProvider")
 
     ssl_options = Dict(
@@ -1400,7 +1406,7 @@ class ServerApp(JupyterApp):
     )
 
     @validate("base_url")
-    def _update_base_url(self, proposal):
+    def _update_base_url(self, proposal: t.Any) -> str:
         value = proposal["value"]
         if not value.startswith("/"):
             value = "/" + value
@@ -1418,14 +1424,14 @@ class ServerApp(JupyterApp):
     )
 
     @property
-    def static_file_path(self):
+    def static_file_path(self) -> t.List[str]:
         """return extra paths + the default location"""
         return [*self.extra_static_paths, DEFAULT_STATIC_FILES_PATH]
 
     static_custom_path = List(Unicode(), help=_i18n("""Path to search for custom.js, css"""))
 
     @default("static_custom_path")
-    def _default_static_custom_path(self):
+    def _default_static_custom_path(self) -> t.List[str]:
         return [os.path.join(d, "custom") for d in (self.config_dir, DEFAULT_STATIC_FILES_PATH)]
 
     extra_template_paths = List(
@@ -1439,7 +1445,7 @@ class ServerApp(JupyterApp):
     )
 
     @property
-    def template_file_path(self):
+    def template_file_path(self) -> t.List[str]:
         """return extra paths + the default locations"""
         return self.extra_template_paths + DEFAULT_TEMPLATE_PATH_LIST
 
@@ -1481,7 +1487,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("kernel_manager_class")
-    def _default_kernel_manager_class(self):
+    def _default_kernel_manager_class(self) -> t.Union[str, t.Type[AsyncMappingKernelManager]]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
         return AsyncMappingKernelManager
@@ -1492,7 +1498,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("session_manager_class")
-    def _default_session_manager_class(self):
+    def _default_session_manager_class(self) -> t.Union[str, t.Type[SessionManager]]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewaySessionManager"
         return SessionManager
@@ -1504,7 +1510,9 @@ class ServerApp(JupyterApp):
     )
 
     @default("kernel_websocket_connection_class")
-    def _default_kernel_websocket_connection_class(self):
+    def _default_kernel_websocket_connection_class(
+        self,
+    ) -> t.Union[str, t.Type[ZMQChannelsWebsocketConnection]]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.connections.GatewayWebSocketConnection"
         return ZMQChannelsWebsocketConnection
@@ -1529,7 +1537,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("kernel_spec_manager_class")
-    def _default_kernel_spec_manager_class(self):
+    def _default_kernel_spec_manager_class(self) -> t.Union[str, t.Type[KernelSpecManager]]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
         return KernelSpecManager
@@ -1585,7 +1593,7 @@ class ServerApp(JupyterApp):
     info_file = Unicode()
 
     @default("info_file")
-    def _default_info_file(self):
+    def _default_info_file(self) -> str:
         info_file = "jpserver-%s.json" % os.getpid()
         return os.path.join(self.runtime_dir, info_file)
 
@@ -1596,14 +1604,14 @@ class ServerApp(JupyterApp):
     browser_open_file = Unicode()
 
     @default("browser_open_file")
-    def _default_browser_open_file(self):
+    def _default_browser_open_file(self) -> str:
         basename = "jpserver-%s-open.html" % os.getpid()
         return os.path.join(self.runtime_dir, basename)
 
     browser_open_file_to_run = Unicode()
 
     @default("browser_open_file_to_run")
-    def _default_browser_open_file_to_run(self):
+    def _default_browser_open_file_to_run(self) -> str:
         basename = "jpserver-file-to-run-%s-open.html" % os.getpid()
         return os.path.join(self.runtime_dir, basename)
 
@@ -1618,7 +1626,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("pylab")
-    def _update_pylab(self, change):
+    def _update_pylab(self, change: t.Any) -> None:
         """when --pylab is specified, display a warning and exit"""
         backend = " %s" % change["new"] if change["new"] != "warn" else ""
         self.log.error(
@@ -1634,7 +1642,7 @@ class ServerApp(JupyterApp):
     notebook_dir = Unicode(config=True, help=_i18n("DEPRECATED, use root_dir."))
 
     @observe("notebook_dir")
-    def _update_notebook_dir(self, change):
+    def _update_notebook_dir(self, change: t.Any) -> None:
         if self._root_dir_set:
             # only use deprecated config if new config is not set
             return
@@ -1665,14 +1673,14 @@ class ServerApp(JupyterApp):
     _root_dir_set = False
 
     @default("root_dir")
-    def _default_root_dir(self):
+    def _default_root_dir(self) -> str:
         if self.file_to_run:
             self._root_dir_set = True
             return os.path.dirname(os.path.abspath(self.file_to_run))
         else:
             return os.getcwd()
 
-    def _normalize_dir(self, value):
+    def _normalize_dir(self, value: str) -> str:
         """Normalize a directory."""
         # Strip any trailing slashes
         # *except* if it's root
@@ -1686,14 +1694,14 @@ class ServerApp(JupyterApp):
         return value
 
     @validate("root_dir")
-    def _root_dir_validate(self, proposal):
+    def _root_dir_validate(self, proposal: t.Any) -> str:
         value = self._normalize_dir(proposal["value"])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
         return value
 
     @observe("root_dir")
-    def _root_dir_changed(self, change):
+    def _root_dir_changed(self, change: t.Any) -> None:
         # record that root_dir is set,
         # which affects loading of deprecated notebook_dir
         self._root_dir_set = True
@@ -1705,18 +1713,18 @@ class ServerApp(JupyterApp):
     )
 
     @default("preferred_dir")
-    def _default_prefered_dir(self):
+    def _default_prefered_dir(self) -> str:
         return self.root_dir
 
     @validate("preferred_dir")
-    def _preferred_dir_validate(self, proposal):
+    def _preferred_dir_validate(self, proposal: t.Any) -> str:
         value = self._normalize_dir(proposal["value"])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such preferred dir: '%r'") % value)
         return value
 
     @observe("server_extensions")
-    def _update_server_extensions(self, change):
+    def _update_server_extensions(self, change: t.Any) -> None:
         self.log.warning(_i18n("server_extensions is deprecated, use jpserver_extensions"))
         self.server_extensions = change["new"]
 
@@ -1747,7 +1755,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("kernel_ws_protocol")
-    def _deprecated_kernel_ws_protocol(self, change):
+    def _deprecated_kernel_ws_protocol(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "ZMQChannelsWebsocketConnection")
 
     limit_rate = Bool(
@@ -1757,7 +1765,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("limit_rate")
-    def _deprecated_limit_rate(self, change):
+    def _deprecated_limit_rate(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "ZMQChannelsWebsocketConnection")
 
     iopub_msg_rate_limit = Float(
@@ -1767,7 +1775,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("iopub_msg_rate_limit")
-    def _deprecated_iopub_msg_rate_limit(self, change):
+    def _deprecated_iopub_msg_rate_limit(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "ZMQChannelsWebsocketConnection")
 
     iopub_data_rate_limit = Float(
@@ -1777,7 +1785,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("iopub_data_rate_limit")
-    def _deprecated_iopub_data_rate_limit(self, change):
+    def _deprecated_iopub_data_rate_limit(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "ZMQChannelsWebsocketConnection")
 
     rate_limit_window = Float(
@@ -1787,7 +1795,7 @@ class ServerApp(JupyterApp):
     )
 
     @observe("rate_limit_window")
-    def _deprecated_rate_limit_window(self, change):
+    def _deprecated_rate_limit_window(self, change: t.Any) -> None:
         self._warn_deprecated_config(change, "ZMQChannelsWebsocketConnection")
 
     shutdown_no_activity_timeout = Integer(
@@ -1819,7 +1827,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("terminals_enabled")
-    def _default_terminals_enabled(self):
+    def _default_terminals_enabled(self) -> bool:
         return True
 
     authenticate_prometheus = Bool(
@@ -1848,11 +1856,11 @@ class ServerApp(JupyterApp):
     )
 
     @property
-    def starter_app(self):
+    def starter_app(self) -> t.Optional[ExtensionApp]:
         """Get the Extension that started this server."""
         return self._starter_app
 
-    def parse_command_line(self, argv=None):
+    def parse_command_line(self, argv: t.Optional[t.List[str]] = None) -> None:
         """Parse the command line options."""
         super().parse_command_line(argv)
 
@@ -1873,7 +1881,7 @@ class ServerApp(JupyterApp):
                 c.ServerApp.file_to_run = f
             self.update_config(c)
 
-    def init_configurables(self):
+    def init_configurables(self) -> None:
         """Initialize configurables."""
         # If gateway server is configured, replace appropriate managers to perform redirection.  To make
         # this determination, instantiate the GatewayClient config singleton.
@@ -1989,7 +1997,7 @@ class ServerApp(JupyterApp):
             parent=self, log=self.log, identity_provider=self.identity_provider
         )
 
-    def init_logging(self):
+    def init_logging(self) -> None:
         """Initialize logging."""
         # This prevents double log messages because tornado use a root logger that
         # self.log is a child of. The logging module dipatches log messages to a log
@@ -2005,7 +2013,7 @@ class ServerApp(JupyterApp):
         logger.parent = self.log
         logger.setLevel(self.log.level)
 
-    def init_event_logger(self):
+    def init_event_logger(self) -> None:
         """Initialize the Event Bus."""
         self.event_logger = EventLogger(parent=self)
         # Load the core Jupyter Server event schemas
@@ -2023,7 +2031,7 @@ class ServerApp(JupyterApp):
             # Use this pathlib object to register the schema
             self.event_logger.register_event_schema(schema_path)
 
-    def init_webapp(self):
+    def init_webapp(self) -> None:
         """initialize tornado webapp"""
         self.tornado_settings["allow_origin"] = self.allow_origin
         self.tornado_settings["websocket_compression_options"] = self.websocket_compression_options
@@ -2125,7 +2133,7 @@ class ServerApp(JupyterApp):
             # LegacyIdentityProvider needs access to the tornado settings dict
             self.identity_provider.settings = self.web_app.settings
 
-    def init_resources(self):
+    def init_resources(self) -> None:
         """initialize system resources"""
         if resource is None:
             self.log.debug(  # type:ignore[unreachable]
@@ -2144,7 +2152,7 @@ class ServerApp(JupyterApp):
             )
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
-    def _get_urlparts(self, path=None, include_token=False):
+    def _get_urlparts(self, path: t.Optional[str] = None, include_token: bool = False) -> t.Any:
         """Constructs a urllib named tuple, ParseResult,
         with default values set by server config.
         The returned tuple can be manipulated using the `_replace` method.
@@ -2178,7 +2186,7 @@ class ServerApp(JupyterApp):
         return urlparts
 
     @property
-    def public_url(self):
+    def public_url(self) -> str:
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if self.custom_display_url:
@@ -2191,7 +2199,7 @@ class ServerApp(JupyterApp):
         return parts.geturl()
 
     @property
-    def local_url(self):
+    def local_url(self) -> str:
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if not self.sock:
@@ -2199,7 +2207,7 @@ class ServerApp(JupyterApp):
         return parts.geturl()
 
     @property
-    def display_url(self):
+    def display_url(self) -> str:
         """Human readable string with URLs for interacting
         with the running Jupyter Server
         """
@@ -2207,11 +2215,11 @@ class ServerApp(JupyterApp):
         return url
 
     @property
-    def connection_url(self):
+    def connection_url(self) -> str:
         urlparts = self._get_urlparts(path=self.base_url)
         return urlparts.geturl()
 
-    def init_signal(self):
+    def init_signal(self) -> None:
         """Initialize signal handlers."""
         if (
             not sys.platform.startswith("win")
@@ -2227,7 +2235,7 @@ class ServerApp(JupyterApp):
             # only on BSD-based systems
             signal.signal(signal.SIGINFO, self._signal_info)
 
-    def _handle_sigint(self, sig, frame):
+    def _handle_sigint(self, sig: t.Any, frame: t.Any) -> None:
         """SIGINT handler spawns confirmation dialog"""
         # register more forceful signal handler for ^C^C case
         signal.signal(signal.SIGINT, self._signal_stop)
@@ -2237,11 +2245,11 @@ class ServerApp(JupyterApp):
         thread.daemon = True
         thread.start()
 
-    def _restore_sigint_handler(self):
+    def _restore_sigint_handler(self) -> None:
         """callback for restoring original SIGINT handler"""
         signal.signal(signal.SIGINT, self._handle_sigint)
 
-    def _confirm_exit(self):
+    def _confirm_exit(self) -> None:
         """confirm shutdown on ^C
 
         A second ^C, or answering 'y' within 5s will cause shutdown,
@@ -2285,21 +2293,21 @@ class ServerApp(JupyterApp):
         # from main thread
         self.io_loop.add_callback_from_signal(self._restore_sigint_handler)
 
-    def _signal_stop(self, sig, frame):
+    def _signal_stop(self, sig: t.Any, frame: t.Any) -> None:
         """Handle a stop signal."""
         self.log.critical(_i18n("received signal %s, stopping"), sig)
         self.stop(from_signal=True)
 
-    def _signal_info(self, sig, frame):
+    def _signal_info(self, sig: t.Any, frame: t.Any) -> None:
         """Handle an info signal."""
         self.log.info(self.running_server_info())
 
-    def init_components(self):
+    def init_components(self) -> None:
         """Check the components submodule, and warn if it's unclean"""
         # TODO: this should still check, but now we use bower, not git submodule
         pass
 
-    def find_server_extensions(self):
+    def find_server_extensions(self) -> None:
         """
         Searches Jupyter paths for jpserver_extensions.
         """
@@ -2322,7 +2330,7 @@ class ServerApp(JupyterApp):
                 self.config.ServerApp.jpserver_extensions.update({modulename: enabled})
                 self.jpserver_extensions.update({modulename: enabled})
 
-    def init_server_extensions(self):
+    def init_server_extensions(self) -> None:
         """
         If an extension's metadata includes an 'app' key,
         the value must be a subclass of ExtensionApp. An instance
@@ -2335,7 +2343,7 @@ class ServerApp(JupyterApp):
         self.extension_manager.from_jpserver_extensions(self.jpserver_extensions)
         self.extension_manager.link_all_extensions()
 
-    def load_server_extensions(self):
+    def load_server_extensions(self) -> None:
         """Load any extensions specified by config.
 
         Import the module, then call the load_jupyter_server_extension function,
@@ -2345,7 +2353,7 @@ class ServerApp(JupyterApp):
         """
         self.extension_manager.load_all_extensions()
 
-    def init_mime_overrides(self):
+    def init_mime_overrides(self) -> None:
         # On some Windows machines, an application has registered incorrect
         # mimetypes in the registry.
         # Tornado uses this when serving .css and .js files, causing browsers to
@@ -2361,7 +2369,7 @@ class ServerApp(JupyterApp):
         # for python <3.8
         mimetypes.add_type("application/wasm", ".wasm")
 
-    def shutdown_no_activity(self):
+    def shutdown_no_activity(self) -> None:
         """Shutdown server on timeout when there are no kernels or terminals."""
         km = self.kernel_manager
         if len(km) != 0:
@@ -2379,7 +2387,7 @@ class ServerApp(JupyterApp):
             )
             self.stop()
 
-    def init_shutdown_no_activity(self):
+    def init_shutdown_no_activity(self) -> None:
         """Initialize a shutdown on no activity."""
         if self.shutdown_no_activity_timeout > 0:
             self.log.info(
@@ -2390,7 +2398,7 @@ class ServerApp(JupyterApp):
             pc.start()
 
     @property
-    def http_server(self):
+    def http_server(self) -> httpserver.HTTPServer:
         """An instance of Tornado's HTTPServer class for the Server Web Application."""
         try:
             return self._http_server
@@ -2402,7 +2410,7 @@ class ServerApp(JupyterApp):
             )
             raise AttributeError(msg) from None
 
-    def init_httpserver(self):
+    def init_httpserver(self) -> None:
         """Creates an instance of a Tornado HTTPServer for the Server Web Application
         and sets the http_server attribute.
         """
@@ -2428,7 +2436,7 @@ class ServerApp(JupyterApp):
             self._find_http_port()
         self.io_loop.add_callback(self._bind_http_server)
 
-    def _bind_http_server(self):
+    def _bind_http_server(self) -> None:
         """Bind our http server."""
         success = self._bind_http_server_unix() if self.sock else self._bind_http_server_tcp()
         if not success:
@@ -2440,7 +2448,7 @@ class ServerApp(JupyterApp):
             )
             self.exit(1)
 
-    def _bind_http_server_unix(self):
+    def _bind_http_server_unix(self) -> bool:
         """Bind an http server on unix."""
         if unix_socket_in_use(self.sock):
             self.log.warning(_i18n("The socket %s is already in use.") % self.sock)
@@ -2461,12 +2469,12 @@ class ServerApp(JupyterApp):
         else:
             return True
 
-    def _bind_http_server_tcp(self):
+    def _bind_http_server_tcp(self) -> bool:
         """Bind a tcp server."""
         self.http_server.listen(self.port, self.ip)
         return True
 
-    def _find_http_port(self):
+    def _find_http_port(self) -> None:
         """Find an available http port."""
         success = False
         port = self.port
@@ -2514,7 +2522,7 @@ class ServerApp(JupyterApp):
             self.exit(1)
 
     @staticmethod
-    def _init_asyncio_patch():
+    def _init_asyncio_patch() -> None:
         """set default asyncio policy to be compatible with tornado
 
         Tornado 6.0 is not compatible with default asyncio
@@ -2541,11 +2549,11 @@ class ServerApp(JupyterApp):
     @catch_config_error
     def initialize(
         self,
-        argv=None,
-        find_extensions=True,
-        new_httpserver=True,
-        starter_extension=None,
-    ):
+        argv: t.Optional[t.List[str]] = None,
+        find_extensions: bool = True,
+        new_httpserver: bool = True,
+        starter_extension: t.Any = None,
+    ) -> None:
         """Initialize the Server application class, configurables, web application, and http server.
 
         Parameters
@@ -2604,7 +2612,7 @@ class ServerApp(JupyterApp):
         if new_httpserver:
             self.init_httpserver()
 
-    async def cleanup_kernels(self):
+    async def cleanup_kernels(self) -> None:
         """Shutdown all kernels.
 
         The kernels will shutdown themselves when this process no longer exists,
@@ -2619,7 +2627,7 @@ class ServerApp(JupyterApp):
         self.log.info(kernel_msg % n_kernels)
         await ensure_async(self.kernel_manager.shutdown_all())
 
-    async def cleanup_extensions(self):
+    async def cleanup_extensions(self) -> None:
         """Call shutdown hooks in all extensions."""
         if not getattr(self, "extension_manager", None):
             return
@@ -2630,7 +2638,7 @@ class ServerApp(JupyterApp):
         self.log.info(extension_msg % n_extensions)
         await ensure_async(self.extension_manager.stop_all_extensions())
 
-    def running_server_info(self, kernel_count=True):
+    def running_server_info(self, kernel_count: bool = True) -> str:
         """Return the current working directory and the server url information"""
         info = self.contents_manager.info_string() + "\n"
         if kernel_count:
@@ -2647,7 +2655,7 @@ class ServerApp(JupyterApp):
             )
         return info
 
-    def server_info(self):
+    def server_info(self) -> t.Dict[str, t.Any]:
         """Return a JSONable dict of information about this server."""
         return {
             "url": self.connection_url,
@@ -2663,7 +2671,7 @@ class ServerApp(JupyterApp):
             "version": ServerApp.version,
         }
 
-    def write_server_info_file(self):
+    def write_server_info_file(self) -> None:
         """Write the result of server_info() to the JSON file info_file."""
         try:
             with secure_write(self.info_file) as f:
@@ -2671,7 +2679,7 @@ class ServerApp(JupyterApp):
         except OSError as e:
             self.log.error(_i18n("Failed to write server-info to %s: %r"), self.info_file, e)
 
-    def remove_server_info_file(self):
+    def remove_server_info_file(self) -> None:
         """Remove the jpserver-<pid>.json file created for this server.
 
         Ignores the error raised when the file has already been removed.
@@ -2682,7 +2690,7 @@ class ServerApp(JupyterApp):
             if e.errno != errno.ENOENT:
                 raise
 
-    def _resolve_file_to_run_and_root_dir(self):
+    def _resolve_file_to_run_and_root_dir(self) -> str:
         """Returns a relative path from file_to_run
         to root_dir. If root_dir and file_to_run
         are incompatible, i.e. on different subtrees,
@@ -2712,8 +2720,9 @@ class ServerApp(JupyterApp):
             "is on the same path as `root_dir`."
         )
         self.exit(1)
+        return ""
 
-    def _write_browser_open_file(self, url, fh):
+    def _write_browser_open_file(self, url: str, fh: t.Any) -> None:
         """Write the browser open file."""
         if self.identity_provider.token:
             url = url_concat(url, {"token": self.identity_provider.token})
@@ -2723,7 +2732,7 @@ class ServerApp(JupyterApp):
         template = jinja2_env.get_template("browser-open.html")
         fh.write(template.render(open_url=url, base_url=self.base_url))
 
-    def write_browser_open_files(self):
+    def write_browser_open_files(self) -> None:
         """Write an `browser_open_file` and `browser_open_file_to_run` files
 
         This can be used to open a file directly in a browser.
@@ -2744,7 +2753,7 @@ class ServerApp(JupyterApp):
             with open(self.browser_open_file_to_run, "w", encoding="utf-8") as f:
                 self._write_browser_open_file(file_open_url, f)
 
-    def write_browser_open_file(self):
+    def write_browser_open_file(self) -> None:
         """Write an jpserver-<pid>-open.html file
 
         This can be used to open the notebook in a browser
@@ -2755,7 +2764,7 @@ class ServerApp(JupyterApp):
         with open(self.browser_open_file, "w", encoding="utf-8") as f:
             self._write_browser_open_file(open_url, f)
 
-    def remove_browser_open_files(self):
+    def remove_browser_open_files(self) -> None:
         """Remove the `browser_open_file` and `browser_open_file_to_run` files
         created for this server.
 
@@ -2768,7 +2777,7 @@ class ServerApp(JupyterApp):
             if e.errno != errno.ENOENT:
                 raise
 
-    def remove_browser_open_file(self):
+    def remove_browser_open_file(self) -> None:
         """Remove the jpserver-<pid>-open.html file created for this server.
 
         Ignores the error raised when the file has already been removed.
@@ -2779,7 +2788,7 @@ class ServerApp(JupyterApp):
             if e.errno != errno.ENOENT:
                 raise
 
-    def _prepare_browser_open(self):
+    def _prepare_browser_open(self) -> t.Tuple[str, t.Optional[str]]:
         """Prepare to open the browser."""
         if not self.use_redirect_file:
             uri = self.default_url[len(self.base_url) :]
@@ -2802,7 +2811,7 @@ class ServerApp(JupyterApp):
 
         return assembled_url, open_file
 
-    def launch_browser(self):
+    def launch_browser(self) -> None:
         """Launch the browser."""
         # Deferred import for environments that do not have
         # the webbrowser module.
@@ -2825,7 +2834,7 @@ class ServerApp(JupyterApp):
 
         threading.Thread(target=target).start()
 
-    def start_app(self):
+    def start_app(self) -> None:
         """Start the Jupyter Server application."""
         super().start()
 
@@ -2908,7 +2917,7 @@ class ServerApp(JupyterApp):
 
                 self.log.critical("\n".join(message))
 
-    async def _cleanup(self):
+    async def _cleanup(self) -> None:
         """General cleanup of files, extensions and kernels created
         by this instance ServerApp.
         """
@@ -2937,7 +2946,7 @@ class ServerApp(JupyterApp):
             # Stop a server if its set.
             self.http_server.stop()
 
-    def start_ioloop(self):
+    def start_ioloop(self) -> None:
         """Start the IO Loop."""
         if sys.platform.startswith("win"):
             # add no-op to wake every 5s
@@ -2949,11 +2958,11 @@ class ServerApp(JupyterApp):
         except KeyboardInterrupt:
             self.log.info(_i18n("Interrupted..."))
 
-    def init_ioloop(self):
+    def init_ioloop(self) -> None:
         """init self.io_loop so that an extension can use it by io_loop.call_later() to create background tasks"""
         self.io_loop = ioloop.IOLoop.current()
 
-    def start(self):
+    def start(self) -> None:
         """Start the Jupyter server app, after initialization
 
         This method takes no arguments so all configuration and initialization
@@ -2961,13 +2970,13 @@ class ServerApp(JupyterApp):
         self.start_app()
         self.start_ioloop()
 
-    async def _stop(self):
+    async def _stop(self) -> None:
         """Cleanup resources and stop the IO Loop."""
         await self._cleanup()
         if getattr(self, "io_loop", None):
             self.io_loop.stop()
 
-    def stop(self, from_signal=False):
+    def stop(self, from_signal: bool = False) -> None:
         """Cleanup resources and stop the server."""
         # signal that stopping has begun
         self._stopping = True
@@ -2983,7 +2992,9 @@ class ServerApp(JupyterApp):
                 self.io_loop.add_callback(self._stop)
 
 
-def list_running_servers(runtime_dir=None, log=None):
+def list_running_servers(
+    runtime_dir: t.Optional[str] = None, log: t.Optional[logging.Logger] = None
+) -> t.Generator[t.Any, None, None]:
     """Iterate over the server info files of running Jupyter servers.
 
     Given a runtime directory, find jpserver-* files in the security directory,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -150,9 +150,6 @@ except ImportError:
     # Windows
     resource = None  # type:ignore[assignment]
 
-if t.TYPE_CHECKING:
-    from jupyter_server.extension.application import ExtensionApp
-
 # -----------------------------------------------------------------------------
 # Module globals
 # -----------------------------------------------------------------------------
@@ -1856,7 +1853,7 @@ class ServerApp(JupyterApp):
     )
 
     @property
-    def starter_app(self) -> "t.Optional[ExtensionApp]":
+    def starter_app(self) -> t.Any:
         """Get the Extension that started this server."""
         return self._starter_app
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1856,7 +1856,7 @@ class ServerApp(JupyterApp):
     )
 
     @property
-    def starter_app(self) -> t.Optional[ExtensionApp]:
+    def starter_app(self) -> "t.Optional[ExtensionApp]":
         """Get the Extension that started this server."""
         return self._starter_app
 

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -33,8 +33,8 @@ from .manager import AsyncContentsManager, ContentsManager, copy_pat
 try:
     from os.path import samefile
 except ImportError:
-    # windows + py2
-    from jupyter_server.utils import samefile_simple as samefile
+    # windows
+    from jupyter_server.utils import samefile_simple as samefile  # type:ignore[assignment]
 
 _script_exporter = None
 

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -353,7 +353,7 @@ class NotebooksRedirectHandler(JupyterHandler):
 class TrustNotebooksHandler(JupyterHandler):
     """Handles trust/signing of notebooks"""
 
-    @web.authenticated
+    @web.authenticated  # type:ignore[misc]
     @authorized(resource=AUTH_RESOURCE)
     async def post(self, path=""):
         """Trust a notebook by path."""

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -325,7 +325,7 @@ class ContentsManager(LoggingConfigurable):
 
     @default("checkpoints")
     def _default_checkpoints(self):
-        return self.checkpoints_class(**self.checkpoints_kwargs)  # type:ignore[operator]
+        return self.checkpoints_class(**self.checkpoints_kwargs)
 
     @default("checkpoints_kwargs")
     def _default_checkpoints_kwargs(self):
@@ -761,7 +761,7 @@ class AsyncContentsManager(ContentsManager):
 
     @default("checkpoints")
     def _default_checkpoints(self):
-        return self.checkpoints_class(**self.checkpoints_kwargs)  # type:ignore[operator]
+        return self.checkpoints_class(**self.checkpoints_kwargs)
 
     @default("checkpoints_kwargs")
     def _default_checkpoints_kwargs(self):

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -2,9 +2,11 @@
 
 .. versionadded:: 2.0
 """
+from __future__ import annotations
+
 import json
 from datetime import datetime
-from typing import Any, Dict, Optional, cast
+from typing import Any, cast
 
 from jupyter_events import EventLogger
 from tornado import web, websocket
@@ -63,7 +65,7 @@ class SubscribeWebsocket(
         self.event_logger.remove_listener(listener=self.event_listener)
 
 
-def validate_model(data: Dict[str, Any]) -> None:
+def validate_model(data: dict[str, Any]) -> None:
     """Validates for required fields in the JSON request body"""
     required_keys = {"schema_id", "version", "data"}
     for key in required_keys:
@@ -71,7 +73,7 @@ def validate_model(data: Dict[str, Any]) -> None:
             raise web.HTTPError(400, f"Missing `{key}` in the JSON request body.")
 
 
-def get_timestamp(data: Dict[str, Any]) -> Optional[datetime]:
+def get_timestamp(data: dict[str, Any]) -> datetime | None:
     """Parses timestamp from the JSON request body"""
     try:
         if "timestamp" in data:

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -4,7 +4,7 @@
 """
 import json
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from jupyter_events import EventLogger
 from tornado import web, websocket
@@ -105,8 +105,8 @@ class EventHandler(APIHandler):
         try:
             validate_model(payload)
             self.event_logger.emit(
-                schema_id=payload.get("schema_id"),
-                data=payload.get("data"),
+                schema_id=cast(str, payload.get("schema_id")),
+                data=cast("dict[str, Any]", payload.get("data")),
                 timestamp_override=get_timestamp(payload),
             )
             self.set_status(204)

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -48,7 +48,7 @@ class SubscribeWebsocket(
             await res
 
     async def event_listener(
-        self, logger: jupyter_events.logger.EventLogger, schema_id: str, data: Dict
+        self, logger: jupyter_events.logger.EventLogger, schema_id: str, data: dict
     ) -> None:
         """Write an event message."""
         capsule = dict(schema_id=schema_id, **data)

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -94,7 +94,7 @@ class KernelActionHandler(KernelsAPIHandler):
         """Interrupt or restart a kernel."""
         km = self.kernel_manager
         if action == "interrupt":
-            km.interrupt_kernel(kernel_id)
+            await ensure_async(km.interrupt_kernel(kernel_id))  # type:ignore[func-returns-value]
             self.set_status(204)
         if action == "restart":
             try:

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -53,7 +53,9 @@ class MainKernelHandler(KernelsAPIHandler):
             model.setdefault("name", km.default_kernel_name)
 
         kernel_id = await ensure_async(
-            km.start_kernel(kernel_name=model["name"], path=model.get("path"))
+            km.start_kernel(
+                kernel_name=model["name"], path=model.get("path")
+            )  # type:ignore[has-type]
         )
         model = await ensure_async(km.kernel_model(kernel_id))
         location = url_path_join(self.base_url, "api", "kernels", url_escape(kernel_id))
@@ -92,7 +94,7 @@ class KernelActionHandler(KernelsAPIHandler):
         """Interrupt or restart a kernel."""
         km = self.kernel_manager
         if action == "interrupt":
-            await ensure_async(km.interrupt_kernel(kernel_id))
+            km.interrupt_kernel(kernel_id)
             self.set_status(204)
         if action == "restart":
             try:

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -53,9 +53,9 @@ class MainKernelHandler(KernelsAPIHandler):
             model.setdefault("name", km.default_kernel_name)
 
         kernel_id = await ensure_async(
-            km.start_kernel(
+            km.start_kernel(  # type:ignore[has-type]
                 kernel_name=model["name"], path=model.get("path")
-            )  # type:ignore[has-type]
+            )
         )
         model = await ensure_async(km.kernel_model(kernel_id))
         location = url_path_join(self.base_url, "api", "kernels", url_escape(kernel_id))

--- a/jupyter_server/services/kernelspecs/handlers.py
+++ b/jupyter_server/services/kernelspecs/handlers.py
@@ -4,9 +4,12 @@ Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-25%3A-
 """
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import annotations
+
 import glob
 import json
 import os
+from typing import Any
 
 pjoin = os.path.join
 
@@ -63,7 +66,7 @@ class MainKernelSpecHandler(KernelSpecsAPIHandler):
         """Get the list of kernel specs."""
         ksm = self.kernel_spec_manager
         km = self.kernel_manager
-        model = {}
+        model: dict[str, Any] = {}
         model["default"] = km.default_kernel_name
         model["kernelspecs"] = specs = {}
         kspecs = await ensure_async(ksm.get_all_specs())

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -109,7 +109,7 @@ class SessionRootHandler(SessionsAPIHandler):
         location = url_path_join(self.base_url, "api", "sessions", s_model["id"])
         self.set_header("Location", location)
         self.set_status(201)
-        self.finish(json.dumps(model, default=json_default))
+        self.finish(json.dumps(s_model, default=json_default))
 
 
 class SessionHandler(SessionsAPIHandler):

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -83,10 +83,10 @@ class SessionRootHandler(SessionsAPIHandler):
 
         exists = await ensure_async(sm.session_exists(path=path))
         if exists:
-            model = await sm.get_session(path=path)
+            s_model = await sm.get_session(path=path)
         else:
             try:
-                model = await sm.create_session(
+                s_model = await sm.create_session(
                     path=path,
                     kernel_name=kernel_name,
                     kernel_id=kernel_id,
@@ -106,7 +106,7 @@ class SessionRootHandler(SessionsAPIHandler):
             except Exception as e:
                 raise web.HTTPError(500, str(e)) from e
 
-        location = url_path_join(self.base_url, "api", "sessions", model["id"])
+        location = url_path_join(self.base_url, "api", "sessions", s_model["id"])
         self.set_header("Location", location)
         self.set_status(201)
         self.finish(json.dumps(model, default=json_default))
@@ -170,16 +170,16 @@ class SessionHandler(SessionsAPIHandler):
                 changes["kernel_id"] = kernel_id
 
         await sm.update_session(session_id, **changes)
-        model = await sm.get_session(session_id=session_id)
+        s_model = await sm.get_session(session_id=session_id)
 
-        if model["kernel"]["id"] != before["kernel"]["id"]:
+        if s_model["kernel"]["id"] != before["kernel"]["id"]:
             # kernel_id changed because we got a new kernel
             # shutdown the old one
             fut = asyncio.ensure_future(ensure_async(km.shutdown_kernel(before["kernel"]["id"])))
             # If we are not using pending kernels, wait for the kernel to shut down
             if not getattr(km, "use_pending_kernels", None):
                 await fut
-        self.finish(json.dumps(model, default=json_default))
+        self.finish(json.dumps(s_model, default=json_default))
 
     @web.authenticated
     @authorized

--- a/jupyter_server/services/shutdown.py
+++ b/jupyter_server/services/shutdown.py
@@ -19,7 +19,8 @@ class ShutdownHandler(JupyterHandler):
         """Shut down the server."""
         self.log.info("Shutting down on /api/shutdown request.")
 
-        await self.serverapp._cleanup()
+        if self.serverapp:
+            await self.serverapp._cleanup()
 
         ioloop.IOLoop.current().stop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ pydist_resource_paths = ["jupyter_server/static/style/bootstrap.min.css", "jupyt
 post-version-spec = "dev"
 
 [tool.mypy]
+python_version = "3.8"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test"]
-dependencies = [ "mypy>=1.5.1", "traitlets>=5.10.1", "jupyter_core>=5.3.2"]
+dependencies = [ "mypy>=1.5.1", "traitlets>=5.11.2", "jupyter_core>=5.3.2"]
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args:.}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ nowarn = "test -W default {args}"
 
 [tool.hatch.envs.typing]
 features = ["test"]
-dependencies = [ "mypy>=1.5.1", "traitlets>=5.10.1" ]
+dependencies = [ "mypy>=1.5.1", "traitlets>=5.10.1", "jupyter_core>=5.3.2"]
 [tool.hatch.envs.typing.scripts]
 test = "mypy --install-types --non-interactive {args:.}"
 

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -52,7 +52,7 @@ def test_jupyter_handler(jp_serverapp):
     assert handler.mathjax_config == "bar"
     handler.settings["terminal_manager"] = None
     assert handler.terminal_manager is None
-    handler.settings["allow_origin"] = True
+    handler.settings["allow_origin"] = True  # type:ignore[unreachable]
     handler.set_cors_headers()
     handler.settings["allow_origin"] = False
     handler.settings["allow_origin_pat"] = "foo"

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -50,8 +50,8 @@ def test_jupyter_handler(jp_serverapp):
     handler.settings["mathjax_config"] = "bar"
     assert handler.mathjax_url == "/foo"
     assert handler.mathjax_config == "bar"
-    handler.settings["terminal_manager"] = "fizz"
-    assert handler.terminal_manager == "fizz"
+    handler.settings["terminal_manager"] = None
+    assert handler.terminal_manager is None
     handler.settings["allow_origin"] = True
     handler.set_cors_headers()
     handler.settings["allow_origin"] = False

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime
 
 import pytest
 from tornado import web
@@ -18,7 +19,7 @@ from jupyter_server.services.sessions.sessionmanager import (
 
 class DummyKernel:
     execution_state: str
-    last_activity: str
+    last_activity: datetime
 
     def __init__(self, kernel_name="python"):
         self.kernel_name = kernel_name

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -322,13 +322,13 @@ def test_token_renewer_config(jp_server_config, jp_configurable_serverapp, renew
     if renewer_type == "default":
         assert isinstance(gw_client.gateway_token_renewer, NoOpTokenRenewer)
         token = gw_client.gateway_token_renewer.get_token(
-            gw_client.auth_header_key, gw_client.auth_scheme, gw_client.auth_token
+            gw_client.auth_header_key, gw_client.auth_scheme, gw_client.auth_token or ""
         )
         assert token == gw_client.auth_token
     else:
         assert isinstance(gw_client.gateway_token_renewer, CustomTestTokenRenewer)
         token = gw_client.gateway_token_renewer.get_token(
-            gw_client.auth_header_key, gw_client.auth_scheme, gw_client.auth_token
+            gw_client.auth_header_key, gw_client.auth_scheme, gw_client.auth_token or ""
         )
         assert token == CustomTestTokenRenewer.TEST_EXPECTED_TOKEN_VALUE
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,7 +95,7 @@ def test_path_utils(tmp_path):
 def test_check_version():
     assert check_version("1.0.2", "1.0.1")
     assert not check_version("1.0.0", "1.0.1")
-    assert check_version(1.0, "1.0.1")
+    assert check_version(1.0, "1.0.1")  # type:ignore[arg-type]
 
 
 def test_check_pid():


### PR DESCRIPTION
I looked at which APIs were used by `jupyterlab_server`, `notebook`, and `jupyterlab` and this covers most of them.