### PR TITLE
tests: install test-functional requirements for Jupytext downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -122,6 +122,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/downstream-test@v1
         with:
           package_name: jupytext
+          package_spec: '."[test,test-functional]"'
           test_command: pip install pytest-jupyter[server] gitpython pre-commit && python -m ipykernel install --name jupytext-dev --user && pytest -vv -raXxs -W default --durations 10 --ignore=tests/functional/others --color=yes
 
   downstream_check: # This job does nothing and is only used for the branch protection


### PR DESCRIPTION
Recent released commit in Jupytext (https://github.com/mwouts/jupytext/commit/cb96a90be548856662685467587cec4566ad78ca#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R59), introduced `black` as requirement for their functional tests.

Even though `--ignore=tests/functional/others` is set, `pytest` will import the whole test suite during the test gather phase, thus requiring `black`.

In this MR, we update the `package_spec` to grab all dependencies required for the `test` and `test-functional`.