### PR TITLE
Update simple extension examples: _jupyter_server_extension_points

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -187,8 +187,6 @@ open http://localhost:8888/
 # TODO Fix Default URL, it does not show on startup.
 # Home page as defined by default_url = '/default'.
 open http://localhost:8888/simple_ext11/default
-# HTML static page.
-open http://localhost:8888/static/simple_ext11/test.html
 # Content from Handlers.
 open http://localhost:8888/simple_ext11/params/test?var1=foo
 # Content from Template.

--- a/examples/simple/simple_ext1/__init__.py
+++ b/examples/simple/simple_ext1/__init__.py
@@ -1,5 +1,8 @@
 from .application import SimpleApp1
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [{"module": "simple_ext1.application", "app": SimpleApp1}]
+
+
+_jupyter_server_extension_paths = _jupyter_server_extension_points

--- a/examples/simple/simple_ext1/__init__.py
+++ b/examples/simple/simple_ext1/__init__.py
@@ -3,6 +3,3 @@ from .application import SimpleApp1
 
 def _jupyter_server_extension_points():
     return [{"module": "simple_ext1.application", "app": SimpleApp1}]
-
-
-_jupyter_server_extension_paths = _jupyter_server_extension_points

--- a/examples/simple/simple_ext11/__init__.py
+++ b/examples/simple/simple_ext11/__init__.py
@@ -5,6 +5,3 @@ from .application import SimpleApp11
 
 def _jupyter_server_extension_points():
     return [{"module": "simple_ext11.application", "app": SimpleApp11}]
-
-
-_jupyter_server_extension_paths = _jupyter_server_extension_points

--- a/examples/simple/simple_ext11/__init__.py
+++ b/examples/simple/simple_ext11/__init__.py
@@ -3,5 +3,8 @@
 from .application import SimpleApp11
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [{"module": "simple_ext11.application", "app": SimpleApp11}]
+
+
+_jupyter_server_extension_paths = _jupyter_server_extension_points

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -3,7 +3,10 @@
 from .application import SimpleApp2
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [
         {"module": "simple_ext2.application", "app": SimpleApp2},
     ]
+
+
+_jupyter_server_extension_paths = _jupyter_server_extension_points

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -7,6 +7,3 @@ def _jupyter_server_extension_points():
     return [
         {"module": "simple_ext2.application", "app": SimpleApp2},
     ]
-
-
-_jupyter_server_extension_paths = _jupyter_server_extension_points


### PR DESCRIPTION
The simple examples were using the deprecated `_jupyter_server_extension_paths`