### PR TITLE
Ignore zero-length page_config.json, restore previous behavior of crashing for invalid JSON

### DIFF
--- a/jupyter_server/config_manager.py
+++ b/jupyter_server/config_manager.py
@@ -101,12 +101,9 @@ class BaseJSONConfigManager(LoggingConfigurable):
         )
         data: dict[str, t.Any] = {}
         for path in paths:
-            if os.path.isfile(path):
+            if os.path.isfile(path) and os.path.getsize(path):
                 with open(path, encoding="utf-8") as f:
-                    try:
-                        recursive_update(data, json.load(f))
-                    except json.decoder.JSONDecodeError:
-                        self.log.warn("Invalid JSON in %s, skipping", path)
+                    recursive_update(data, json.load(f))
         return data
 
     def set(self, section_name: str, data: t.Any) -> None:

--- a/jupyter_server/config_manager.py
+++ b/jupyter_server/config_manager.py
@@ -103,7 +103,10 @@ class BaseJSONConfigManager(LoggingConfigurable):
         for path in paths:
             if os.path.isfile(path):
                 with open(path, encoding="utf-8") as f:
-                    recursive_update(data, json.load(f))
+                    try:
+                        recursive_update(data, json.load(f))
+                    except json.decoder.JSONDecodeError:
+                        self.log.warn("Invalid JSON in %s, skipping", path)
         return data
 
     def set(self, section_name: str, data: t.Any) -> None:


### PR DESCRIPTION
Hi,

Thanks for merging my earlier patch! 

Please see the comments here from @manics and @krassowski here (https://github.com/jupyterlab/jupyterlab_server/pull/444) on a similar patch for jupyterlab_server.  There are reasonable arguments to be made for continuing to crash on invalid JSON.  

I've prepared this PR which preserves the previous behavior and only ignores the page_config.json file if it's zero-length.