### PR TITLE
Update Contribution Page for Jupyter Server

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,7 +93,7 @@ Running Tests
 
 Install dependencies::
 
-    pip install -e .[test]
+    pip install -e ".[test]"
     pip install -e examples/simple  # to test the examples
 
 To run the Python tests, use::
@@ -119,15 +119,20 @@ Building the Docs
 
 Install the docs requirements using ``pip``::
 
-    pip install .[doc]
+    pip install ".[doc]"
 
 Once you have installed the required packages, you can build the docs with::
 
     cd docs
     make html
 
+The above may run into issues related to unavailability of sphinx and related dependencies. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ and the following dependencies.:: 
+
+    pip install myst_parser sphinxcontrib_github_alt sphinxcontrib.openapi \
+    sphinxemoji sphinx_autodoc_typehints pydata-sphinx-theme
+
 You can also run the tests using ``hatch`` without installing test dependencies
-in your local environment.
+in your local environment.::
 
     pip install hatch
     hatch run docs:build

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -119,17 +119,14 @@ Building the Docs
 
 Install the docs requirements using ``pip``::
 
-    pip install ".[doc]"
+    pip install ".[docs]"
 
 Once you have installed the required packages, you can build the docs with::
 
     cd docs
     make html
 
-The above may run into issues related to unavailability of sphinx and related dependencies. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ and the following dependencies.::
-
-    pip install myst_parser sphinxcontrib_github_alt sphinxcontrib.openapi \
-    sphinxemoji sphinx_autodoc_typehints pydata-sphinx-theme
+The above may run into issues related to unavailability of sphinx. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ to resolve them.
 
 You can also run the tests using ``hatch`` without installing test dependencies
 in your local environment.::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -126,10 +126,8 @@ Once you have installed the required packages, you can build the docs with::
     cd docs
     make html
 
-The above may run into issues related to unavailability of sphinx. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ to resolve them.
-
 You can also run the tests using ``hatch`` without installing test dependencies
-in your local environment.::
+in your local environment::
 
     pip install hatch
     hatch run docs:build

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -126,7 +126,7 @@ Once you have installed the required packages, you can build the docs with::
     cd docs
     make html
 
-The above may run into issues related to unavailability of sphinx and related dependencies. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ and the following dependencies.:: 
+The above may run into issues related to unavailability of sphinx and related dependencies. You can `install sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ and the following dependencies.::
 
     pip install myst_parser sphinxcontrib_github_alt sphinxcontrib.openapi \
     sphinxemoji sphinx_autodoc_typehints pydata-sphinx-theme

--- a/docs/source/api/jupyter_server.auth.rst
+++ b/docs/source/api/jupyter_server.auth.rst
@@ -7,49 +7,49 @@ Submodules
 
 .. automodule:: jupyter_server.auth.authorizer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.decorator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.identity
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.login
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.logout
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.security
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.auth.utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.auth
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.base.rst
+++ b/docs/source/api/jupyter_server.base.rst
@@ -7,31 +7,31 @@ Submodules
 
 .. automodule:: jupyter_server.base.call_context
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.base.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.base.websocket
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.base.zmqhandlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.extension.rst
+++ b/docs/source/api/jupyter_server.extension.rst
@@ -7,43 +7,43 @@ Submodules
 
 .. automodule:: jupyter_server.extension.application
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.extension.config
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.extension.handler
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.extension.manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.extension.serverextension
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.extension.utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.extension
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.files.rst
+++ b/docs/source/api/jupyter_server.files.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.files.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.files
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.gateway.rst
+++ b/docs/source/api/jupyter_server.gateway.rst
@@ -7,31 +7,31 @@ Submodules
 
 .. automodule:: jupyter_server.gateway.connections
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.gateway.gateway_client
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.gateway.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.gateway.managers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.gateway
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.i18n.rst
+++ b/docs/source/api/jupyter_server.i18n.rst
@@ -6,5 +6,5 @@ Module contents
 
 .. automodule:: jupyter_server.i18n
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.kernelspecs.rst
+++ b/docs/source/api/jupyter_server.kernelspecs.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.kernelspecs.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.kernelspecs
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.nbconvert.rst
+++ b/docs/source/api/jupyter_server.nbconvert.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.nbconvert.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.nbconvert
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.prometheus.rst
+++ b/docs/source/api/jupyter_server.prometheus.rst
@@ -7,19 +7,19 @@ Submodules
 
 .. automodule:: jupyter_server.prometheus.log_functions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.prometheus.metrics
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.prometheus
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.rst
+++ b/docs/source/api/jupyter_server.rst
@@ -25,43 +25,43 @@ Submodules
 
 .. automodule:: jupyter_server.config_manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.log
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.serverapp
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.traittypes
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.transutils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.api.rst
+++ b/docs/source/api/jupyter_server.services.api.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.api.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.api
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.config.rst
+++ b/docs/source/api/jupyter_server.services.config.rst
@@ -7,19 +7,19 @@ Submodules
 
 .. automodule:: jupyter_server.services.config.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.config.manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.config
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.contents.rst
+++ b/docs/source/api/jupyter_server.services.contents.rst
@@ -7,49 +7,49 @@ Submodules
 
 .. automodule:: jupyter_server.services.contents.checkpoints
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.filecheckpoints
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.fileio
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.filemanager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.largefilemanager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.contents.manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.contents
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.events.rst
+++ b/docs/source/api/jupyter_server.services.events.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.events.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.events
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.kernels.connection.rst
+++ b/docs/source/api/jupyter_server.services.kernels.connection.rst
@@ -7,25 +7,25 @@ Submodules
 
 .. automodule:: jupyter_server.services.kernels.connection.abc
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.kernels.connection.base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.kernels.connection.channels
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.kernels.connection
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.kernels.rst
+++ b/docs/source/api/jupyter_server.services.kernels.rst
@@ -15,25 +15,25 @@ Submodules
 
 .. automodule:: jupyter_server.services.kernels.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.kernels.kernelmanager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.kernels.websocket
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.kernels
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.kernelspecs.rst
+++ b/docs/source/api/jupyter_server.services.kernelspecs.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.kernelspecs.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.kernelspecs
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.nbconvert.rst
+++ b/docs/source/api/jupyter_server.services.nbconvert.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.nbconvert.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.nbconvert
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.rst
+++ b/docs/source/api/jupyter_server.services.rst
@@ -23,13 +23,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.shutdown
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.security.rst
+++ b/docs/source/api/jupyter_server.services.security.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.services.security.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.security
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.services.sessions.rst
+++ b/docs/source/api/jupyter_server.services.sessions.rst
@@ -7,19 +7,19 @@ Submodules
 
 .. automodule:: jupyter_server.services.sessions.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 
 .. automodule:: jupyter_server.services.sessions.sessionmanager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.services.sessions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/source/api/jupyter_server.view.rst
+++ b/docs/source/api/jupyter_server.view.rst
@@ -7,13 +7,13 @@ Submodules
 
 .. automodule:: jupyter_server.view.handlers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: jupyter_server.view
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:


### PR DESCRIPTION
The following updates are made to [the contributing page ](https://jupyter-server.readthedocs.io/en/latest/contributors/contributing.html#setting-up-a-development-environment). 

1. During building the docs, errors related to non availability of `sphinx` can happen. New instructions are added to install this package ~~and its related dependencies~~
2. Changed format for the line `pip install hatch hatch run docs:build` to reflect it properly
3. Added double quotes which were missing for some commands like `pip install ".[docs]"` and `pip install ".[test]"`