### PR TITLE
Add prometheus metric with version information

### DIFF
--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -38,7 +38,7 @@ except ImportError:
 
 from prometheus_client import Info
 
-SERVER_INFO = Info("jupyter_server_info", "Jupyter Server Version information")
+SERVER_INFO = Info("jupyter_server", "Jupyter Server Version information")
 
 __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -4,6 +4,12 @@ Prometheus metrics exported by Jupyter Server
 Read https://prometheus.io/docs/practices/naming/ for naming
 conventions for metrics & labels.
 """
+# Do this to see if we end up in an import loop?
+from notebook.prometheus.metrics import (
+    HTTP_REQUEST_DURATION_SECONDS,
+    KERNEL_CURRENTLY_RUNNING_TOTAL,
+    TERMINAL_CURRENTLY_RUNNING_TOTAL,
+)
 
 try:
     # Jupyter Notebook also defines these metrics.  Re-defining them results in a ValueError.

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -10,16 +10,13 @@ from jupyter_server._version import version_info as server_version_info
 
 try:
     from notebook._version import version_info as notebook_version_info
-    v6_notebook_present = notebook_version_info != server_version_info
 except ImportError:
-    # notebook._version is not present, so notebook v6 can not be present
-    v6_notebook_present = False
+    notebook_version_info = None
 
 
-if v6_notebook_present:
+if notebook_version_info is not None and notebook_version_info < (7,) and notebook_version_info != server_version_info:
     print("yes, we think we have an unshimmed notebook package")
     print(notebook_version_info)
-    print(server_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
     # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -10,13 +10,16 @@ from jupyter_server._version import version_info as server_version_info
 
 try:
     from notebook._version import version_info as notebook_version_info
+    v6_notebook_present = notebook_version_info != server_version_info
 except ImportError:
-    notebook_version_info = None
+    # notebook._version is not present, so notebook v6 can not be present
+    v6_notebook_present = False
 
 
-if notebook_version_info is not None and notebook_version_info < (7,) and notebook_version_info != server_version_info:
+if v6_notebook_present:
     print("yes, we think we have an unshimmed notebook package")
     print(notebook_version_info)
+    print(server_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
     # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -6,6 +6,7 @@ conventions for metrics & labels.
 """
 
 from prometheus_client import Gauge, Histogram, Info
+from jupyter_server._version import version_info as server_version_info
 
 try:
     from notebook._version import version_info as notebook_version_info
@@ -13,7 +14,7 @@ except ImportError:
     notebook_version_info = None
 
 
-if notebook_version_info is not None and notebook_version_info < (7,):
+if notebook_version_info is not None and notebook_version_info < (7,) and notebook_version_info != server_version_info:
     print("yes, we think we have an unshimmed notebook package")
     print(notebook_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -12,7 +12,10 @@ try:
 except ImportError:
     notebook_version_info = None
 
+
 if notebook_version_info is not None and notebook_version_info < (7,):
+    print("yes, we think we have an unshimmed notebook package")
+    print(notebook_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
     # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -19,7 +19,7 @@ if (
     notebook_version_info is not None  # No notebook package found
     and notebook_version_info < (7,)  # Notebook package found, is version 6
     # Notebook package found, but its version is the same as jupyter_server
-    # version. This means some package (lookin at you, nbclassic) has shimmed
+    # version. This means some package (looking at you, nbclassic) has shimmed
     # the notebook package to instead be imports from the jupyter_server package.
     # In such cases, notebook.prometheus.metrics is actually *this file*, so
     # trying to import it will cause a circular import. So we don't.

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -4,7 +4,8 @@ Prometheus metrics exported by Jupyter Server
 Read https://prometheus.io/docs/practices/naming/ for naming
 conventions for metrics & labels.
 """
-from prometheus_client import Info, Gauge, Histogram
+
+from prometheus_client import Gauge, Histogram, Info
 
 try:
     from notebook._version import version_info as notebook_version_info

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -6,6 +6,7 @@ conventions for metrics & labels.
 """
 
 from prometheus_client import Gauge, Histogram, Info
+
 from jupyter_server._version import version_info as server_version_info
 
 try:
@@ -14,7 +15,11 @@ except ImportError:
     notebook_version_info = None
 
 
-if notebook_version_info is not None and notebook_version_info < (7,) and notebook_version_info != server_version_info:
+if (
+    notebook_version_info is not None
+    and notebook_version_info < (7,)
+    and notebook_version_info != server_version_info
+):
     print("yes, we think we have an unshimmed notebook package")
     print(notebook_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -16,12 +16,15 @@ except ImportError:
 
 
 if (
-    notebook_version_info is not None
-    and notebook_version_info < (7,)
+    notebook_version_info is not None # No notebook package found
+    and notebook_version_info < (7,) # Notebook package found, is version 6
+    # Notebook package found, but its version is the same as jupyter_server
+    # version. This means some package (lookin at you, nbclassic) has shimmed
+    # the notebook package to instead be imports from the jupyter_server package.
+    # In such cases, notebook.prometheus.metrics is actually *this file*, so
+    # trying to import it will cause a circular import. So we don't.
     and notebook_version_info != server_version_info
 ):
-    print("yes, we think we have an unshimmed notebook package")
-    print(notebook_version_info)
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
     # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -4,26 +4,23 @@ Prometheus metrics exported by Jupyter Server
 Read https://prometheus.io/docs/practices/naming/ for naming
 conventions for metrics & labels.
 """
-# Do this to see if we end up in an import loop?
-from notebook.prometheus.metrics import (
-    HTTP_REQUEST_DURATION_SECONDS,
-    KERNEL_CURRENTLY_RUNNING_TOTAL,
-    TERMINAL_CURRENTLY_RUNNING_TOTAL,
-)
+from prometheus_client import Info, Gauge, Histogram
 
 try:
-    # Jupyter Notebook also defines these metrics.  Re-defining them results in a ValueError.
-    # Try to de-duplicate by using the ones in Notebook if available.
+    from notebook._version import version_info as notebook_version_info
+except ImportError:
+    notebook_version_info = None
+
+if not notebook_version_info >= (7,):
+    # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
+    # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209
     from notebook.prometheus.metrics import (
         HTTP_REQUEST_DURATION_SECONDS,
         KERNEL_CURRENTLY_RUNNING_TOTAL,
         TERMINAL_CURRENTLY_RUNNING_TOTAL,
     )
-
-except ImportError:
-    from prometheus_client import Gauge, Histogram
-
+else:
     HTTP_REQUEST_DURATION_SECONDS = Histogram(
         "http_request_duration_seconds",
         "duration in seconds for all HTTP requests",
@@ -41,9 +38,7 @@ except ImportError:
         ["type"],
     )
 
-
-from prometheus_client import Info
-
+# New prometheus metrics that do not exist in notebook v6 go here
 SERVER_INFO = Info("jupyter_server", "Jupyter Server Version information")
 
 __all__ = [

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     notebook_version_info = None
 
-if not notebook_version_info >= (7,):
+if notebook_version_info is not None and notebook_version_info < (7,):
     # Jupyter Notebook v6 also defined these metrics.  Re-defining them results in a ValueError,
     # so we simply re-export them if we are co-existing with the notebook v6 package.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -37,6 +37,7 @@ except ImportError:
 
 
 from prometheus_client import Info
+
 from .._version import __version__
 
 SERVER_INFO = Info("jupyter_server_info", "Jupyter Server Version information")
@@ -46,5 +47,5 @@ __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",
     "TERMINAL_CURRENTLY_RUNNING_TOTAL",
     "KERNEL_CURRENTLY_RUNNING_TOTAL",
-    "SERVER_INFO"
+    "SERVER_INFO",
 ]

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -36,8 +36,15 @@ except ImportError:
     )
 
 
+from prometheus_client import Info
+from .._version import __version__
+
+SERVER_INFO = Info("jupyter_server_info", "Jupyter Server Version information")
+SERVER_INFO.info({"version": __version__})
+
 __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",
     "TERMINAL_CURRENTLY_RUNNING_TOTAL",
     "KERNEL_CURRENTLY_RUNNING_TOTAL",
+    "SERVER_INFO"
 ]

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -38,8 +38,6 @@ except ImportError:
 
 from prometheus_client import Info
 
-from .._version import __version__
-
 SERVER_INFO = Info("jupyter_server_info", "Jupyter Server Version information")
 
 __all__ = [

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -16,8 +16,8 @@ except ImportError:
 
 
 if (
-    notebook_version_info is not None # No notebook package found
-    and notebook_version_info < (7,) # Notebook package found, is version 6
+    notebook_version_info is not None  # No notebook package found
+    and notebook_version_info < (7,)  # Notebook package found, is version 6
     # Notebook package found, but its version is the same as jupyter_server
     # version. This means some package (lookin at you, nbclassic) has shimmed
     # the notebook package to instead be imports from the jupyter_server package.

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -41,7 +41,6 @@ from prometheus_client import Info
 from .._version import __version__
 
 SERVER_INFO = Info("jupyter_server_info", "Jupyter Server Version information")
-SERVER_INFO.info({"version": __version__})
 
 __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -110,6 +110,7 @@ from jupyter_server.gateway.managers import (
     GatewaySessionManager,
 )
 from jupyter_server.log import log_request
+from jupyter_server.prometheus.metrics import SERVER_INFO
 from jupyter_server.services.config import ConfigManager
 from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
@@ -123,7 +124,6 @@ from jupyter_server.services.kernels.kernelmanager import (
     AsyncMappingKernelManager,
     MappingKernelManager,
 )
-from jupyter_server.prometheus.metrics import SERVER_INFO
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
     JupyterServerAuthWarning,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -123,6 +123,7 @@ from jupyter_server.services.kernels.kernelmanager import (
     AsyncMappingKernelManager,
     MappingKernelManager,
 )
+from jupyter_server.prometheus.metrics import SERVER_INFO
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
     JupyterServerAuthWarning,
@@ -2696,6 +2697,12 @@ class ServerApp(JupyterApp):
                     # prefer Selector to Proactor for tornado + pyzmq
                     asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())
 
+    def init_metrics(self) -> None:
+        """
+        Initialize any prometheus metrics that need to be set up on server startup
+        """
+        SERVER_INFO.info({"version": __version__})
+
     @catch_config_error
     def initialize(
         self,
@@ -2763,6 +2770,7 @@ class ServerApp(JupyterApp):
         self.load_server_extensions()
         self.init_mime_overrides()
         self.init_shutdown_no_activity()
+        self.init_metrics()
         if new_httpserver:
             self.init_httpserver()
 


### PR DESCRIPTION
- Allows for collection of jupyter server version as a prometheus metric, and filtering of various other metrics based on server version.
- Builds on top of conventions in other servers that expose version (or build) info. For example, kubernetes puts out this metric:
  > kubernetes_build_info{build_date="2024-09-09T04:15:23Z", compiler="gc",
  > git_commit="fa081458abcdbbc3ddfc3f99546ae5ea45aece17", git_tree_state="clean",
  > git_version="v1.29.8-gke.1700", go_version="go1.22.5 X:boringcrypto",
  > instance="10.128.0.50:443", job="kubernetes-apiservers", major="1", minor="29",
  > platform="linux/amd64"}
  Most of these parameters are not particularly relevant to us, but version is. So this PR only adds version - future labels can be added as needed.
- Fix circular import of `jupyter_server.prometheus.metrics` when nbclassic shims `notebook.prometheus` to be the same as `jupyter_server.prometheus`