### PR TITLE
 Validate extension name before toggling through CLI

### DIFF
--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -259,9 +259,23 @@ class ToggleServerExtensionApp(BaseExtensionApp):
             self.log.info(f"- Writing config: {config_dir}")
             # Validate the server extension.
             self.log.info(f"    - Validating {import_name}...")
+            config = extension_manager.config_manager
+            enabled = False
+            if config:
+                jpserver_extensions = config.get_jpserver_extensions()
+                if import_name not in jpserver_extensions:
+                    msg = (
+                        f"The module '{import_name}' could not be found. Are you "
+                        "sure the extension is installed?"
+                    )
+                    raise ValueError(msg)
+                enabled = jpserver_extensions[import_name]
+
             # Interface with the Extension Package and validate.
-            extpkg = ExtensionPackage(name=import_name)
-            extpkg.validate()
+            extpkg = ExtensionPackage(name=import_name, enabled=enabled)
+            if not extpkg.validate():
+                msg = "validation failed"
+                raise ValueError(msg)
             version = extpkg.version
             self.log.info(f"      {import_name} {version} {GREEN_OK}")
 


### PR DESCRIPTION
## Fixes #1507 

### Description
This PR fixes an issue where running

```bash
jupyter server extension disable <nonexistent-extension> 
```
would misleadingly add the non-existent or misspelled extension to extension list and mark it as disabled, even though it was never installed.

### Fix
A validation step is added to check if the extension name is valid and currently installed. If the extension is not found, an error is logged and it is not added to the extension list.

### Changes

- **Before**
```bash
$ jupyter server extension disable jupyter-ai   # should be jupyter_ai

Disabling: jupyter-ai
- Writing config: /<path_to>/etc/jupyter
    - Validating jupyter-ai...
      jupyter-ai  OK
    - Extension successfully disabled.
```

- **After**
```bash
$ jupyter server extension disable jupyter-ai

Disabling: jupyter-ai
- Writing config: /<path_to>/etc/jupyter
    - Validating jupyter-ai...
      X Validation failed: The module 'jupyter-ai' could not be found. Are you sure the extension is installed?
```

This issue was bugging me for a while, and I believe this change enhances the CLI user experience.