### PR TITLE
log extension import time at debug level unless it's actually slow

### DIFF
--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -68,7 +68,8 @@ def get_metadata(package_name, logger=None):
     # each module took to import. This makes it much easier for users to report
     # slow loading modules upstream, as slow loading modules will block server startup
     if logger:
-        logger.info(f"Package {package_name} took {duration:.4f}s to import")
+        log = logger.info if duration > 0.1 else logger.debug
+        log(f"Extension package {package_name} took {duration:.4f}s to import")
 
     try:
         return module, module._jupyter_server_extension_points()


### PR DESCRIPTION
avoids unnecessary noise most of the time, while still reporting when things are slow enough to cause a problem.