### PR TITLE
don't include token in dashboard link, when available

### DIFF
--- a/jupyter_server/templates/page.html
+++ b/jupyter_server/templates/page.html
@@ -34,8 +34,7 @@
 
   <div id="header" role="navigation" aria-label="{% trans %}Top Menu{% endtrans %}">
     <div id="header-container" class="container">
-      <div id="jupyter_server" class="nav navbar-brand"><a href="{{default_url}}
-    {%- if logged_in and token -%}?token={{token}}{%- endif -%}" title='{% trans %}dashboard{% endtrans %}'>
+      <div id="jupyter_server" class="nav navbar-brand"><a href="{{default_url}}" title='{% trans %}dashboard{% endtrans %}'>
           {% block logo %}<img src='{{static_url("logo/logo.png") }}' alt='Jupyter Server' />{% endblock %}
         </a></div>
 


### PR DESCRIPTION
this was added to make transferrable login more convenient [long ago](https://github.com/jupyter/notebook/issues/2094), but persisting passwords are the way to go these days, and this isn't the right thing to do in e.g. jupyterhub

ref: https://discourse.jupyter.org/t/is-it-possible-to-avoid-exposing-token-in-get-parameter-in-jupyterhub/24367

This is not a vulnerability, just an improvement in where we pass tokens and when.