### PR TITLE
Do not log environment variables passed to kernels

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -243,7 +243,12 @@ class MappingKernelManager(MultiKernelManager):
             kernel.reason = ""  # type:ignore[attr-defined]
             kernel.last_activity = utcnow()  # type:ignore[attr-defined]
             self.log.info("Kernel started: %s", kernel_id)
-            self.log.debug("Kernel args: %r", {k: v for k, v in kwargs.items() if k != "env"})
+            self.log.debug(
+                "Kernel args (excluding env): %r", {k: v for k, v in kwargs.items() if k != "env"}
+            )
+            env = kwargs.get("env", None)
+            if env and isinstance(env, dict):
+                self.log.debug("Kernel argument 'env' passed with: %r", list(env.keys()))
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -247,8 +247,8 @@ class MappingKernelManager(MultiKernelManager):
                 "Kernel args (excluding env): %r", {k: v for k, v in kwargs.items() if k != "env"}
             )
             env = kwargs.get("env", None)
-            if env and isinstance(env, dict):
-                self.log.debug("Kernel argument 'env' passed with: %r", list(env.keys()))
+            if env and isinstance(env, dict):  # type:ignore[unreachable]
+                self.log.debug("Kernel argument 'env' passed with: %r", list(env.keys()))  # type:ignore[unreachable]
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -243,7 +243,7 @@ class MappingKernelManager(MultiKernelManager):
             kernel.reason = ""  # type:ignore[attr-defined]
             kernel.last_activity = utcnow()  # type:ignore[attr-defined]
             self.log.info("Kernel started: %s", kernel_id)
-            self.log.debug("Kernel args: %r", kwargs)
+            self.log.debug("Kernel args: %r", {k: v for k, v in kwargs.items() if k != "env"})
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1


### PR DESCRIPTION
Fixes #1436

This is mostly to guard users posting debug logs online from exposing secrets which they may have in their environment