### PR TITLE
prometheus: Expose 3 activity metrics

### DIFF
--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -58,9 +58,17 @@ SERVER_EXTENSION_INFO = Info(
     "Jupyter Server Extensiom Version Information",
     ["name", "version", "enabled"],
 )
-LAST_ACTIVITY = Gauge("jupyter_server_last_activity_timestamp_seconds", "Timestamp of last seen activity on this Jupyter Server")
-SERVER_STARTED = Gauge("jupyter_server_started_timestamp_seconds", "Timestamp of when this Jupyter Server was started")
-ACTIVE_DURATION = Gauge("jupyter_server_active_duration_seconds", "Number of seconds this Jupyter Server has been active")
+LAST_ACTIVITY = Gauge(
+    "jupyter_server_last_activity_timestamp_seconds",
+    "Timestamp of last seen activity on this Jupyter Server",
+)
+SERVER_STARTED = Gauge(
+    "jupyter_server_started_timestamp_seconds", "Timestamp of when this Jupyter Server was started"
+)
+ACTIVE_DURATION = Gauge(
+    "jupyter_server_active_duration_seconds",
+    "Number of seconds this Jupyter Server has been active",
+)
 
 __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -58,6 +58,9 @@ SERVER_EXTENSION_INFO = Info(
     "Jupyter Server Extensiom Version Information",
     ["name", "version", "enabled"],
 )
+LAST_ACTIVITY = Gauge("jupyter_server_last_activity_timestamp_seconds", "Timestamp of last seen activity on this Jupyter Server")
+SERVER_STARTED = Gauge("jupyter_server_started_timestamp_seconds", "Timestamp of when this Jupyter Server was started")
+ACTIVE_DURATION = Gauge("jupyter_server_active_duration_seconds", "Number of seconds this Jupyter Server has been active")
 
 __all__ = [
     "HTTP_REQUEST_DURATION_SECONDS",

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -110,7 +110,7 @@ from jupyter_server.gateway.managers import (
     GatewaySessionManager,
 )
 from jupyter_server.log import log_request
-from jupyter_server.prometheus.metrics import SERVER_EXTENSION_INFO, SERVER_INFO
+from jupyter_server.prometheus.metrics import SERVER_EXTENSION_INFO, SERVER_INFO, SERVER_STARTED, LAST_ACTIVITY, ACTIVE_DURATION
 from jupyter_server.services.config import ConfigManager
 from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
@@ -2707,6 +2707,12 @@ class ServerApp(JupyterApp):
             SERVER_EXTENSION_INFO.labels(
                 name=ext.name, version=ext.version, enabled=str(ext.enabled).lower()
             )
+
+        started = self.web_app.settings["started"]
+        SERVER_STARTED.set(started.timestamp())
+
+        LAST_ACTIVITY.set_function(lambda: self.web_app.last_activity().timestamp())
+        ACTIVE_DURATION.set_function(lambda: (self.web_app.last_activity() - self.web_app.settings["started"]).total_seconds())
 
     @catch_config_error
     def initialize(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -110,7 +110,13 @@ from jupyter_server.gateway.managers import (
     GatewaySessionManager,
 )
 from jupyter_server.log import log_request
-from jupyter_server.prometheus.metrics import SERVER_EXTENSION_INFO, SERVER_INFO, SERVER_STARTED, LAST_ACTIVITY, ACTIVE_DURATION
+from jupyter_server.prometheus.metrics import (
+    ACTIVE_DURATION,
+    LAST_ACTIVITY,
+    SERVER_EXTENSION_INFO,
+    SERVER_INFO,
+    SERVER_STARTED,
+)
 from jupyter_server.services.config import ConfigManager
 from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
@@ -2712,7 +2718,11 @@ class ServerApp(JupyterApp):
         SERVER_STARTED.set(started.timestamp())
 
         LAST_ACTIVITY.set_function(lambda: self.web_app.last_activity().timestamp())
-        ACTIVE_DURATION.set_function(lambda: (self.web_app.last_activity() - self.web_app.settings["started"]).total_seconds())
+        ACTIVE_DURATION.set_function(
+            lambda: (
+                self.web_app.last_activity() - self.web_app.settings["started"]
+            ).total_seconds()
+        )
 
     @catch_config_error
     def initialize(


### PR DESCRIPTION
This exposes some of the info from /api/status in the prometheus metrics endpoint, so they can be scraped over time and queried.

- Server started timestamp, so we can easily see how long servers have been running
- Last activity timestamp, so we can see when users were actually active
- User activity duration (in seconds), so we can more easily build reports of how long users are actually active over time.

All these would be very helpful in JupyterHub environments.

Follow-up to https://github.com/jupyter-server/jupyter_server/pull/1470