### PR TITLE
fix "Shutdown" -> "Shut down"

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2268,7 +2268,7 @@ class ServerApp(JupyterApp):
         info(self.running_server_info())
         yes = _i18n("y")
         no = _i18n("n")
-        sys.stdout.write(_i18n("Shutdown this Jupyter server (%s/[%s])? ") % (yes, no))
+        sys.stdout.write(_i18n("Shut down this Jupyter server (%s/[%s])? ") % (yes, no))
         sys.stdout.flush()
         r, w, x = select.select([sys.stdin], [], [], 5)
         if r:


### PR DESCRIPTION
"Shutdown" is a noun. "Shut down" is a verb. I don't like seeing this error when I shut down a server so I'm fixing it :)