### PR TITLE
Don't hide .so,.dylib files by default

### DIFF
--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -126,7 +126,6 @@ class ContentsManager(LoggingConfigurable):
             "*.pyc",
             "*.pyo",
             ".DS_Store",
-            "*.dylib",
             "*~",
         ],
         config=True,

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -126,7 +126,6 @@ class ContentsManager(LoggingConfigurable):
             "*.pyc",
             "*.pyo",
             ".DS_Store",
-            "*.so",
             "*.dylib",
             "*~",
         ],


### PR DESCRIPTION
It's confusing that the .so files are hidden. They appear, for example, when compiling Python code, and it becomes unclear that the compiled files will be executed because Jupyter gives the impression that they don't exist. There is [an issue on GitHub](https://github.com/jupyter/notebook/issues/7409) and a [question on Stack Overflow](https://stackoverflow.com/questions/78260388/jupyter-lab-file-explorer-not-showing-so-files).

This PR removes .so files from the default list.
