### PR TITLE
Move files_handler_params default from FileContentsManager to ContentsManager

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -123,10 +123,6 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     def _files_handler_class_default(self):
         return AuthenticatedFileHandler
 
-    @default("files_handler_params")
-    def _files_handler_params_default(self):
-        return {"path": self.root_dir}
-
     def is_hidden(self, path):
         """Does the API style path correspond to a hidden directory or file?
 

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -148,10 +148,6 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     def _files_handler_class_default(self):
         return AuthenticatedFileHandler
 
-    @default("files_handler_params")
-    def _files_handler_params_default(self):
-        return {"path": self.root_dir}
-
     def is_hidden(self, path):
         """Does the API style path correspond to a hidden directory or file?
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -361,6 +361,10 @@ class ContentsManager(LoggingConfigurable):
         """,
     )
 
+    @default("files_handler_params")
+    def _files_handler_params_default(self):
+        return {"path": self.root_dir}
+
     def get_extra_handlers(self):
         """Return additional handlers
 


### PR DESCRIPTION
This PR moves the default `files_handler_params` from `FileContentsManager` to `ContentsManager` to match its signature.

In 
https://github.com/jupyter-server/jupyter_server/pull/1069/files#diff-4d8c8c45026f674a455c1e41558c6a9a05d8766adc81a6e56d8cafc7e5d8077cR17  the `web.StaticFileHandler` was introduced as superclass to `FilesHandler`. This causes all subclasses of `ContentsManager` (e.g. a version for S3) to fail serving the file due to:
```
    Traceback (most recent call last):
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/http1connection.py", line 278, in _read_message
        delegate.finish()
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/httpserver.py", line 399, in finish
        self.delegate.finish()
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/routing.py", line 268, in finish
        self.delegate.finish()
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/web.py", line 2399, in finish
        self.execute()
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/web.py", line 2421, in execute
        self.handler = self.handler_class(
                       ^^^^^^^^^^^^^^^^^^^
      File "/home/bigdata/venv/lib64/python3.11/site-packages/tornado/web.py", line 238, in __init__
        self.initialize(**kwargs)  # type: ignore
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: StaticFileHandler.initialize() missing 1 required positional argument: 'path'
```