### PR TITLE
Update kernel env to reflect changes in session.

### DIFF
--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -461,6 +461,13 @@ class SessionManager(LoggingConfigurable):
         query = "UPDATE session SET %s WHERE session_id=?" % (", ".join(sets))  # noqa
         self.cursor.execute(query, [*list(kwargs.values()), session_id])
 
+        if hasattr(self.kernel_manager, "update_env"):
+            self.cursor.execute(
+                "SELECT path, name, kernel_id FROM session WHERE session_id=?", [session_id]
+            )
+            path, name, kernel_id = self.cursor.fetchone()
+            self.kernel_manager.update_env(kernel_id=kernel_id, env=self.get_kernel_env(path, name))
+
     async def kernel_culled(self, kernel_id: str) -> bool:
         """Checks if the kernel is still considered alive and returns true if its not found."""
         return kernel_id not in self.kernel_manager


### PR DESCRIPTION
This rely on jupyter/jupyter_client#987 and fixes ipython/ipykernel#1102 When a user rename the notebook in the UI, it will update the kernel env, so that the ``__session__`` variable reflect the new name on the next restart.

It _does_ seem that each rename of a notebook in JupyterLab creates 4 update_session (2 with name, and 2 with path), but that does not seem to be a problem in this repository.