### PR TITLE
Improve the busy/idle execution state tracking for kernels.

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -534,12 +534,14 @@ class MappingKernelManager(MultiKernelManager):
 
     def start_watching_activity(self, kernel_id):
         kernel = self._kernels[kernel_id]
-        kernel.start_watching_activity()
+        if getattr(kernel, "start_watching_activity", None):
+            kernel.start_watching_activity()
 
     def stop_watching_activity(self, kernel_id):
         """Stop watching IOPub messages on a kernel for activity."""
         kernel = self._kernels[kernel_id]
-        kernel.stop_watching_activity()
+        if getattr(kernel, "stop_watching_activity", None):
+            kernel.stop_watching_activity()
 
     def initialize_culler(self):
         """Start idle culler if 'cull_idle_timeout' is greater than zero.

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -563,6 +563,7 @@ class MappingKernelManager(MultiKernelManager):
         kernel._activity_stream = kernel.connect_iopub()
 
         def record_activity(msg_list):
+            """Record an IOPub message arriving from a kernel"""
             _, fed_msg_list = kernel.session.feed_identities(msg_list)
             msg = kernel.session.deserialize(fed_msg_list)
             msg_type = msg.get("header", {}).get("msg_type", "")

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -532,16 +532,81 @@ class MappingKernelManager(MultiKernelManager):
 
     # monitoring activity:
 
+    tracked_message_types = List(
+        trait=Unicode(),
+        config=True,
+        default_value=[
+            "comm_close",
+            "comm_msg",
+            "comm_open",
+            "complete_request",
+            "execute_input",
+            "execute_reply",
+            "execute_request",
+            "inspect_request",
+        ],
+        help="""List of kernel message types included in activity tracking.""",
+    )
+
     def start_watching_activity(self, kernel_id):
+        """Start watching IOPub messages on a kernel for activity.
+
+        - update last_activity on every message
+        - record execution_state from status messages
+        """
         kernel = self._kernels[kernel_id]
-        if getattr(kernel, "start_watching_activity", None):
-            kernel.start_watching_activity()
+        # add busy/activity markers:
+        kernel.execution_state = "starting"
+        kernel.reason = ""
+        kernel.last_activity = utcnow()
+        kernel._busy_requests = set({})
+        kernel._activity_stream = kernel.connect_iopub()
+
+        def record_activity(msg_list):
+            if kernel.execution_state == "starting":
+                # Starting is just the state we use until the kernel is up and running...
+                #
+                # If we've received a message from the kernel, then we know it is no longer
+                # starting and we need to change its state accordingly.
+                kernel.execution_state = "idle"
+            _, fed_msg_list = kernel.session.feed_identities(msg_list)
+            msg = kernel.session.deserialize(fed_msg_list)
+            msg_type = msg.get("header", {}).get("msg_type", "")
+            parent_msg_type = msg.get("parent_header", {}).get("msg_type", "")
+            parent_id = msg.get("parent_header", {}).get("msg_id", "")
+            if (
+                (msg_type in self.tracked_message_types)
+                or (parent_msg_type in self.tracked_message_types)
+                or kernel.execution_state == "busy"
+            ):
+                self.last_kernel_activity = kernel.last_activity = utcnow()
+            if msg_type == "status" and parent_msg_type in self.tracked_message_types:
+                execution_state = msg.get("content", {}).get("execution_state", "")
+                if execution_state == "busy":
+                    kernel._busy_requests = kernel._busy_requests | set({parent_id})
+                elif execution_state == "idle":
+                    kernel._busy_requests = kernel._busy_requests - set({parent_id})
+                kernel.execution_state = "idle" if len(kernel._busy_requests) == 0 else "busy"
+                self.log.debug(
+                    "activity on %s: %s (%s)",
+                    kernel_id,
+                    msg_type,
+                    kernel.execution_state,
+                )
+            else:
+                self.log.debug("activity on %s: %s", kernel_id, msg_type)
+
+        kernel._activity_stream.on_recv(record_activity)
 
     def stop_watching_activity(self, kernel_id):
         """Stop watching IOPub messages on a kernel for activity."""
         kernel = self._kernels[kernel_id]
-        if getattr(kernel, "stop_watching_activity", None):
-            kernel.stop_watching_activity()
+        if getattr(kernel, "_activity_stream", None):
+            if not kernel._activity_stream.socket.closed:
+                kernel._activity_stream.close()
+            kernel._activity_stream = None
+        if getattr(kernel, "_pending_restart_cleanup", None):
+            kernel._pending_restart_cleanup()
 
     def initialize_culler(self):
         """Start idle culler if 'cull_idle_timeout' is greater than zero.
@@ -796,80 +861,6 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
             except SchemaRegistryException:
                 pass
         return logger
-
-    tracked_message_types = List(
-        trait=Unicode(),
-        config=True,
-        default_value=[
-            "comm_close",
-            "comm_msg",
-            "comm_open",
-            "complete_request",
-            "execute_input",
-            "execute_reply",
-            "execute_request",
-            "inspect_request",
-        ],
-        help="""List of kernel message types included in activity tracking.""",
-    )
-
-    def reset_execution_state(self):
-        self.execution_state = "starting"
-        self.reason = ""
-        self.last_activity = utcnow()
-        self._busy_requests = set({})
-
-    def record_activity(self, msg_list):
-        if self.execution_state == "starting":
-            # Starting is just the state we use unti the kernel is up and running...
-            #
-            # If we've received a message from the kernel, then we know it is no longer
-            # starting and we need to change its state accordingly.
-            self.execution_state = "idle"
-        _, fed_msg_list = self.session.feed_identities(msg_list)
-        msg = self.session.deserialize(fed_msg_list)
-        msg_type = msg.get("header", {}).get("msg_type", "")
-        parent_msg_type = msg.get("parent_header", {}).get("msg_type", "")
-        parent_id = msg.get("parent_header", {}).get("msg_id", "")
-        if (
-            (msg_type in self.tracked_message_types)
-            or (parent_msg_type in self.tracked_message_types)
-            or self.execution_state == "busy"
-        ):
-            self.last_activity = utcnow()
-        if msg_type == "status" and parent_msg_type in self.tracked_message_types:
-            execution_state = msg.get("content", {}).get("execution_state", "")
-            if execution_state == "busy":
-                self._busy_requests = self._busy_requests | set({parent_id})
-            elif execution_state == "idle":
-                self._busy_requests = self._busy_requests - set({parent_id})
-            self.execution_state = "idle" if len(self._busy_requests) == 0 else "busy"
-            self.log.debug(
-                "activity on %s: %s (%s)",
-                self.kernel_id,
-                msg_type,
-                self.execution_state,
-            )
-        else:
-            self.log.debug("activity on %s: %s", self.kernel_id, msg_type)
-
-    def start_watching_activity(self):
-        """Start watching IOPub messages on the kernel for activity.
-
-        - update last_activity on every tracked message
-        - record execution_state from the cumulative status of tracked messages.
-        """
-        self.reset_execution_state()
-        self._activity_stream = self.connect_iopub()
-        self._activity_stream.on_recv(self.record_activity)
-
-    def stop_watching_activity(self):
-        activity_stream = getattr(self, "_activity_stream", None)
-        if activity_stream:
-            activity_stream.close()
-        pending_restart_cleanup = getattr(self, "_pending_restart_cleanup", None)
-        if pending_restart_cleanup:
-            pending_restart_cleanup()
 
     def emit(self, schema_id, data):
         """Emit an event from the kernel manager."""

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -141,7 +141,7 @@ async def test_cull_connected(jp_fetch, jp_ws_fetch):
             {
                 "channel": "shell",
                 "header": {
-                    "date": datetime.datetime.now().isoformat(),
+                    "date": datetime.datetime.now(tz=datetime.UTC).isoformat(),
                     "session": session_id,
                     "msg_id": message_id,
                     "msg_type": "execute_request",

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -141,7 +141,7 @@ async def test_cull_connected(jp_fetch, jp_ws_fetch):
             {
                 "channel": "shell",
                 "header": {
-                    "date": datetime.datetime.now(tz=datetime.UTC).isoformat(),
+                    "date": datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
                     "session": session_id,
                     "msg_id": message_id,
                     "msg_type": "execute_request",

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -1,7 +1,9 @@
 import asyncio
+import datetime
 import json
 import os
 import platform
+import uuid
 import warnings
 
 import jupyter_client
@@ -92,6 +94,83 @@ async def test_cull_idle(jp_fetch, jp_ws_fetch):
     ws.close()
     culled = await get_cull_status(kid, jp_fetch)  # not connected, should be culled
     assert culled
+
+
+@pytest.mark.parametrize(
+    "jp_server_config",
+    [
+        # Test the synchronous case
+        Config(
+            {
+                "ServerApp": {
+                    "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.MappingKernelManager",
+                    "MappingKernelManager": {
+                        "cull_idle_timeout": CULL_TIMEOUT,
+                        "cull_interval": CULL_INTERVAL,
+                        "cull_connected": True,
+                    },
+                }
+            }
+        ),
+        # Test the async case
+        Config(
+            {
+                "ServerApp": {
+                    "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager",
+                    "AsyncMappingKernelManager": {
+                        "cull_idle_timeout": CULL_TIMEOUT,
+                        "cull_interval": CULL_INTERVAL,
+                        "cull_connected": True,
+                    },
+                }
+            }
+        ),
+    ],
+)
+async def test_cull_connected(jp_fetch, jp_ws_fetch):
+    r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
+    kernel = json.loads(r.body.decode())
+    kid = kernel["id"]
+
+    # Open a websocket connection.
+    ws = await jp_ws_fetch("api", "kernels", kid, "channels")
+    session_id = uuid.uuid1().hex
+    message_id = uuid.uuid1().hex
+    await ws.write_message(
+        json.dumps(
+            {
+                "channel": "shell",
+                "header": {
+                    "date": datetime.datetime.now().isoformat(),
+                    "session": session_id,
+                    "msg_id": message_id,
+                    "msg_type": "execute_request",
+                    "username": "",
+                    "version": "5.2",
+                },
+                "parent_header": {},
+                "metadata": {},
+                "content": {
+                    "code": f"import time\ntime.sleep({CULL_TIMEOUT-1})",
+                    "silent": False,
+                    "allow_stdin": False,
+                    "stop_on_error": True,
+                },
+                "buffers": [],
+            }
+        )
+    )
+
+    r = await jp_fetch("api", "kernels", kid, method="GET")
+    model = json.loads(r.body.decode())
+    assert model["connections"] == 1
+    culled = await get_cull_status(
+        kid, jp_fetch
+    )  # connected, but code cell still running. Should not be culled
+    assert not culled
+    culled = await get_cull_status(kid, jp_fetch)  # still connected, but idle... should be culled
+    assert culled
+    ws.close()
 
 
 async def test_cull_idle_disable(jp_fetch, jp_ws_fetch, jp_kernelspec_with_metadata):

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -12,8 +12,9 @@ import pytest
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
 
-MAX_POLL_ATTEMPTS = 3
+MAX_POLL_ATTEMPTS = 5
 POLL_INTERVAL = 1
+MINIMUM_CONSISTENT_COUNT = 3
 
 
 async def test_execution_state(jp_fetch, jp_ws_fetch):
@@ -104,15 +105,22 @@ async def get_execution_state(kid, jp_fetch):
     #
     # To work-around this, we don't return the status until we've been able to fetch
     # it twice in a row and get the same result both times.
-    last_execution_state = None
+    last_execution_states = []
 
     for _ in range(MAX_POLL_ATTEMPTS):
         r = await jp_fetch("api", "kernels", kid, method="GET")
         model = json.loads(r.body.decode())
         execution_state = model["execution_state"]
-        if execution_state == last_execution_state:
-            return execution_state
-        last_execution_state = execution_state
+        last_execution_states.append(execution_state)
+        consistent_count = 0
+        last_execution_state = None
+        for es in last_execution_states:
+            if es != last_execution_state:
+                consistent_count = 0
+                last_execution_state = es
+            consistent_count += 1
+            if consistent_count >= MINIMUM_CONSISTENT_COUNT:
+                return es
         time.sleep(POLL_INTERVAL)
 
     raise AssertionError("failed to get a consistent execution state")

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -1,0 +1,121 @@
+import asyncio
+import datetime
+import json
+import os
+import platform
+import uuid
+import warnings
+
+import jupyter_client
+import pytest
+from tornado.httpclient import HTTPClientError
+from traitlets.config import Config
+
+POLL_TIMEOUT = 10
+POLL_INTERVAL = 1
+
+
+async def test_execution_state(jp_fetch, jp_ws_fetch):
+    r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
+    kernel = json.loads(r.body.decode())
+    kid = kernel["id"]
+
+    # Open a websocket connection.
+    ws = await jp_ws_fetch("api", "kernels", kid, "channels")
+    await poll_for_execution_state(kid, "idle", jp_fetch)
+
+    session_id = uuid.uuid1().hex
+    message_id = uuid.uuid1().hex
+    await ws.write_message(
+        json.dumps(
+            {
+                "channel": "shell",
+                "header": {
+                    "date": datetime.datetime.now().isoformat(),
+                    "session": session_id,
+                    "msg_id": message_id,
+                    "msg_type": "execute_request",
+                    "username": "",
+                    "version": "5.2",
+                },
+                "parent_header": {},
+                "metadata": {},
+                "content": {
+                    "code": f"import time\ntime.sleep({POLL_TIMEOUT-1})",
+                    "silent": False,
+                    "allow_stdin": False,
+                    "stop_on_error": True,
+                },
+                "buffers": [],
+            }
+        )
+    )
+    await poll_for_execution_state(kid, "busy", jp_fetch)
+
+    message_id_2 = uuid.uuid1().hex
+    await ws.write_message(
+        json.dumps(
+            {
+                "channel": "shell",
+                "header": {
+                    "date": datetime.datetime.now().isoformat(),
+                    "session": session_id,
+                    "msg_id": message_id_2,
+                    "msg_type": "execute_request",
+                    "username": "",
+                    "version": "5.2",
+                },
+                "parent_header": {},
+                "metadata": {},
+                "content": {
+                    "code": "pass",
+                    "silent": False,
+                    "allow_stdin": False,
+                    "stop_on_error": True,
+                },
+                "buffers": [],
+            }
+        )
+    )
+    await get_idle_reply(kid, message_id_2, ws)
+    es = await get_execution_state(kid, jp_fetch)
+
+    # Verify that the overall kernel status is still "busy" even though one
+    # "idle" response was already seen for the second execute request.
+    assert es == "busy"
+
+    await poll_for_execution_state(kid, "idle", jp_fetch)
+    ws.close()
+
+
+async def get_execution_state(kid, jp_fetch):
+    r = await jp_fetch("api", "kernels", kid, method="GET")
+    model = json.loads(r.body.decode())
+    return model["execution_state"]
+
+
+async def poll_for_execution_state(kid, target_state, jp_fetch):
+    for _ in range(int(POLL_TIMEOUT / POLL_INTERVAL)):
+        es = await get_execution_state(kid, jp_fetch)
+        if es == target_state:
+            return True
+        else:
+            await asyncio.sleep(POLL_INTERVAL)
+    raise AssertionError(f"Timed out waiting for kernel execution state {target_state}")
+
+
+async def get_idle_reply(kid, parent_message_id, ws):
+    while True:
+        resp = await ws.read_message()
+        resp_json = json.loads(resp)
+        parent_message = resp_json.get("parent_header", {}).get("msg_id", None)
+        if parent_message != parent_message_id:
+            continue
+
+        response_type = resp_json.get("header", {}).get("msg_type", None)
+        if response_type != "status":
+            continue
+
+        execution_state = resp_json.get("content", {}).get("execution_state", "")
+        if execution_state == "idle":
+            return

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -12,9 +12,9 @@ import pytest
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
 
-MAX_POLL_ATTEMPTS = 5
+MAX_POLL_ATTEMPTS = 10
 POLL_INTERVAL = 1
-MINIMUM_CONSISTENT_COUNT = 3
+MINIMUM_CONSISTENT_COUNT = 4
 
 
 async def test_execution_state(jp_fetch, jp_ws_fetch):

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -9,14 +9,12 @@ import warnings
 
 import jupyter_client
 import pytest
+from flaky import flaky
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
 
-MAX_POLL_ATTEMPTS = 10
-POLL_INTERVAL = 1
-MINIMUM_CONSISTENT_COUNT = 4
 
-
+@flaky
 async def test_execution_state(jp_fetch, jp_ws_fetch):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
@@ -100,30 +98,10 @@ async def test_execution_state(jp_fetch, jp_ws_fetch):
 
 
 async def get_execution_state(kid, jp_fetch):
-    # There is an inherent race condition when getting the kernel execution status
-    # where we might fetch the status right before an expected state change occurs.
-    #
-    # To work-around this, we don't return the status until we've been able to fetch
-    # it twice in a row and get the same result both times.
-    last_execution_states = []
-
-    for _ in range(MAX_POLL_ATTEMPTS):
-        r = await jp_fetch("api", "kernels", kid, method="GET")
-        model = json.loads(r.body.decode())
-        execution_state = model["execution_state"]
-        last_execution_states.append(execution_state)
-        consistent_count = 0
-        last_execution_state = None
-        for es in last_execution_states:
-            if es != last_execution_state:
-                consistent_count = 0
-                last_execution_state = es
-            consistent_count += 1
-            if consistent_count >= MINIMUM_CONSISTENT_COUNT:
-                return es
-        time.sleep(POLL_INTERVAL)
-
-    raise AssertionError("failed to get a consistent execution state")
+    r = await jp_fetch("api", "kernels", kid, method="GET")
+    model = json.loads(r.body.decode())
+    execution_state = model["execution_state"]
+    return execution_state
 
 
 async def poll_for_parent_message_status(kid, parent_message_id, target_status, ws):

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -12,14 +12,11 @@ import pytest
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
 
-POLL_INTERVAL = 1
-
 
 async def test_execution_state(jp_fetch, jp_ws_fetch):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
     kid = kernel["id"]
-    await poll_for_execution_state(kid, "idle", jp_fetch)
 
     # Open a websocket connection.
     ws = await jp_ws_fetch("api", "kernels", kid, "channels")
@@ -102,14 +99,6 @@ async def get_execution_state(kid, jp_fetch):
     r = await jp_fetch("api", "kernels", kid, method="GET")
     model = json.loads(r.body.decode())
     return model["execution_state"]
-
-
-async def poll_for_execution_state(kid, target_state, jp_fetch):
-    while True:
-        es = await get_execution_state(kid, jp_fetch)
-        if es == target_state:
-            return
-        time.sleep(POLL_INTERVAL)
 
 
 async def poll_for_parent_message_status(kid, parent_message_id, target_status, ws):

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -31,7 +31,7 @@ async def test_execution_state(jp_fetch, jp_ws_fetch):
             {
                 "channel": "shell",
                 "header": {
-                    "date": datetime.datetime.now().isoformat(),
+                    "date": datetime.datetime.now(tz=datetime.UTC).isoformat(),
                     "session": session_id,
                     "msg_id": message_id,
                     "msg_type": "execute_request",
@@ -58,7 +58,7 @@ async def test_execution_state(jp_fetch, jp_ws_fetch):
             {
                 "channel": "shell",
                 "header": {
-                    "date": datetime.datetime.now().isoformat(),
+                    "date": datetime.datetime.now(tz=datetime.UTC).isoformat(),
                     "session": session_id,
                     "msg_id": message_id_2,
                     "msg_type": "execute_request",

--- a/tests/services/kernels/test_execution_state.py
+++ b/tests/services/kernels/test_execution_state.py
@@ -12,6 +12,9 @@ import pytest
 from tornado.httpclient import HTTPClientError
 from traitlets.config import Config
 
+MAX_POLL_ATTEMPTS = 3
+POLL_INTERVAL = 1
+
 
 async def test_execution_state(jp_fetch, jp_ws_fetch):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
@@ -96,9 +99,23 @@ async def test_execution_state(jp_fetch, jp_ws_fetch):
 
 
 async def get_execution_state(kid, jp_fetch):
-    r = await jp_fetch("api", "kernels", kid, method="GET")
-    model = json.loads(r.body.decode())
-    return model["execution_state"]
+    # There is an inherent race condition when getting the kernel execution status
+    # where we might fetch the status right before an expected state change occurs.
+    #
+    # To work-around this, we don't return the status until we've been able to fetch
+    # it twice in a row and get the same result both times.
+    last_execution_state = None
+
+    for _ in range(MAX_POLL_ATTEMPTS):
+        r = await jp_fetch("api", "kernels", kid, method="GET")
+        model = json.loads(r.body.decode())
+        execution_state = model["execution_state"]
+        if execution_state == last_execution_state:
+            return execution_state
+        last_execution_state = execution_state
+        time.sleep(POLL_INTERVAL)
+
+    raise AssertionError("failed to get a consistent execution state")
 
 
 async def poll_for_parent_message_status(kid, parent_message_id, target_status, ws):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,7 +160,7 @@ def test_filefind(tmp_path, filename, result):
     if isinstance(result, str):
         found = filefind(filename, [str(a), str(b)])
         found_relative = Path(found).relative_to(tmp_path)
-        assert str(found_relative) == result
+        assert str(found_relative) == result.replace("/", os.sep)
     else:
         with pytest.raises(result):
             filefind(filename, [str(a), str(b)])


### PR DESCRIPTION
This PR makes two adjustments/enhancements for the way kernel execution state is tracked:

1. Distinguish between "busy"/"idle" status messages with different parent IDs.

    A "busy" or "idle" status message is not sent in isolation, but rather in response to a specific parent message, and
    the kernel might still be busy with one parent message even after reporting that it is done (e.g. has an "idle" status)
    with a different parent message.

    Accordingly, the overall kernel execution state is only switched to "idle" once all previously seen "busy" status
    messages have had a corresponding "idle" message sent with the same parent message ID.

2. Distinguish between different types of parent message when determining whether or not the overall kernel is "busy".

    Not every message type corresponds to a user action, so not all of them should be included in the logic for determining
    that a kernel is "busy". This is especially true for the case of kernel culling where the distinction between "idle" and
    "busy" is used to decide whether or not to cull the kernels.

    Since there might be different setups where the server admin might want to include/exclude different types of
    messages from this calculation, the set of message types used for status tracking is configurable.

Fixes #1360