### PR TITLE
Pin to Pytest 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "pytest-console-scripts",
     "pytest-timeout",
     "pytest-jupyter[server]>=0.7",
-    "pytest>=7.0",
+    "pytest>=7.0,<8",
     "requests",
     "pre-commit",
     'flaky'


### PR DESCRIPTION
We'll need https://github.com/box/flaky/pull/199 before flaky is compatible.