### PR TITLE
Support get file(notebook) md5

### DIFF
--- a/docs/source/developers/contents.rst
+++ b/docs/source/developers/contents.rst
@@ -63,6 +63,10 @@ Models may contain the following entries:
 |                    |``None``   |if any. (:ref:`See            |
 |                    |           |Below<modelcontent>`)         |
 +--------------------+-----------+------------------------------+
+|**md5**             |unicode or |The md5 of the contents.      |
+|                    |``None``   |                              |
+|                    |           |                              |
++--------------------+-----------+------------------------------+
 
 .. _modelcontent:
 
@@ -76,6 +80,8 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       :class:`nbformat.notebooknode.NotebookNode` representing the .ipynb file
       represented by the model.  See the `NBFormat`_ documentation for a full
       description.
+    - The ``md5`` field a hexdigest string of the md5 value of the notebook
+      file.
 
 - ``file`` models
     - The ``format`` field is either ``"text"`` or ``"base64"``.
@@ -85,12 +91,14 @@ model. There are three model types: **notebook**, **file**, and **directory**.
       file models, ``content`` simply contains the file's bytes after decoding
       as UTF-8.  Non-text (``base64``) files are read as bytes, base64 encoded,
       and then decoded as UTF-8.
+    - The ``md5`` field a hexdigest string of the md5 value of the file.
 
 - ``directory`` models
     - The ``format`` field is always ``"json"``.
     - The ``mimetype`` field is always ``None``.
     - The ``content`` field contains a list of :ref:`content-free<contentfree>`
       models representing the entities in the directory.
+    - The ``md5`` field is always ``None``.
 
 .. note::
 
@@ -129,6 +137,7 @@ model. There are three model types: **notebook**, **file**, and **directory**.
         "path": "foo/a.ipynb",
         "type": "notebook",
         "writable": True,
+        "md5": "7e47382b370c05a1b14706a2a8aff91a",
     }
 
     # Notebook Model without Content

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -478,5 +478,5 @@ class AsyncFileManagerMixin(FileManagerMixin):
     async def _get_md5(self, os_path):
         c, _ = await self._read_file(os_path, "byte")
         md5 = hashlib.md5()  # noqa: S324
-        md5.update(c)
+        await run_sync(md5.update, c)
         return md5.hexdigest()

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -37,9 +37,7 @@ try:
     from os.path import samefile
 except ImportError:
     # windows
-    from jupyter_server.utils import (
-        samefile_simple as samefile,
-    )
+    from jupyter_server.utils import samefile_simple as samefile  # type:ignore[assignment]
 
 _script_exporter = None
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -447,7 +447,7 @@ class ContentsManager(LoggingConfigurable):
         """
         return self.file_exists(path) or self.dir_exists(path)
 
-    def get(self, path, content=True, type=None, format=None):
+    def get(self, path, content=True, type=None, format=None, md5=False):
         """Get a file or directory model."""
         raise NotImplementedError
 

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -103,6 +103,20 @@ async def test_get_nb_contents(jp_fetch, contents, path, name):
 
 
 @pytest.mark.parametrize("path,name", dirs)
+async def test_get_nb_md5(jp_fetch, contents, path, name):
+    nbname = name + ".ipynb"
+    nbpath = (path + "/" + nbname).lstrip("/")
+    r = await jp_fetch("api", "contents", nbpath, method="GET", params=dict(md5="1"))
+    model = json.loads(r.body.decode())
+    assert model["name"] == nbname
+    assert model["path"] == nbpath
+    assert model["type"] == "notebook"
+    assert "md5" in model
+    assert "metadata" in model["content"]
+    assert isinstance(model["content"]["metadata"], dict)
+
+
+@pytest.mark.parametrize("path,name", dirs)
 async def test_get_nb_no_contents(jp_fetch, contents, path, name):
     nbname = name + ".ipynb"
     nbpath = (path + "/" + nbname).lstrip("/")
@@ -184,6 +198,19 @@ async def test_get_text_file_contents(jp_fetch, contents, path, name):
             params=dict(type="file", format="text"),
         )
     assert expected_http_error(e, 400)
+
+
+@pytest.mark.parametrize("path,name", dirs)
+async def test_get_text_file_md5(jp_fetch, contents, path, name):
+    txtname = name + ".txt"
+    txtpath = (path + "/" + txtname).lstrip("/")
+    r = await jp_fetch("api", "contents", txtpath, method="GET", params=dict(md5="1"))
+    model = json.loads(r.body.decode())
+    assert model["name"] == txtname
+    assert model["path"] == txtpath
+    assert "md5" in model
+    assert model["format"] == "text"
+    assert model["type"] == "file"
 
 
 async def test_get_404_hidden(jp_fetch, contents, contents_dir):

--- a/tests/services/contents/test_fileio.py
+++ b/tests/services/contents/test_fileio.py
@@ -142,6 +142,8 @@ def test_file_manager_mixin(tmpdir):
     mixin.log = logging.getLogger()
     bad_content = tmpdir / "bad_content.ipynb"
     bad_content.write_text("{}", "utf8")
+    # Same as `echo -n {} | md5sum`
+    assert mixin._get_md5(bad_content) == "99914b932bd37a50b983c5e7c90ae93b"
     with pytest.raises(HTTPError):
         mixin._read_notebook(bad_content)
     other = path_to_intermediate(bad_content)
@@ -164,6 +166,8 @@ async def test_async_file_manager_mixin(tmpdir):
     mixin.log = logging.getLogger()
     bad_content = tmpdir / "bad_content.ipynb"
     bad_content.write_text("{}", "utf8")
+    # Same as `echo -n {} | md5sum`
+    assert await mixin._get_md5(bad_content) == "99914b932bd37a50b983c5e7c90ae93b"
     with pytest.raises(HTTPError):
         await mixin._read_notebook(bad_content)
     other = path_to_intermediate(bad_content)

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -571,6 +571,9 @@ async def test_get(jp_contents_manager):  # noqa
     nb_as_bin_file = await ensure_async(cm.get(path, content=True, type="file", format="base64"))
     assert nb_as_bin_file["format"] == "base64"
 
+    nb_with_md5 = await ensure_async(cm.get(path, md5=True))
+    assert nb_with_md5["md5"]
+
     # Test in sub-directory
     sub_dir = "/foo/"
     _make_dir(cm, "foo")
@@ -585,7 +588,7 @@ async def test_get(jp_contents_manager):  # noqa
 
     # Test with a regular file.
     file_model_path = (await ensure_async(cm.new_untitled(path=sub_dir, ext=".txt")))["path"]
-    file_model = await ensure_async(cm.get(file_model_path))
+    file_model = await ensure_async(cm.get(file_model_path, md5=True))
     expected_model = {
         "content": "",
         "format": "text",
@@ -600,6 +603,7 @@ async def test_get(jp_contents_manager):  # noqa
         assert file_model[key] == value
     assert "created" in file_model
     assert "last_modified" in file_model
+    assert "md5" in file_model
 
     # Create a sub-sub directory to test getting directory contents with a
     # subdir.


### PR DESCRIPTION
## Motivation

Currently, JupyterLab determines whether a file has been manually modified by another client or user by **comparing timestamps**. 

In this way, JupyterLab can prompt the user whether to overwrite the file on disk with the file on the current page, or discard the file on the current page.

This usually performs well on local storage. However, when users use remote storage such as nfs, samba, the modified time of the file is not reliable due to things such as network latency or storage back-end implementations. To solve this problem, https://github.com/jupyterlab/jupyterlab/pull/15037 tries to compare content by comparing them one by one, but this definitely increases the network overhead and client burden.

## What is this PR

I propose that this PR to **add md5 parameter to the contents API**. Any client can get the md5 value of the current file as it needs it and compare it to the previous value to make sure the file has not been modified by another program.

## Performance Impact

The server-side calculation of md5 values has essentially no performance impact and it's optional.

Create a 5M file with random bytes.

```bash
dd bs=1024 count=5120 </dev/urandom > 5mfile
```

Calculate its md5.

```python
import hashlib
def caculate(file):
    md5 = hashlib.md5()
    with open(file, "rb") as f:
        c = f.read()
    md5.update(c)
    return md5.hexdigest()
caculate("5mfile")
```

Here I'm using `hyperfine` to help me test it.

```
$hyperfine "python main.py"
Benchmark 1: python main.py
  Time (mean ± σ):      29.4 ms ±   1.4 ms    [User: 24.6 ms, System: 4.7 ms]
  Range (min … max):    27.6 ms …  34.8 ms    91 runs
```
