### PR TITLE
Check file permissions before making tmp file

### DIFF
--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -42,7 +42,7 @@ def copy2_safe(src, dst, log=None):
     # if src file is not writable, avoid creating a back-up
     if not os.access(src, os.W_OK):
         if log:
-            log.debug("Source file, %s, is not writeable", src, exc_info=True)
+            log.debug("Source file, %s, is not writable", src, exc_info=True)
         raise PermissionError(errno.EACCES, f"File is not writable: {src}")
 
     shutil.copyfile(src, dst)

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -39,6 +39,12 @@ def copy2_safe(src, dst, log=None):
 
     like shutil.copy2, but log errors in copystat instead of raising
     """
+    # if src file is not writable, avoid creating a back-up
+    if not os.access(src, os.W_OK):
+        if log:
+            log.debug("Source file is not writeable: ", src)
+        raise PermissionError(errno.EACCES, f"File is not writable: {src}")
+
     shutil.copyfile(src, dst)
     try:
         shutil.copystat(src, dst)
@@ -52,6 +58,11 @@ async def async_copy2_safe(src, dst, log=None):
 
     like shutil.copy2, but log errors in copystat instead of raising
     """
+    if not os.access(src, os.W_OK):
+        if log:
+            log.debug("Source file is not writeable: ", src)
+        raise PermissionError(errno.EACCES, f"File is not writable: {src}")
+
     await run_sync(shutil.copyfile, src, dst)
     try:
         await run_sync(shutil.copystat, src, dst)

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -42,7 +42,7 @@ def copy2_safe(src, dst, log=None):
     # if src file is not writable, avoid creating a back-up
     if not os.access(src, os.W_OK):
         if log:
-            log.debug("Source file is not writeable: ", src)
+            log.debug("Source file, %s, is not writeable", src, exc_info=True)
         raise PermissionError(errno.EACCES, f"File is not writable: {src}")
 
     shutil.copyfile(src, dst)
@@ -60,7 +60,7 @@ async def async_copy2_safe(src, dst, log=None):
     """
     if not os.access(src, os.W_OK):
         if log:
-            log.debug("Source file is not writeable: ", src)
+            log.debug("Source file, %s, is not writeable", src, exc_info=True)
         raise PermissionError(errno.EACCES, f"File is not writable: {src}")
 
     await run_sync(shutil.copyfile, src, dst)

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -60,7 +60,7 @@ async def async_copy2_safe(src, dst, log=None):
     """
     if not os.access(src, os.W_OK):
         if log:
-            log.debug("Source file, %s, is not writeable", src, exc_info=True)
+            log.debug("Source file, %s, is not writable", src, exc_info=True)
         raise PermissionError(errno.EACCES, f"File is not writable: {src}")
 
     await run_sync(shutil.copyfile, src, dst)


### PR DESCRIPTION
To address #1502 avoid calling `shutil.copyfile()` and creating a`tmp_path` if the source file is not writable.