### PR TITLE
extensions: render default templates with default static_url

### DIFF
--- a/tests/extension/mockextensions/__init__.py
+++ b/tests/extension/mockextensions/__init__.py
@@ -2,7 +2,7 @@
 to load in various tests.
 """
 
-from .app import MockExtensionApp
+from .app import MockExtensionApp, MockExtensionNoTemplateApp
 
 
 # Function that makes these extensions discoverable
@@ -12,6 +12,10 @@ def _jupyter_server_extension_points():
         {
             "module": "tests.extension.mockextensions.app",
             "app": MockExtensionApp,
+        },
+        {
+            "module": "tests.extension.mockextensions.app",
+            "app": MockExtensionNoTemplateApp,
         },
         {"module": "tests.extension.mockextensions.mock1"},
         {"module": "tests.extension.mockextensions.mock2"},

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -170,12 +170,14 @@ async def test_stop_extension(jp_serverapp, caplog):
         "Shutting down 2 extensions",
         "jupyter_server_terminals | extension app 'jupyter_server_terminals' stopping",
         f"{extension_name} | extension app 'mockextension' stopping",
+        f"{extension_name} | extension app 'mockextension_notemplate' stopping",
         "jupyter_server_terminals | extension app 'jupyter_server_terminals' stopped",
         f"{extension_name} | extension app 'mockextension' stopped",
+        f"{extension_name} | extension app 'mockextension_notemplate' stopped",
     }
 
     # check the shutdown method was called twice
-    assert calls == 2
+    assert calls == 3
 
 
 async def test_events(jp_serverapp, jp_fetch):


### PR DESCRIPTION
avoids rendering errors or incorrect URLs for error pages, which must use the base static_url function

closes #1434

A probably cleaner approach would be to attach `static_url` to jinja environment globals instead of a method on the Handler, but the compatibility implications of switching to that are more complicated than I felt comfortable tackling.