### PR TITLE
Import User unconditionally

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -30,8 +30,8 @@ from jupyter_server import CallContext
 from jupyter_server._sysinfo import get_sys_info
 from jupyter_server._tz import utcnow
 from jupyter_server.auth.decorator import authorized
-from jupyter_server.i18n import combine_translations
 from jupyter_server.auth.identity import User
+from jupyter_server.i18n import combine_translations
 from jupyter_server.services.security import csp_report_uri
 from jupyter_server.utils import (
     ensure_async,

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -31,6 +31,7 @@ from jupyter_server._sysinfo import get_sys_info
 from jupyter_server._tz import utcnow
 from jupyter_server.auth.decorator import authorized
 from jupyter_server.i18n import combine_translations
+from jupyter_server.auth.identity import User
 from jupyter_server.services.security import csp_report_uri
 from jupyter_server.utils import (
     ensure_async,
@@ -47,7 +48,7 @@ if TYPE_CHECKING:
     from tornado.concurrent import Future
 
     from jupyter_server.auth.authorizer import Authorizer
-    from jupyter_server.auth.identity import IdentityProvider, User
+    from jupyter_server.auth.identity import IdentityProvider
     from jupyter_server.serverapp import ServerApp
     from jupyter_server.services.config.manager import ConfigManager
     from jupyter_server.services.contents.manager import ContentsManager


### PR DESCRIPTION
It is used in a cast on line 617, rather than just a type annotation. Without this, requests fail with:

```
[E 2024-01-09 18:30:53.736 SingleUserNotebookApp web:1871] Uncaught exception GET /user/yuvi.panda@utoronto.ca/lab (10.1.0.10)
    HTTPServerRequest(protocol='https', host='jupyter.utoronto.ca', method='GET', uri='/user/yuvi.panda@utoronto.ca/lab', version='HTTP/1.1', remote_ip='10.1.0.10')
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.11/site-packages/tornado/web.py", line 1765, in _execute
        result = await result  # type: ignore
                 ^^^^^^^^^^^^
      File "/opt/conda/lib/python3.11/site-packages/jupyter_server/base/handlers.py", line 616, in prepare
        user = User(self.get_current_user())
               ^^^^
    NameError: name 'User' is not defined
```