### PR TITLE
Better error message when starting kernel for session.

### DIFF
--- a/examples/simple/simple_ext1/handlers.py
+++ b/examples/simple/simple_ext1/handlers.py
@@ -18,7 +18,8 @@ class DefaultHandler(ExtensionHandlerMixin, JupyterHandler):
         self.log.info(f"Extension Name in {self.name} Default Handler: {self.name}")
         # A method for getting the url to static files (prefixed with /static/<name>).
         self.log.info(
-            "Static URL for / in simple_ext1 Default Handler: {}".format(self.static_url(path="/"))
+            "Static URL for / in simple_ext1 Default Handler: %s",
+            self.static_url(path="/"),
         )
         self.write("<h1>Hello Simple 1 - I am the default...</h1>")
         self.write(f"Config in {self.name} Default Handler: {self.config}")

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -632,9 +632,10 @@ class ChannelQueue(Queue):  # type:ignore[type-arg]
         timeout = kwargs.get("timeout", 1)
         msg = await self._async_get(timeout=timeout)
         self.log.debug(
-            "Received message on channel: {}, msg_id: {}, msg_type: {}".format(
-                self.channel_name, msg["msg_id"], msg["msg_type"] if msg else "null"
-            )
+            "Received message on channel: {}, msg_id: {}, msg_type: {}",
+            self.channel_name,
+            msg["msg_id"],
+            msg["msg_type"] if msg else "null",
         )
         self.task_done()
         return cast("dict[str, Any]", msg)
@@ -643,9 +644,10 @@ class ChannelQueue(Queue):  # type:ignore[type-arg]
         """Send a message to the queue."""
         message = json.dumps(msg, default=ChannelQueue.serialize_datetime).replace("</", "<\\/")
         self.log.debug(
-            "Sending message on channel: {}, msg_id: {}, msg_type: {}".format(
-                self.channel_name, msg["msg_id"], msg["msg_type"] if msg else "null"
-            )
+            "Sending message on channel: %s, msg_id: %s, msg_type: %s",
+            self.channel_name,
+            msg["msg_id"],
+            msg["msg_type"] if msg else "null",
         )
         self.channel_socket.send(message)
 

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -632,7 +632,7 @@ class ChannelQueue(Queue):  # type:ignore[type-arg]
         timeout = kwargs.get("timeout", 1)
         msg = await self._async_get(timeout=timeout)
         self.log.debug(
-            "Received message on channel: {}, msg_id: {}, msg_type: {}",
+            "Received message on channel: %s, msg_id: %s, msg_type: %s",
             self.channel_name,
             msg["msg_id"],
             msg["msg_type"] if msg else "null",

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -210,10 +210,9 @@ class ContentsHandler(ContentsAPIHandler):
     async def _copy(self, copy_from, copy_to=None):
         """Copy a file, optionally specifying a target directory."""
         self.log.info(
-            "Copying {copy_from} to {copy_to}".format(
-                copy_from=copy_from,
-                copy_to=copy_to or "",
-            )
+            "Copying %r to %r",
+            copy_from,
+            copy_to or "",
         )
         model = await ensure_async(self.contents_manager.copy(copy_from, copy_to))
         self.set_status(201)

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -161,14 +161,30 @@ class SessionHandler(SessionsAPIHandler):
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
                 kernel_name = model["kernel"]["name"]
-                kernel_id = await sm.start_kernel_for_session(
-                    session_id,
-                    kernel_name=kernel_name,
-                    name=before["name"],
-                    path=before["path"],
-                    type=before["type"],
-                )
-                changes["kernel_id"] = kernel_id
+
+                try:
+                    kernel_id = await sm.start_kernel_for_session(
+                        session_id,
+                        kernel_name=kernel_name,
+                        name=before["name"],
+                        path=before["path"],
+                        type=before["type"],
+                    )
+                    changes["kernel_id"] = kernel_id
+                except Exception as e:
+                    # the error message may contain sensitive information, so we want to
+                    # be careful with it, thus we only give the short repr of the exception
+                    # and the full traceback.
+                    # this should be fine as we are exposing here the same info as when we strt a new kernel
+                    msg = "The '%s' kernel could not be started: %s" % (
+                        kernel_name,
+                        repr(str(e)),
+                    )
+                    status_msg = "Error starting kernel %s" % kernel_name
+                    self.log.error("Error starting kernel: %s", kernel_name)
+                    self.set_status(501)
+                    self.finish(json.dumps({"message": msg, "short_message": status_msg}))
+                    return
 
         await sm.update_session(session_id, **changes)
         s_model = await sm.get_session(session_id=session_id)

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -175,7 +175,7 @@ class SessionHandler(SessionsAPIHandler):
                     # the error message may contain sensitive information, so we want to
                     # be careful with it, thus we only give the short repr of the exception
                     # and the full traceback.
-                    # this should be fine as we are exposing here the same info as when we strt a new kernel
+                    # this should be fine as we are exposing here the same info as when we start a new kernel
                     msg = "The '%s' kernel could not be started: %s" % (
                         kernel_name,
                         repr(str(e)),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ extend-select = [
   "B",  # flake8-bugbear
   "I",  # isort
   "UP",  # pyupgrade
+  "G001", # no % or f formatting in logs, prevents sttructured logging
 ]
 unfixable = [
   # Don't touch print statements


### PR DESCRIPTION
This catches error when starting a kernel for a session (for example if one switches the kernel for an existing notebook), and propagate the error. Otherwise the frontend will just show "Error: uncaught exception".

In addition this setup ruff G001 – do not use string formatting in logging, see some of the reasons to not do that:

https://docs.astral.sh/ruff/rules/logging-string-format/

And fixes the few instances where jupyter-server does it.