### PR TITLE
Fix a typo in error message

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -1025,7 +1025,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
             try:
                 send2trash(os_path)
             except OSError as e:
-                raise web.HTTPError(400, "send2trash f`1ailed: %s" % e) from e
+                raise web.HTTPError(400, "send2trash failed: %s" % e) from e
             return
 
         if os.path.isdir(os_path):


### PR DESCRIPTION
Fixing a minor typo introduced in https://github.com/jupyter-server/jupyter_server/pull/1291 which is visible in user-facing messages as seen in https://github.com/jupyterlab/jupyterlab/issues/15589