### PR TITLE
write server extension list to stdout

### DIFF
--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -276,7 +276,7 @@ class ToggleServerExtensionApp(BaseExtensionApp):
             # If successful, let's log.
             self.log.info(f"    - Extension successfully {self._toggle_post_message}.")
         except Exception as err:
-            self.log.info(f"     {RED_X} Validation failed: {err}")
+            self.log.error(f"     {RED_X} Validation failed: {err}")
 
     def start(self) -> None:
         """Perform the App's actions as configured"""
@@ -336,7 +336,7 @@ class ListServerExtensionsApp(BaseExtensionApp):
 
         for option in configurations:
             config_dir = _get_config_dir(**option)
-            self.log.info(f"Config dir: {config_dir}")
+            print(f"Config dir: {config_dir}")
             write_dir = "jupyter_server_config.d"
             config_manager = ExtensionConfigManager(
                 read_config_path=[config_dir],
@@ -345,20 +345,18 @@ class ListServerExtensionsApp(BaseExtensionApp):
             jpserver_extensions = config_manager.get_jpserver_extensions()
             for name, enabled in jpserver_extensions.items():
                 # Attempt to get extension metadata
-                self.log.info(f"    {name} {GREEN_ENABLED if enabled else RED_DISABLED}")
+                print(f"    {name} {GREEN_ENABLED if enabled else RED_DISABLED}")
                 try:
-                    self.log.info(f"    - Validating {name}...")
+                    print(f"    - Validating {name}...")
                     extension = ExtensionPackage(name=name, enabled=enabled)
                     if not extension.validate():
                         msg = "validation failed"
                         raise ValueError(msg)
                     version = extension.version
-                    self.log.info(f"      {name} {version} {GREEN_OK}")
+                    print(f"      {name} {version} {GREEN_OK}")
                 except Exception as err:
-                    exc_info = False
-                    if int(self.log_level) <= logging.DEBUG:  # type:ignore[call-overload]
-                        exc_info = True
-                    self.log.warning(f"      {RED_X} {err}", exc_info=exc_info)
+                    self.log.debug("", exc_info=True)
+                    print(f"      {RED_X} {err}")
             # Add a blank line between paths.
             self.log.info("")
 


### PR DESCRIPTION
list output shouldn't be sensitive to log level; folks should be able to `jupyter server extension list | grep ...` which won't have expected behavior when logging to stderr.

Did the same for `server list` in #1275