### PR TITLE
Add deprecation note for `ServerApp.preferred_dir`

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1740,7 +1740,9 @@ class ServerApp(JupyterApp):
 
     preferred_dir = Unicode(
         config=True,
-        help=trans.gettext("Preferred starting directory to use for notebooks and kernels. ServerApp.preferred_dir is deprecated in jupyter-server 2.0. Use FileContentsManager.preferred_dir instead"),
+        help=trans.gettext(
+            "Preferred starting directory to use for notebooks and kernels. ServerApp.preferred_dir is deprecated in jupyter-server 2.0. Use FileContentsManager.preferred_dir instead"
+        ),
     )
 
     @default("preferred_dir")

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1740,7 +1740,7 @@ class ServerApp(JupyterApp):
 
     preferred_dir = Unicode(
         config=True,
-        help=trans.gettext("Preferred starting directory to use for notebooks and kernels."),
+        help=trans.gettext("Preferred starting directory to use for notebooks and kernels. ServerApp.preferred_dir is deprecated in jupyter-server 2.0. Use FileContentsManager.preferred_dir instead"),
     )
 
     @default("preferred_dir")


### PR DESCRIPTION
Passing `--ServerApp.preferred_dir` warns:

```
FutureWarning: ServerApp.preferred_dir config is deprecated in jupyter-server 2.0. Use FileContentsManager.preferred_dir instead
  return self._get_trait_default_generator(names[0])(self)
```

This is the case since https://github.com/jupyter-server/jupyter_server/pull/1162 see:

https://github.com/jupyter-server/jupyter_server/blob/62f4ca250c945dc8953f4d7e5c6f99b516279730/jupyter_server/services/contents/filemanager.py#L79-L84

but this is not documented. This PR adds the warning to trait description for it to be picked up by the docs.


Of note this will not affect the description of the other trait as it is redefined in:

https://github.com/jupyter-server/jupyter_server/blob/62f4ca250c945dc8953f4d7e5c6f99b516279730/jupyter_server/services/contents/manager.py#L83-L89