### PR TITLE
If ServerApp.ip is ipv6 use [::1] as local_url

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2377,10 +2377,7 @@ class ServerApp(JupyterApp):
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if not self.sock:
-            if ":" in self.ip:
-                localhost = "[::1]"
-            else:
-                localhost = "127.0.0.1"
+            localhost = "[::1]" if ":" in self.ip else "127.0.0.1"
             parts = parts._replace(netloc=f"{localhost}:{self.port}")
         return parts.geturl()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2377,7 +2377,11 @@ class ServerApp(JupyterApp):
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if not self.sock:
-            parts = parts._replace(netloc=f"127.0.0.1:{self.port}")
+            if ":" in self.ip:
+                localhost = "[::1]"
+            else:
+                localhost = "127.0.0.1"
+            parts = parts._replace(netloc=f"{localhost}:{self.port}")
         return parts.geturl()
 
     @property


### PR DESCRIPTION
Currently jupyter-server always uses `http://127.0.0.1:8888/?token=TOKEN` as the local URL. This changes it to use `[::1]` if jupyter-server is configured to listen on an IPv6 IP:

```
$ jupyter-server --ip=::

[I 2025-01-26 13:55:09.642 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2025-01-26 13:55:09.657 ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I 2025-01-26 13:55:09.660 ServerApp] Serving notebooks from local directory: /tmp/test
[I 2025-01-26 13:55:09.660 ServerApp] Jupyter Server 2.16.0.dev0 is running at:
[I 2025-01-26 13:55:09.660 ServerApp] http://HOSTNAME:8888/?token=TOKEN
[I 2025-01-26 13:55:09.660 ServerApp]     http://[::1]:8888/?token=TOKEN
[I 2025-01-26 13:55:09.660 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[I 2025-01-26 13:55:09.661 ServerApp] Welcome to Project Jupyter! Explore the various tools available and their corresponding documentation. If you are interested in contributing to the platform, please visit the community resources section at https://jupyter.org/community.html.
[C 2025-01-26 13:55:09.664 ServerApp] 
    
    To access the server, open this file in a browser:
        file:///tmp/test/jpserver-1134488-open.html
    Or copy and paste one of these URLs:
        http://HOSTNAME:8888/?token=TOKEN
        http://[::1]:8888/?token=TOKEN
```