### PR TITLE
Improve warning handling

### DIFF
--- a/jupyter_server/services/contents/largefilemanager.py
+++ b/jupyter_server/services/contents/largefilemanager.py
@@ -20,7 +20,7 @@ class LargeFileManager(FileContentsManager):
             path = path.strip("/")
 
             if chunk == 1:
-                self.run_pre_save_hook(model=model, path=path)
+                self.run_pre_save_hooks(model=model, path=path)
 
             if "type" not in model:
                 raise web.HTTPError(400, "No file type provided")
@@ -92,7 +92,7 @@ class AsyncLargeFileManager(AsyncFileContentsManager):
             path = path.strip("/")
 
             if chunk == 1:
-                self.run_pre_save_hook(model=model, path=path)
+                self.run_pre_save_hooks(model=model, path=path)
 
             if "type" not in model:
                 raise web.HTTPError(400, "No file type provided")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,13 +239,7 @@ timeout = 100
 timeout_method = "thread"
 filterwarnings = [
   "error",
-  "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
-  "ignore:run_pre_save_hook is deprecated:DeprecationWarning",
-  "always:unclosed <socket.socket:ResourceWarning",
-  "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
-  "ignore:jupyter_server.base.zmqhandlers module is deprecated in Jupyter Server 2.0:DeprecationWarning",
-  "ignore:datetime.datetime.utc:DeprecationWarning:dateutil",
-  "ignore:datetime.datetime.utc:DeprecationWarning:tornado",
+  "ignore:datetime.datetime.utc:DeprecationWarning",
   "module:add_callback_from_signal is deprecated:DeprecationWarning",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import os
 
+# isort: off
+# This must come before any Jupyter imports.
+os.environ["JUPYTER_PLATFORM_DIRS"] = "1"
+# isort: on
+
 import pytest
 from nbformat import writes
 from nbformat.v4 import new_notebook

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
 from io import StringIO
 from logging import StreamHandler
 from typing import Any
+from unittest import mock
 
 import pytest
 from traitlets.config import Config
@@ -121,12 +123,14 @@ OPEN_BROWSER_COMBINATIONS: Any = (
 
 @pytest.mark.parametrize("expected_value, config", OPEN_BROWSER_COMBINATIONS)
 async def test_browser_open(monkeypatch, jp_environ, config, expected_value):
-    serverapp = MockExtensionApp.initialize_server(config=Config(config))
+    with mock.patch("jupyter_server.serverapp.ServerApp.init_httpserver"):
+        serverapp = MockExtensionApp.initialize_server(config=Config(config))
     assert serverapp.open_browser == expected_value
 
 
 async def test_load_parallel_extensions(monkeypatch, jp_environ):
-    serverapp = MockExtensionApp.initialize_server()
+    with mock.patch("jupyter_server.serverapp.ServerApp.init_httpserver"):
+        serverapp = MockExtensionApp.initialize_server()
     exts = serverapp.extension_manager.extensions
     assert "tests.extension.mockextensions.mock1" in exts
     assert "tests.extension.mockextensions" in exts

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -715,20 +715,21 @@ async def test_websocket_connection_closed(init_gateway, jp_serverapp, jp_fetch,
     handler.ws_connection.is_closing = lambda: True
 
     # Create the GatewayWebSocketConnection and attach it to the handler...
-    conn = GatewayWebSocketConnection(parent=km, websocket_handler=handler)
-    handler.connection = conn
-    await conn.connect()
+    with mocked_gateway:
+        conn = GatewayWebSocketConnection(parent=km, websocket_handler=handler)
+        handler.connection = conn
+        await conn.connect()
 
-    # Processing websocket messages happens in separate coroutines and any
-    # errors in that process will show up in logs, but not bubble up to the
-    # caller.
-    #
-    # To check for these, we wait for the server to stop and then check the
-    # logs for errors.
-    await jp_serverapp._cleanup()
-    for _, level, message in caplog.record_tuples:
-        if level >= logging.ERROR:
-            pytest.fail(f"Logs contain an error: {message}")
+        # Processing websocket messages happens in separate coroutines and any
+        # errors in that process will show up in logs, but not bubble up to the
+        # caller.
+        #
+        # To check for these, we wait for the server to stop and then check the
+        # logs for errors.
+        await jp_serverapp._cleanup()
+        for _, level, message in caplog.record_tuples:
+            if level >= logging.ERROR:
+                pytest.fail(f"Logs contain an error: {message}")
 
 
 #


### PR DESCRIPTION
Address all but `add_callback_from_signal`, which will be handled by #1362.

I isolated the socket open problems with:

```python
@pytest.fixture(autouse=True)
def gc_cleanup():
    yield
    import gc
    gc.collect()
```