### PR TITLE
docs: list server extensions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ copyright = "2020, Jupyter Team, https://jupyter.org"
 author = "The Jupyter Team"
 
 # ghissue config
-github_project_url = "https://github.com/jupyter/jupyter_server"
+github_project_url = "https://github.com/jupyter-server/jupyter_server"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/contributors/team-meetings.rst
+++ b/docs/source/contributors/team-meetings.rst
@@ -23,7 +23,7 @@ Also check out Jupyter Server's roadmap where we track future plans for Jupyter 
 
 `Jupyter Server 2.0 Discussion <https://github.com/jupyter-server/team-compass/issues/24>`_
 
-`Archived roadmap <https://github.com/jupyter/jupyter_server/issues/127>`_
+`Archived roadmap <https://github.com/jupyter-server/jupyter_server/issues/127>`_
 
 Jupyter Calendar
 ----------------

--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -6,8 +6,12 @@ Server Extensions
 
 A Jupyter Server extension is typically a module or package that extends to Server’s REST API/endpoints—i.e. adds extra request handlers to Server’s Tornado Web Application.
 
-You can check some simple examples on the `examples folder
+For examples of jupyter server extensions, see the
+:ref:`homepage <examples of jupyter server extensions>`.
+
+To get started writing your own extension, see the simple examples in the `examples folder
 <https://github.com/jupyter/jupyter_server/tree/main/examples/simple>`_ in the GitHub jupyter_server repository.
+
 
 Authoring a basic server extension
 ==================================

--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -10,7 +10,7 @@ For examples of jupyter server extensions, see the
 :ref:`homepage <examples of jupyter server extensions>`.
 
 To get started writing your own extension, see the simple examples in the `examples folder
-<https://github.com/jupyter/jupyter_server/tree/main/examples/simple>`_ in the GitHub jupyter_server repository.
+<https://github.com/jupyter-server/jupyter_server/tree/main/examples/simple>`_ in the GitHub jupyter_server repository.
 
 
 Authoring a basic server extension

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,8 @@ You've landed on the documentation pages for the **Jupyter Server** Project. Som
 Introduction
 ------------
 
-Jupyter Server is the backend—the core services, APIs, and `REST endpoints`_—to Jupyter web applications.
+Jupyter Server is the backend that provides the core services, APIs, and
+`REST endpoints`_ for Jupyter web applications.
 
 .. note::
 
@@ -20,6 +21,34 @@ Jupyter Server is the backend—the core services, APIs, and `REST endpoints`_�
 .. _Tornado: https://www.tornadoweb.org/en/stable/
 .. _Jupyter Notebook: https://github.com/jupyter/notebook
 .. _REST endpoints: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/main/jupyter_server/services/api/api.yaml
+
+
+Applications
+------------
+
+Jupyter Server extensions can use the framework and services provided by
+Jupyter Server to create applications and services.
+
+Examples of Jupyter Server extensions include:
+
+.. _examples of jupyter server extensions:
+
+`Jupyter Lab <https://jupyterlab.readthedocs.io>`_
+   JupyterLab computational environment.
+`Jupyter Resource Usage <https://github.com/jupyter-server/jupyter-resource-usage>`_
+   Jupyter Notebook Extension for monitoring your own resource usage.
+`Jupyter Scheduler <https://jupyter-scheduler.readthedocs.io>`_
+   Run Jupyter notebooks as jobs.
+`jupyter-collaboration <https://jupyterlab-realtime-collaboration.readthedocs.io>`_
+   A Jupyter Server Extension Providing Support for Y Documents.
+`NbClassic <https://jupyterlab.readthedocs.io>`_
+   Jupyter notebook as a Jupyter Server extension.
+`Cylc UI Server <https://cylc.org>`_
+   A Jupyter Server extension that serves the cylc-ui web application for
+   monitoring and controlling Cylc workflows.
+
+For more information on extensions, see :ref:`extensions`.
+
 
 Who's this for?
 ---------------
@@ -32,6 +61,7 @@ The Jupyter Server is a highly technical piece of the Jupyter Stack, so we've se
 4. :ref:`Contributors <contributors>`: people contributing directly to the Jupyter Server library.
 
 If you finds gaps in our documentation, please open an issue (or better, a pull request) on the Jupyter Server `Github repo <https://github.com/jupyter/jupyter_server>`_.
+
 
 Table of Contents
 -----------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Welcome!
 
 You've landed on the documentation pages for the **Jupyter Server** Project. Some other pages you may have been looking for:
 
-* `Jupyter Server Github Repo <https://github.com/jupyter/jupyter_server>`_, the source code we describe in this code.
+* `Jupyter Server Github Repo <https://github.com/jupyter-server/jupyter_server>`_, the source code we describe in this code.
 * `Jupyter Notebook Github Repo <https://github.com/jupyter/notebook>`_ , the source code for the classic Notebook.
 * `JupyterLab Github Repo <https://github.com/jupyterlab/jupyterlab>`_, the JupyterLab server which runs on the Jupyter Server.
 
@@ -60,7 +60,7 @@ The Jupyter Server is a highly technical piece of the Jupyter Stack, so we've se
 3. :ref:`Developers <developers>`: people writing Jupyter Server extensions and web applications.
 4. :ref:`Contributors <contributors>`: people contributing directly to the Jupyter Server library.
 
-If you finds gaps in our documentation, please open an issue (or better, a pull request) on the Jupyter Server `Github repo <https://github.com/jupyter/jupyter_server>`_.
+If you finds gaps in our documentation, please open an issue (or better, a pull request) on the Jupyter Server `Github repo <https://github.com/jupyter-server/jupyter_server>`_.
 
 
 Table of Contents

--- a/docs/source/other/links.rst
+++ b/docs/source/other/links.rst
@@ -2,7 +2,7 @@ List of helpful links
 =====================
 
 * :ref:`Frequently Asked Questions <faq>`
-* `Jupyter Server Github Repo <https://github.com/jupyter/jupyter_server>`_
+* `Jupyter Server Github Repo <https://github.com/jupyter-server/jupyter_server>`_
 * `JupyterLab Github Repo <https://github.com/jupyterlab/jupyterlab>`_
 * `Jupyter Notebook Github Repo <https://github.com/jupyter/notebook>`_
 * `Jupyterhub Github Repo <https://github.com/jupyterhub/jupyterhub>`_

--- a/docs/source/users/help.rst
+++ b/docs/source/users/help.rst
@@ -3,6 +3,6 @@
 Getting Help
 ============
 
-If you run into any issues or bugs, please open an `issue on Github <https://github.com/jupyter/jupyter_server/issues>`_.
+If you run into any issues or bugs, please open an `issue on Github <https://github.com/jupyter-server/jupyter_server/issues>`_.
 
 We'd also love to have you come by our :ref:`Team Meetings <contributors-team-meetings-roadmap-calendar>`.


### PR DESCRIPTION
I thought it would be good to list some examples of Jupyter Server extensions on the website.

This could help:
* Make folks aware of the multifaceted applications that Jupyter Server is capable of supporting (much more than just notebooks!).
* Provide a handy reference for extension developers (I found the Jupyter Lab source code an invaluable resource).
* Raise awareness of the extensions already out there (I'm sure there are more that I'm not aware of).

I've listed the server extensions I'm aware of, including my own if you're happy to list it, in descending order of GH stars along with their GH project descriptions. Let me know if there are others I should add. My suggestion is to keep it to actively maintained Jupyter Server extensions (not downstream extensions e.g. Jupyter Lab extensions).