### PR TITLE
Fallback to direct write for readonly dirs and use temp path for checkpoints

### DIFF
--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -112,7 +112,7 @@ class FileCheckpoints(FileManagerMixin, Checkpoints):
         filename = f"{basename}-{checkpoint_id}{ext}"
         os_path = self._get_os_path(path=parent)
         cp_dir = os.path.join(os_path, self.checkpoint_dir)
-        # If parent directory isn’t writable, use system temp
+        # If parent directory isn't writable, use system temp
         if not os.access(os.path.dirname(cp_dir), os.W_OK):
             rel = os.path.relpath(os_path, start=self.root_dir)
             cp_dir = os.path.join(tempfile.gettempdir(), "jupyter_checkpoints", rel)

--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -4,6 +4,7 @@ File-based Checkpoints implementations.
 
 import os
 import shutil
+import tempfile
 
 from anyio.to_thread import run_sync
 from jupyter_core.utils import ensure_dir_exists
@@ -111,6 +112,10 @@ class FileCheckpoints(FileManagerMixin, Checkpoints):
         filename = f"{basename}-{checkpoint_id}{ext}"
         os_path = self._get_os_path(path=parent)
         cp_dir = os.path.join(os_path, self.checkpoint_dir)
+        # If parent directory isn’t writable, use system temp
+        if not os.access(os.path.dirname(cp_dir), os.W_OK):
+            rel = os.path.relpath(os_path, start=self.root_dir)
+            cp_dir = os.path.join(tempfile.gettempdir(), "jupyter_checkpoints", rel)
         with self.perm_to_403():
             ensure_dir_exists(cp_dir)
         cp_path = os.path.join(cp_dir, filename)

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -107,9 +107,9 @@ def atomic_writing(path, text=True, encoding="utf-8", log=None, **kwargs):
         mode = "w" if text else "wb"
         # direct open on the target file
         if text:
-            fileobj = open(path, mode, encoding=encoding, **kwargs)
+            fileobj = open(path, mode, encoding=encoding, **kwargs)  # noqa: SIM115
         else:
-            fileobj = open(path, mode, **kwargs)
+            fileobj = open(path, mode, **kwargs)  # noqa: SIM115
         try:
             yield fileobj
         finally:


### PR DESCRIPTION
### Fixes #1515

### Description

This PR improves compatibility in environments where the working directory is read-only but the file isn't.

- **atomic_writing fallback**: If the parent directory is not writable but the file is, fall back to direct write instead of using atomic write with a temp file.
- **Checkpoints**: If the `.ipynb_checkpoints` directory is not writable, redirect checkpoints to a temp path:  
  `$TMPDIR/jupyter_checkpoints/<rel_path>`.

This ensures writing and checkpointing continue to work smoothly in restricted or non-standard setups.
