### PR TITLE
Link to GitHub repo from the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -159,7 +159,7 @@ html_theme_options = {
         }
     ],
     "navigation_with_keys": False,
-    "use_edit_page_button": True
+    "use_edit_page_button": True,
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,7 +150,17 @@ html_logo = "_static/jupyter_server_logo.svg"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {"navigation_with_keys": False}
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/jupyter-server/jupyter_server",
+            "icon": "fab fa-github-square",
+        }
+    ],
+    "navigation_with_keys": False,
+    "use_edit_page_button": True
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -162,6 +162,14 @@ html_theme_options = {
     "use_edit_page_button": True,
 }
 
+# Output for github to be used in links
+html_context = {
+    "github_user": "jupyter-server",  # Username
+    "github_repo": "jupyter_server",  # Repo name
+    "github_version": "main",  # Version
+    "doc_path": "docs/source/",  # Path in the checkout to the docs root
+}
+
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 


### PR DESCRIPTION
Small quality of life improvement:

- Adds a link icon in the navigation bar
- Adds Edit on GitHub link

### Before

![Screenshot from 2024-04-11 15-47-57](https://github.com/jupyter-server/jupyter_server/assets/5832902/0629e5ed-cbc0-48ab-b045-b7110d482750)

### After

![Screenshot from 2024-04-11 15-47-29](https://github.com/jupyter-server/jupyter_server/assets/5832902/1282f6ed-bfde-4681-9d04-ab9cb5063af2)
