### PR TITLE
Enable htmlzip and epub on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,8 @@ python:
       path: .
       extra_requirements:
         - docs
+formats:
+  - epub
+  - htmlzip
+  # TODO: evaluate, see https://github.com/jupyter-server/jupyter_server/issues/1378
+  # - pdf


### PR DESCRIPTION
## References

- fixes #1378

## Changes

- [x] enable `htmlzip` and `epub` offline formats for ReadTheDocs
- [x] add a note about `pdf`, to investigate at a later date

## Notes

This _won't_ trigger on the per-PR-push docs build, so kinda needs to be merged to `main` be fully tested, with a quick revert if necessary.... or going through the hassle of making a fake site.