### PR TITLE
Removing excessive logging from reading local files

### DIFF
--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -264,6 +264,7 @@ class FileManagerMixin(LoggingConfigurable, Configurable):
         ------
         404: if path is outside root
         """
+        # This statement can cause excessive logging, uncomment if necessary when troubleshooting.
         # self.log.debug("Reading path from disk: %s", path)
         root = os.path.abspath(self.root_dir)  # type:ignore[attr-defined]
         # to_os_path is not safe if path starts with a drive, since os.path.join discards first part

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -264,7 +264,7 @@ class FileManagerMixin(LoggingConfigurable, Configurable):
         ------
         404: if path is outside root
         """
-        self.log.debug("Reading path from disk: %s", path)
+        # self.log.debug("Reading path from disk: %s", path)
         root = os.path.abspath(self.root_dir)  # type:ignore[attr-defined]
         # to_os_path is not safe if path starts with a drive, since os.path.join discards first part
         if os.path.splitdrive(path)[0]:


### PR DESCRIPTION
The following is causing excessive logging and polluting the log file making it hard to troubleshoot issues based on log outputs.