### PR TITLE
Fix chunked file upload

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -251,8 +251,8 @@ class ContentsHandler(ContentsAPIHandler):
         self.log.info(f"Appending file chunk {chunk} at path: {path}")
         existing_model = self.contents_manager.get(path)
         # TODO: Test binary files encoding works properly:
-        assert existing_model['format'] == to_append_model['format']
-        existing_model['content'] = existing_model['content'] + to_append_model['content']
+        assert existing_model["format"] == to_append_model["format"]
+        existing_model["content"] = existing_model["content"] + to_append_model["content"]
         model = await ensure_async(self.contents_manager.save(existing_model, path))
         validate_model(model)
         self._finish_model(model)


### PR DESCRIPTION
Jupyter has manual upload system instead of using a standard form-multipart upload.

In the browser [we manually chunk and upload files via separate PUT requests](https://github.com/jupyterlab/jupyterlab/blob/a036d6b10084d35436682bbb086324a1ea71eaac/packages/filebrowser/src/model.ts#L453), and then in the code referenced in this PR, we save those chunks from the separate requests.

A significant issue is that requests can be lost or out of order, making the uploader fundamentally untrustworthy, but that isn't the focus of the PR.

There is a bug currently where files being uploaded with more than one chunk are only saving the last chunk, I've found this is due to overwriting after receiving each chunk, instead of appending.

This PR fixes that bug by adding a separate append function.
