### PR TITLE
Fix color in windows log console with colorama

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -45,6 +45,14 @@ from tornado.netutil import bind_sockets
 if not sys.platform.startswith("win"):
     from tornado.netutil import bind_unix_socket
 
+if sys.platform.startswith("win"):
+    try:
+        import colorama
+
+        colorama.init()
+    except ImportError:
+        pass
+
 from traitlets import (
     Any,
     Bool,


### PR DESCRIPTION
Fixes #943

Fix color in windows log console with colorama. Screenshots below are on Windows.

Before:
![image](https://github.com/jupyter-server/jupyter_server/assets/131813389/1bd6eba7-d726-43e6-8b5e-2d4517cce3eb)

After:
![image](https://github.com/jupyter-server/jupyter_server/assets/131813389/921da622-ce3a-448e-b2e2-f6ddfbadba05)
