### PR TITLE
Add an option to have authentication enabled for all endpoints by default

### DIFF
--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -95,7 +95,7 @@ def allow_unauthenticated(method: FuncT) -> FuncT:
     is active when `ServerApp.allow_unauthenticated_access = False`.
 
     To be used exclusively on endpoints which may be considered public,
-    for example the logic page handler.
+    for example the login page handler.
 
     .. versionadded:: 2.13
 

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -106,12 +106,8 @@ def allow_unauthenticated(method: FuncT) -> FuncT:
     """
 
     @wraps(method)
-    async def wrapper(self, *args, **kwargs):
-        out = method(self, *args, **kwargs)
-        # If the method is a coroutine, await it
-        if asyncio.iscoroutine(out):
-            return await out
-        return out
+    def wrapper(self, *args, **kwargs):
+        return method(self, *args, **kwargs)
 
     setattr(wrapper, "__allow_unauthenticated", True)
 

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -85,3 +85,30 @@ def authorized(
         return cast(FuncT, wrapper(method))
 
     return cast(FuncT, wrapper)
+
+
+def allow_unauthenticated(method: FuncT) -> FuncT:
+    """A decorator for tornado.web.RequestHandler methods
+    that allows any user to make the following request.
+
+    Selectively disables the 'authentication' layer of REST API which
+    is active when `ServerApp.allow_unauthenticated_access = False`.
+
+    To be used exclusively on endpoints which may be considered public,
+    for example the logic page handler.
+
+    .. versionadded:: 2.13
+
+    Parameters
+    ----------
+    method : bound callable
+        the endpoint method to remove authentication from.
+    """
+
+    @wraps(method)
+    async def wrapper(self, *args, **kwargs):
+        return method(self, *args, **kwargs)
+
+    setattr(wrapper, "__allow_unauthenticated", True)
+
+    return cast(FuncT, wrapper)

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -107,7 +107,11 @@ def allow_unauthenticated(method: FuncT) -> FuncT:
 
     @wraps(method)
     async def wrapper(self, *args, **kwargs):
-        return method(self, *args, **kwargs)
+        out = method(self, *args, **kwargs)
+        # If the method is a coroutine, await it
+        if asyncio.iscoroutine(out):
+            return await out
+        return out
 
     setattr(wrapper, "__allow_unauthenticated", True)
 

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from tornado.escape import url_escape
 
 from ..base.handlers import JupyterHandler
+from .decorator import allow_unauthenticated
 from .security import passwd_check, set_password
 
 
@@ -73,6 +74,7 @@ class LoginFormHandler(JupyterHandler):
                 url = default
         self.redirect(url)
 
+    @allow_unauthenticated
     def get(self):
         """Get the login form."""
         if self.current_user:
@@ -81,6 +83,7 @@ class LoginFormHandler(JupyterHandler):
         else:
             self._render()
 
+    @allow_unauthenticated
     def post(self):
         """Post a login."""
         user = self.current_user = self.identity_provider.process_login_form(self)
@@ -110,6 +113,7 @@ class LegacyLoginHandler(LoginFormHandler):
         """Check a passwd."""
         return passwd_check(a, b)
 
+    @allow_unauthenticated
     def post(self):
         """Post a login form."""
         typed_password = self.get_argument("password", default="")

--- a/jupyter_server/auth/logout.py
+++ b/jupyter_server/auth/logout.py
@@ -3,11 +3,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from ..base.handlers import JupyterHandler
+from .decorator import allow_unauthenticated
 
 
 class LogoutHandler(JupyterHandler):
     """An auth logout handler."""
 
+    @allow_unauthenticated
     def get(self):
         """Handle a logout."""
         self.identity_provider.clear_login_cookie(self)

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -1130,7 +1130,7 @@ class FilesRedirectHandler(JupyterHandler):
         self.log.debug("Redirecting %s to %s", self.request.path, url)
         self.redirect(url)
 
-    @web.authenticated
+    @allow_unauthenticated
     async def get(self, path: str = "") -> None:
         return await self.redirect_to_files(self, path)
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -638,7 +638,7 @@ class JupyterHandler(AuthenticatedHandler):
             if not getattr(method, "__allow_unauthenticated", False):
                 # reuse `web.authenticated` logic, which redirects to the login
                 # page on GET and HEAD and otherwise raises 403
-                return web.authenticated(lambda _method: None)(self)
+                return web.authenticated(lambda _: super().prepare)(self)
 
         return super().prepare()
 

--- a/jupyter_server/base/websocket.py
+++ b/jupyter_server/base/websocket.py
@@ -97,6 +97,7 @@ class WebSocketMixin:
                     self.log.warning("Couldn't authenticate WebSocket connection")
                     raise web.HTTPError(403)
 
+    @no_type_check
     def prepare(self, *args, **kwargs):
         """Handle a get request."""
         self._maybe_auth()

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -358,7 +358,7 @@ class ExtensionApp(JupyterApp):
             )
             new_handlers.append(handler)
 
-        webapp.add_handlers(".*$", new_handlers)  # type:ignore[arg-type]
+        webapp.add_handlers(".*$", new_handlers)
 
     def _prepare_templates(self):
         """Add templates to web app settings if extension has templates."""

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -311,19 +311,16 @@ class ServerWebApplication(web.Application):
                 matcher, handler, *_ = rule
             undecorated_methods.extend(self._check_handler_auth(matcher, handler))
 
-        if undecorated_methods:
+        if undecorated_methods and not self.settings["allow_unauthenticated_access"]:
             message = (
                 "Extension endpoints without @allow_unauthenticated, @ws_authenticated, nor @web.authenticated:\n"
                 + "\n".join(undecorated_methods)
             )
-            if self.settings["allow_unauthenticated_access"]:
-                warnings.warn(
-                    message,
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-            else:
-                raise Exception(message)
+            warnings.warn(
+                message,
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
         return super().add_handlers(host_pattern, host_handlers)
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -116,6 +116,7 @@ from jupyter_server.services.kernels.kernelmanager import (
 )
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
+    JupyterServerAuthWarning,
     check_pid,
     fetch,
     unix_socket_in_use,
@@ -256,7 +257,7 @@ class ServerWebApplication(web.Application):
             warnings.warn(
                 "authorizer unspecified. Using permissive AllowAllAuthorizer."
                 " Specify an authorizer to avoid this message.",
-                RuntimeWarning,
+                JupyterServerAuthWarning,
                 stacklevel=2,
             )
             authorizer = AllowAllAuthorizer(parent=jupyter_app, identity_provider=identity_provider)
@@ -293,7 +294,7 @@ class ServerWebApplication(web.Application):
             if jupyter_app.allow_unauthenticated_access:
                 warnings.warn(
                     message,
-                    RuntimeWarning,
+                    JupyterServerAuthWarning,
                     stacklevel=2,
                 )
             else:
@@ -318,7 +319,7 @@ class ServerWebApplication(web.Application):
             )
             warnings.warn(
                 message,
-                RuntimeWarning,
+                JupyterServerAuthWarning,
                 stacklevel=2,
             )
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1275,10 +1275,12 @@ class ServerApp(JupyterApp):
         """,
     )
 
+    _allow_unauthenticated_access_env = "JUPYTER_SERVER_ALLOW_UNAUTHENTICATED_ACCESS"
+
     allow_unauthenticated_access = Bool(
         True,
         config=True,
-        help="""Allow requests unauthenticated access to endpoints without authentication rules.
+        help=f"""Allow unauthenticated access to endpoints without authentication rule.
 
         When set to `True` (default in jupyter-server 2.0, subject to change
         in the future), any request to an endpoint without an authentication rule
@@ -1287,8 +1289,18 @@ class ServerApp(JupyterApp):
 
         When set to `False`, logging in will be required for access to each endpoint,
         excluding the endpoints marked with `@allow_unauthenticated` decorator.
+
+        This option can be configured using `{_allow_unauthenticated_access_env}`
+        environment variable: any non-empty value other than "true" and "yes" will
+        prevent unauthenticated access to endpoints without `@allow_unauthenticated`.
         """,
     )
+
+    @default("allow_unauthenticated_access")
+    def _allow_unauthenticated_access_default(self):
+        if os.getenv(self._allow_unauthenticated_access_env):
+            return os.environ[self._allow_unauthenticated_access_env].lower() in ["true", "yes"]
+        return True
 
     allow_remote_access = Bool(
         config=True,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -529,7 +529,9 @@ class ServerWebApplication(web.Application):
         sources.extend(self.settings["last_activity_times"].values())
         return max(sources)
 
-    def _check_handler_auth(self, matcher: t.Union[str, Matcher], handler: web.RequestHandler):
+    def _check_handler_auth(
+        self, matcher: t.Union[str, Matcher], handler: type[web.RequestHandler]
+    ):
         missing_authentication = []
         for method_name in handler.SUPPORTED_METHODS:
             method = getattr(handler, method_name.lower())
@@ -540,7 +542,7 @@ class ServerWebApplication(web.Application):
             )  # TODO: can we make web.auth leave a better footprint?
             if not is_unimplemented and not is_allowlisted and not possibly_blocklisted:
                 missing_authentication.append(
-                    f"- {method_name} of {handler.__class__.__name__} registered for {matcher}"
+                    f"- {method_name} of {handler.__name__} registered for {matcher}"
                 )
         return missing_authentication
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -538,10 +538,9 @@ class ServerWebApplication(web.Application):
             method = getattr(handler, method_name.lower())
             is_unimplemented = method == web.RequestHandler._unimplemented_method
             is_allowlisted = hasattr(method, "__allow_unauthenticated")
-            possibly_blocklisted = hasattr(
-                method, "__wrapped__"
-            )  # TODO: can we make web.auth leave a better footprint?
-            if not is_unimplemented and not is_allowlisted and not possibly_blocklisted:
+            # TODO: modify `tornado.web.authenticated` upstream?
+            is_blocklisted = method.__code__.co_qualname.startswith("authenticated")
+            if not is_unimplemented and not is_allowlisted and not is_blocklisted:
                 missing_authentication.append(
                     f"- {method_name} of {handler.__name__} registered for {matcher}"
                 )

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -370,6 +370,7 @@ class ServerWebApplication(web.Application):
             "login_url": url_path_join(base_url, "/login"),
             "xsrf_cookies": True,
             "disable_check_xsrf": jupyter_app.disable_check_xsrf,
+            "allow_unauthenticated_access": jupyter_app.allow_unauthenticated_access,
             "allow_remote_access": jupyter_app.allow_remote_access,
             "local_hostnames": jupyter_app.local_hostnames,
             "authenticate_prometheus": jupyter_app.authenticate_prometheus,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1214,6 +1214,21 @@ class ServerApp(JupyterApp):
         """,
     )
 
+    allow_unauthenticated_access = Bool(
+        True,
+        config=True,
+        help="""Allow requests unauthenticated access to endpoints without authentication rules.
+
+        When set to `True` (default in jupyter-server 2.0, subject to change
+        in the future), any request to an endpoint without an authentication rule
+        (either `@tornado.web.authenticated`, or `@allow_unauthenticated`)
+        will be permitted, regardless of whether user has logged in or not.
+
+        When set to `False`, logging in will be required for access to each endpoint,
+        excluding the endpoints marked with `@allow_unauthenticated` decorator.
+        """,
+    )
+
     allow_remote_access = Bool(
         config=True,
         help="""Allow requests where the Host header doesn't point to a local server

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -27,6 +27,11 @@ class APISpecHandler(web.StaticFileHandler, JupyterHandler):
 
     @web.authenticated
     @authorized
+    def head(self):
+        return self.get("api.yaml", include_body=False)
+
+    @web.authenticated
+    @authorized
     def get(self):
         """Get the API spec."""
         self.log.warning("Serving api spec (experimental, incomplete)")

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -16,7 +16,7 @@ except ImportError:
 from jupyter_core.utils import ensure_async
 from tornado import web
 
-from jupyter_server.auth.decorator import authorized
+from jupyter_server.auth.decorator import allow_unauthenticated, authorized
 from jupyter_server.base.handlers import APIHandler, JupyterHandler, path_regex
 from jupyter_server.utils import url_escape, url_path_join
 
@@ -400,6 +400,7 @@ class NotebooksRedirectHandler(JupyterHandler):
         "DELETE",
     )  # type:ignore[assignment]
 
+    @allow_unauthenticated
     def get(self, path):
         """Handle a notebooks redirect."""
         self.log.warning("/api/notebooks is deprecated, use /api/contents")

--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -6,6 +6,7 @@ from jupyter_core.utils import ensure_async
 from tornado import web
 from tornado.websocket import WebSocketHandler
 
+from jupyter_server.auth.decorator import ws_authenticated
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.base.websocket import WebSocketMixin
 
@@ -34,11 +35,7 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
 
     async def pre_get(self):
         """Handle a pre_get."""
-        # authenticate first
         user = self.current_user
-        if user is None:
-            self.log.warning("Couldn't authenticate WebSocket connection")
-            raise web.HTTPError(403)
 
         # authorize the user.
         authorized = await ensure_async(
@@ -61,6 +58,7 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
         if hasattr(self.connection, "prepare"):
             await self.connection.prepare()
 
+    @ws_authenticated
     async def get(self, kernel_id):
         """Handle a get request for a kernel."""
         self.kernel_id = kernel_id

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -439,3 +439,7 @@ def import_item(name: str) -> Any:
     else:
         # called with un-dotted string
         return __import__(parts[0])
+
+
+class JupyterServerAuthWarning(RuntimeWarning):
+    """A subclass of runtime warnings to allow for filtering in tests"""

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -442,4 +442,8 @@ def import_item(name: str) -> Any:
 
 
 class JupyterServerAuthWarning(RuntimeWarning):
-    """A subclass of runtime warnings to allow for filtering in tests"""
+    """Emitted when authentication configuration issue is detected.
+
+    Intended for filtering out expected warnings in tests, including
+    downstream tests, rather than for users to silence this warning.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,6 +241,7 @@ filterwarnings = [
   "error",
   "ignore:datetime.datetime.utc:DeprecationWarning",
   "module:add_callback_from_signal is deprecated:DeprecationWarning",
+  "ignore::jupyter_server.utils.JupyterServerAuthWarning"
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "ipykernel",
     "pytest-console-scripts",
     "pytest-timeout",
-    "pytest-jupyter[server]>=0.4",
+    "pytest-jupyter[server]>=0.7",
     "pytest>=7.0",
     "requests",
     "pre-commit",

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -3,10 +3,13 @@ import os
 import warnings
 from unittest.mock import MagicMock
 
+import pytest
+from tornado.httpclient import HTTPClientError
 from tornado.httpserver import HTTPRequest
 from tornado.httputil import HTTPHeaders
 
 from jupyter_server.auth import AllowAllAuthorizer, IdentityProvider
+from jupyter_server.auth.decorator import allow_unauthenticated
 from jupyter_server.base.handlers import (
     APIHandler,
     APIVersionHandler,
@@ -18,6 +21,7 @@ from jupyter_server.base.handlers import (
     RedirectWithParams,
 )
 from jupyter_server.serverapp import ServerApp
+from jupyter_server.utils import url_path_join
 
 
 def test_authenticated_handler(jp_serverapp):
@@ -59,6 +63,65 @@ def test_jupyter_handler(jp_serverapp):
     handler.settings["allow_credentials"] = True
     handler.set_cors_headers()
     assert handler.check_referer() is True
+
+
+class NoAuthRulesHandler(JupyterHandler):
+    def options(self) -> None:
+        self.finish({})
+
+
+class PermissiveHandler(JupyterHandler):
+    @allow_unauthenticated
+    def options(self) -> None:
+        self.finish({})
+
+
+@pytest.mark.parametrize(
+    "jp_server_config", [{"ServerApp": {"allow_unauthenticated_access": True}}]
+)
+async def test_jupyter_handler_auth_permissive(jp_serverapp, jp_fetch):
+    app: ServerApp = jp_serverapp
+    app.web_app.add_handlers(
+        ".*$",
+        [
+            (url_path_join(app.base_url, "no-rules"), NoAuthRulesHandler),
+            (url_path_join(app.base_url, "permissive"), PermissiveHandler),
+        ],
+    )
+
+    # should allow access by default when no authentication rules are set up
+    res = await jp_fetch("no-rules", method="OPTIONS", headers={"Authorization": ""})
+    assert res.code == 200
+
+    # should allow access by default when `@allow_unauthenticated` is used
+    res = await jp_fetch("permissive", method="OPTIONS", headers={"Authorization": ""})
+    assert res.code == 200
+
+
+@pytest.mark.parametrize(
+    "jp_server_config", [{"ServerApp": {"allow_unauthenticated_access": False}}]
+)
+async def test_jupyter_handler_auth_required(jp_serverapp, jp_fetch):
+    app: ServerApp = jp_serverapp
+    app.web_app.add_handlers(
+        ".*$",
+        [
+            (url_path_join(app.base_url, "no-rules"), NoAuthRulesHandler),
+            (url_path_join(app.base_url, "permissive"), PermissiveHandler),
+        ],
+    )
+
+    # should permit access when `@allow_unauthenticated` is used
+    res = await jp_fetch("permissive", method="OPTIONS", headers={"Authorization": ""})
+    assert res.code == 200
+
+    # should forbid access when no authentication rules are set up
+    with pytest.raises(HTTPClientError) as exception:
+        # note: using OPTIONS because GET and HEAD cause redirects to login page
+        # which prevents the test from finishing; disabling `follow_redirects`
+        # is not supported by `jp_fetch` yet.
+        res = await jp_fetch("no-rules", method="OPTIONS", headers={"Authorization": ""})
+    assert exception.value.code == 403
 
 
 def test_api_handler(jp_serverapp):

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -89,12 +89,12 @@ async def test_jupyter_handler_auth_permissive(jp_serverapp, jp_fetch):
         ],
     )
 
-    # should allow access by default when no authentication rules are set up
-    res = await jp_fetch("no-rules", method="OPTIONS", headers={"Authorization": ""})
+    # should always permit access when `@allow_unauthenticated` is used
+    res = await jp_fetch("permissive", method="OPTIONS", headers={"Authorization": ""})
     assert res.code == 200
 
-    # should allow access by default when `@allow_unauthenticated` is used
-    res = await jp_fetch("permissive", method="OPTIONS", headers={"Authorization": ""})
+    # should allow access when no authentication rules are set up
+    res = await jp_fetch("no-rules", method="OPTIONS", headers={"Authorization": ""})
     assert res.code == 200
 
 
@@ -111,7 +111,7 @@ async def test_jupyter_handler_auth_required(jp_serverapp, jp_fetch):
         ],
     )
 
-    # should permit access when `@allow_unauthenticated` is used
+    # should always permit access when `@allow_unauthenticated` is used
     res = await jp_fetch("permissive", method="OPTIONS", headers={"Authorization": ""})
     assert res.code == 200
 

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from tornado.httpclient import HTTPClientError
 
 
 @pytest.fixture()

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -163,6 +163,26 @@ def test_server_password(tmp_path, jp_configurable_serverapp):
         passwd_check(sv.identity_provider.hashed_password, password)
 
 
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ["yes", True],
+        ["Yes", True],
+        ["True", True],
+        ["true", True],
+        ["TRUE", True],
+        ["no", False],
+        ["nooo", False],
+        ["FALSE", False],
+        ["false", False],
+    ],
+)
+def test_allow_unauthenticated_env_var(jp_configurable_serverapp, env, expected):
+    with patch.dict("os.environ", {"JUPYTER_SERVER_ALLOW_UNAUTHENTICATED_ACCESS": env}):
+        app = jp_configurable_serverapp()
+        assert app.allow_unauthenticated_access == expected
+
+
 def test_list_running_servers(jp_serverapp, jp_web_app):
     servers = list(list_running_servers(jp_serverapp.runtime_dir))
     assert len(servers) >= 1


### PR DESCRIPTION
Opening a draft for early feedback on naming and implementation.

### References

Closes #389

Builds upon @yuvipanda's idea of using `prepare` method as described in https://github.com/jupyter-server/jupyter_server/issues/1012#issuecomment-1926355878.

### Code changes

- adds `ServerApp.allow_unauthenticated_access` traitlet (True by default for backwards compatibility)
- adds `@allow_unauthenticated` decorator, an opposite of Torando's `@web.authenticated`
- if `allow_unauthenticated_access` is False rejects requests to endpoints which do not have `@allow_unauthenticated` decorator for any non-authenticated user

### Punchlist

- [x] add a test for `ServerApp.allow_unauthenticated_access` and `@allow_unauthenticated`
- [x] add a test ensuring that all methods on all `JupyterHandler` descendants in jupyter-server have either `@web.authenticated` or `@allow_unauthenticated`
   - maybe make it a runtime warning?
   - maybe also add a runtime warning if any handlers which inherit directly from `web.RequestHandler` rather than `AuthenticatedHandler`/`JupyterHandler` get registered with the router?
   - maybe raise or warn if both `@allow_unauthenticated` and `@web.authenticated` are set?
- [x] check if any other endpoint beside `login` and `logout` requires `@allow_unauthenticated`
- [x] support websockets in the same way
- [x] <s>consider moving the logic to `AuthenticatedHandler`, but this also requires setting `current_user` in `AuthenticatedHandler`; I do not understand why it is only set in `JupyterHandler`</s> I opened https://github.com/jupyter-server/jupyter_server/issues/1398 to track this as a future improvement