### PR TITLE
Run Gateway token renewers even if the auth token is empty.

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -601,7 +601,7 @@ such that request_timeout >= KERNEL_LAUNCH_TIMEOUT + launch_timeout_pad.
 
         # Give token renewal a shot at renewing the token
         prev_auth_token = self.auth_token
-        if self.auth_token:
+        if self.auth_token is not None:
             try:
                 self.auth_token = self.gateway_token_renewer.get_token(
                     self.auth_header_key, self.auth_scheme, self.auth_token

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -303,12 +303,16 @@ def test_gateway_cli_options(jp_configurable_serverapp, capsys):
     GatewayClient.clear_instance()
 
 
-@pytest.mark.parametrize("renewer_type", ["default", "custom"])
-def test_token_renewer_config(jp_server_config, jp_configurable_serverapp, renewer_type):
+@pytest.mark.parametrize("renewer_type,initial_auth_token", [("default", ""), ("custom", None), ("custom", "")])
+def test_token_renewer_config(jp_server_config, jp_configurable_serverapp, renewer_type, initial_auth_token):
     argv = ["--gateway-url=" + mock_gateway_url]
     if renewer_type == "custom":
         argv.append(
             "--GatewayClient.gateway_token_renewer_class=tests.test_gateway.CustomTestTokenRenewer"
+        )
+    if initial_auth_token is None:
+        argv.append(
+            "--GatewayClient.auth_token=None"
         )
 
     GatewayClient.clear_instance()
@@ -331,6 +335,11 @@ def test_token_renewer_config(jp_server_config, jp_configurable_serverapp, renew
             gw_client.auth_header_key, gw_client.auth_scheme, gw_client.auth_token or ""
         )
         assert token == CustomTestTokenRenewer.TEST_EXPECTED_TOKEN_VALUE
+    gw_client.load_connection_args()
+    if renewer_type == "default" or initial_auth_token is None:
+        assert gw_client.auth_token == initial_auth_token
+    else:
+        assert gw_client.auth_token == CustomTestTokenRenewer.TEST_EXPECTED_TOKEN_VALUE
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -303,17 +303,19 @@ def test_gateway_cli_options(jp_configurable_serverapp, capsys):
     GatewayClient.clear_instance()
 
 
-@pytest.mark.parametrize("renewer_type,initial_auth_token", [("default", ""), ("custom", None), ("custom", "")])
-def test_token_renewer_config(jp_server_config, jp_configurable_serverapp, renewer_type, initial_auth_token):
+@pytest.mark.parametrize(
+    "renewer_type,initial_auth_token", [("default", ""), ("custom", None), ("custom", "")]
+)
+def test_token_renewer_config(
+    jp_server_config, jp_configurable_serverapp, renewer_type, initial_auth_token
+):
     argv = ["--gateway-url=" + mock_gateway_url]
     if renewer_type == "custom":
         argv.append(
             "--GatewayClient.gateway_token_renewer_class=tests.test_gateway.CustomTestTokenRenewer"
         )
     if initial_auth_token is None:
-        argv.append(
-            "--GatewayClient.auth_token=None"
-        )
+        argv.append("--GatewayClient.auth_token=None")
 
     GatewayClient.clear_instance()
     app = jp_configurable_serverapp(argv=argv)


### PR DESCRIPTION
Prior to the `2.8.0` release, Gateway token renewers would be run regardless of the value of the initial auth token configured with the Gateway client.

However, that initial value could potentially be `None`, and token renewers are not required to support that as a value for their `auth_token` parameter. This meant that token renewers might be called with a value they do not support.

The `2.8.0` release fixed that issue by only calling token renewers if the `auth_token` value was truthy. However, this introduced a regression because the default value for auth tokens is the empty string, which is not truthy but which *is* a valid string value (and, as such, is expected to be supported by token renewers).

This change fixes that by calling token renewers as long as the `auth_token` value is not `None`. This is a compromise between the pre-2.8.0 behavior and the 2.8.0 behavior, and is believed to be the least disruptive option.

This fixes #1339