### PR TITLE
Return HTTP 400 when attempting to post an event with an unregistered schema

### DIFF
--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -82,6 +82,9 @@ def validate_model(
             message = f"Missing `{key}` in the JSON request body."
             raise Exception(message)
     schema_id = cast(str, data.get("schema_id"))
+    # The case where a given schema_id isn't found, 
+    # jupyter_events raises a useful error, so there's no need to
+    # handle that case here.
     schema = registry.get(schema_id)
     version = int(cast(int, data.get("version")))
     if schema.version != version:

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from jupyter_core.utils import ensure_async
+from jupyter_events.logger import SchemaNotRegistered
 from tornado import web, websocket
 
 from jupyter_server.auth.decorator import authorized, ws_authenticated
@@ -121,6 +122,9 @@ class EventHandler(APIHandler):
             self.finish()
         except web.HTTPError:
             raise
+        except SchemaNotRegistered as e:
+            message = f"Unregistered event schema: ${str(e)}"
+            raise web.HTTPError(400, message) from e
         except Exception as e:
             raise web.HTTPError(500, str(e)) from e
 

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -82,10 +82,10 @@ def validate_model(
             message = f"Missing `{key}` in the JSON request body."
             raise Exception(message)
     schema_id = cast(str, data.get("schema_id"))
-    version = cast(int, data.get("version"))
     schema = registry.get(schema_id)
+    version = int(cast(int, data.get("version")))
     if schema.version != version:
-        message = f"Unregistered version: `{version}` for `{schema_id}`"
+        message = f"Unregistered version: {version}≠{schema.version} for `{schema_id}`"
         raise Exception(message)
 
 

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -77,13 +77,16 @@ def validate_model(data: dict[str, Any], schema: jupyter_events.schema.EventSche
     required_keys = {"schema_id", "version", "data"}
     for key in required_keys:
         if key not in data:
-            raise Exception(f"Missing `{key}` in the JSON request body.")
+            message = f"Missing `{key}` in the JSON request body."
+            raise Exception(message)
     schema_id = cast(str, data.get("schema_id"))
     version = cast(int, data.get("version"))
     if schema is None:
-        raise Exception(f"Unregistered schema: `{schema_id}`")
+        message = f"Unregistered schema: `{schema_id}`"
+        raise Exception(message)
     if schema.version != version:
-        raise Exception(f"Unregistered version: `{version}` for `{schema_id}`")
+        message = f"Unregistered version: `{version}` for `{schema_id}`"
+        raise Exception(message)
 
 
 def get_timestamp(data: dict[str, Any]) -> Optional[datetime]:

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -82,7 +82,7 @@ def validate_model(
             message = f"Missing `{key}` in the JSON request body."
             raise Exception(message)
     schema_id = cast(str, data.get("schema_id"))
-    # The case where a given schema_id isn't found, 
+    # The case where a given schema_id isn't found,
     # jupyter_events raises a useful error, so there's no need to
     # handle that case here.
     schema = registry.get(schema_id)

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -117,8 +117,18 @@ payload_6 = """\
 }
 """
 
+payload_7 = """\
+{
+    "schema_id": "http://event.mock.jupyter.org/UNREGISTERED-SCHEMA",
+    "version": 1,
+    "data": {
+        "event_message": "Hello, world!"
+    }
+}
+"""
 
-@pytest.mark.parametrize("payload", [payload_3, payload_4, payload_5, payload_6])
+
+@pytest.mark.parametrize("payload", [payload_3, payload_4, payload_5, payload_6, payload_7])
 async def test_post_event_400(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)
@@ -126,7 +136,7 @@ async def test_post_event_400(jp_fetch, event_logger, payload):
     assert expected_http_error(e, 400)
 
 
-payload_7 = """\
+payload_8 = """\
 {
     "schema_id": "http://event.mock.jupyter.org/message",
     "version": 1,
@@ -136,7 +146,7 @@ payload_7 = """\
 }
 """
 
-payload_8 = """\
+payload_9 = """\
 {
     "schema_id": "http://event.mock.jupyter.org/message",
     "version": 2,
@@ -147,7 +157,7 @@ payload_8 = """\
 """
 
 
-@pytest.mark.parametrize("payload", [payload_7, payload_8])
+@pytest.mark.parametrize("payload", [payload_8, payload_9])
 async def test_post_event_500(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -127,15 +127,6 @@ payload_7 = """\
 }
 """
 
-
-@pytest.mark.parametrize("payload", [payload_3, payload_4, payload_5, payload_6, payload_7])
-async def test_post_event_400(jp_fetch, event_logger, payload):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await jp_fetch("api", "events", method="POST", body=payload)
-
-    assert expected_http_error(e, 400)
-
-
 payload_8 = """\
 {
     "schema_id": "http://event.mock.jupyter.org/message",
@@ -151,15 +142,17 @@ payload_9 = """\
     "schema_id": "http://event.mock.jupyter.org/message",
     "version": 2,
     "data": {
-        "message": "Hello, world!"
+        "event_message": "Hello, world!"
     }
 }
 """
 
 
-@pytest.mark.parametrize("payload", [payload_8, payload_9])
-async def test_post_event_500(jp_fetch, event_logger, payload):
+@pytest.mark.parametrize(
+    "payload",
+    [payload_3, payload_4, payload_5, payload_6, payload_7, payload_8, payload_9],
+)
+async def test_post_event_400(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)
-
-    assert expected_http_error(e, 500)
+    assert expected_http_error(e, 400)

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -155,4 +155,5 @@ payload_9 = """\
 async def test_post_event_400(jp_fetch, event_logger, payload):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "events", method="POST", body=payload)
+
     assert expected_http_error(e, 400)


### PR DESCRIPTION
Currently if a `POST` is made to `/api/events` with a well-formed event that has a schema that hasn't been registered with the `event_logger`, the REST API returns an HTTP 500 error, but in every case I could find where an exception is raised, it comes from bad input, so it should be an HTTP 400 error.

**depends on:** https://github.com/jupyter/jupyter_events/pull/101