### PR TITLE
don't let ExtensionApp jpserver_extensions be overridden by config

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2724,7 +2724,11 @@ class ServerApp(JupyterApp):
         self._init_asyncio_patch()
         # Parse command line, load ServerApp config files,
         # and update ServerApp config.
+        # preserve jpserver_extensions, which may have been set by starter_extension
+        # don't let config clobber this value
+        jpserver_extensions = self.jpserver_extensions.copy()
         super().initialize(argv=argv)
+        self.jpserver_extensions.update(jpserver_extensions)
         if self._dispatching:
             return
         # initialize io loop as early as possible,


### PR DESCRIPTION
ensures `jpserver_extensions` set in `make_serverapp` is preserved after loading config files in `ServerApp.initialize`.

closes https://github.com/jupyterhub/jupyterhub/issues/4859

Repro:

```python
# jupyter_server_config.py
c.ServerApp.jpserver_extensions = {"anything": False}
```

```python
# testext.py
from jupyter_server.extension.application import ExtensionApp


def _jupyter_server_extension_points():
    return [{"module": __name__, "app": TestExtension}]


class TestExtension(ExtensionApp):
    name = "tester"


if __name__ == "__main__":
    TestExtension.launch_instance()
```

and run:

```
python3 testext.py --config ./jupyter_server_config.py
```

which results in:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/minrk/dev/jpy/jupyterhub/test-env/testext.py", line 13, in <module>
    TestExtension.launch_instance()
  File "/Users/minrk/dev/jpy/jupyter_server/jupyter_server/extension/application.py", line 618, in launch_instance
    serverapp = cls.initialize_server(argv=args)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/minrk/dev/jpy/jupyter_server/jupyter_server/extension/application.py", line 587, in initialize_server
    serverapp.initialize(
  File "/Users/minrk/.virtualenvs/test-env/lib/python3.11/site-packages/traitlets/config/application.py", line 118, in inner
    return method(app, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/minrk/dev/jpy/jupyter_server/jupyter_server/serverapp.py", line 2750, in initialize
    point = self.extension_manager.extension_points[starter_extension]
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'tester'
```
