### PR TITLE
websockets: add configurations for ping interval and timeout

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1525,7 +1525,7 @@ class ServerApp(JupyterApp):
 
     websocket_ping_interval = Integer(
         config=True,
-        help='''
+        help="""
             Configure the websocket ping interval in seconds.
 
             Websockets are long-lived connections that are used by some Jupyter
@@ -1538,15 +1538,15 @@ class ServerApp(JupyterApp):
             When a ping is sent, the client has ``websocket_ping_timeout``
             seconds to respond. If no response is received within this period,
             the connection will be closed from the server side.
-        ''',
+        """,
     )
     websocket_ping_timeout = Integer(
         config=True,
-        help='''
+        help="""
             Configure the websocket ping timeout in seconds.
 
             See ``websocket_ping_interval`` for details.
-        ''',
+        """,
     )
 
     config_manager_class = Type(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -240,6 +240,8 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        websocket_ping_interval=None,
+        websocket_ping_timeout=None,
     ):
         """Initialize a server web application."""
         if identity_provider is None:
@@ -277,6 +279,8 @@ class ServerWebApplication(web.Application):
             authorizer=authorizer,
             identity_provider=identity_provider,
             kernel_websocket_connection_class=kernel_websocket_connection_class,
+            websocket_ping_interval=websocket_ping_interval,
+            websocket_ping_timeout=websocket_ping_timeout,
         )
         handlers = self.init_handlers(default_services, settings)
 
@@ -301,6 +305,8 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        websocket_ping_interval=None,
+        websocket_ping_timeout=None,
     ):
         """Initialize settings for the web application."""
         _template_path = settings_overrides.get(
@@ -383,6 +389,8 @@ class ServerWebApplication(web.Application):
             "identity_provider": identity_provider,
             "event_logger": event_logger,
             "kernel_websocket_connection_class": kernel_websocket_connection_class,
+            "websocket_ping_interval": websocket_ping_interval,
+            "websocket_ping_timeout": websocket_ping_timeout,
             # handlers
             "extra_services": extra_services,
             # Jupyter stuff
@@ -1515,6 +1523,32 @@ class ServerApp(JupyterApp):
             return "jupyter_server.gateway.connections.GatewayWebSocketConnection"
         return ZMQChannelsWebsocketConnection
 
+    websocket_ping_interval = Integer(
+        config=True,
+        help='''
+            Configure the websocket ping interval in seconds.
+
+            Websockets are long-lived connections that are used by some Jupyter
+            Server extensions.
+
+            Periodic pings help to detect disconnected clients and keep the
+            connection active. If this is set to None, then no pings will be
+            performed.
+
+            When a ping is sent, the client has ``websocket_ping_timeout``
+            seconds to respond. If no response is received within this period,
+            the connection will be closed from the server side.
+        ''',
+    )
+    websocket_ping_timeout = Integer(
+        config=True,
+        help='''
+            Configure the websocket ping timeout in seconds.
+
+            See ``websocket_ping_interval`` for details.
+        ''',
+    )
+
     config_manager_class = Type(
         default_value=ConfigManager,
         config=True,
@@ -2101,6 +2135,8 @@ class ServerApp(JupyterApp):
             authorizer=self.authorizer,
             identity_provider=self.identity_provider,
             kernel_websocket_connection_class=self.kernel_websocket_connection_class,
+            websocket_ping_interval=self.websocket_ping_interval,
+            websocket_ping_timeout=self.websocket_ping_timeout,
         )
         if self.certfile:
             self.ssl_options["certfile"] = self.certfile


### PR DESCRIPTION
Hi all :wave:

I needed to configure the Tornado `websocket_ping_interval` and `websocket_ping_timeout` settings for a deployment (see [Tornado docs](https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler)) but couldn't see how to do so.

This PR adds configurable traits for these two ping configurations with `None` defaults to match the current behaviour (i.e. don't send heartbeat pings).

Questions:
1. Is this the right approach? Apologies if I've overlooked something.
2. Should the default be `None` or would it make sense to send heartbeat pings by default?