### PR TITLE
Ignore unclosed sqlite connection in traits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,10 @@ filterwarnings = [
   "error",
   "ignore:datetime.datetime.utc:DeprecationWarning",
   "module:add_callback_from_signal is deprecated:DeprecationWarning",
-  "ignore::jupyter_server.utils.JupyterServerAuthWarning"
+  "ignore::jupyter_server.utils.JupyterServerAuthWarning",
+
+  # ignore unclosed sqlite in traits
+  "ignore:unclosed database in <sqlite3.Connection:ResourceWarning",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
This matches
https://github.com/ipython/ipykernel/pull/1277/commits/947894b8c0f52cc1ecbfb1600f27112ee1632445, and there doesn't seem to be a sensible alternative at the moment.

Fixes: #1475