### PR TITLE
Simplify the jupytext downstream test

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -122,7 +122,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
-          test_command: pip install pytest-jupyter[server] gitpython pre-commit && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes --ignore=tests/test_doc_files_are_notebooks.py --ignore=tests/test_changelog.py
+          test_command: pip install pytest-jupyter[server] gitpython pre-commit && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --color=yes
 
   downstream_check: # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
Jupytext's documentation is now included in the Jupytext package (from `jupytext>=1.16.0`) so the `ignore` commands should not be needed anymore.