### PR TITLE
Update meetings notes link and zoom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you are interested in contributing to the project, see [`CONTRIBUTING.rst`](C
 ## Team Meetings and Roadmap
 
 - When: Thursdays [8:00am, Pacific time](https://www.thetimezoneconverter.com/?t=8%3A00%20am&tz=San%20Francisco&)
-- Where: [Jovyan Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
+- Where: [Jovyan Zoom](https://zoom.us/j/95228013874?pwd=Ep7HIk8t9JP6VToxt1Wj4P7K5PshC0.1)
 - What: [Meeting notes](https://hackmd.io/Wmz_wjrLRHuUbgWphjwRWw)
 
 See our tentative [roadmap here](https://github.com/jupyter/jupyter_server/issues/127).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you are interested in contributing to the project, see [`CONTRIBUTING.rst`](C
 
 - When: Thursdays [8:00am, Pacific time](https://www.thetimezoneconverter.com/?t=8%3A00%20am&tz=San%20Francisco&)
 - Where: [Jovyan Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
-- What: [Meeting notes](https://github.com/jupyter-server/team-compass/issues/45)
+- What: [Meeting notes](https://hackmd.io/Wmz_wjrLRHuUbgWphjwRWw)
 
 See our tentative [roadmap here](https://github.com/jupyter/jupyter_server/issues/127).
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ If you are interested in contributing to the project, see [`CONTRIBUTING.rst`](C
 
 - When: Thursdays [8:00am, Pacific time](https://www.thetimezoneconverter.com/?t=8%3A00%20am&tz=San%20Francisco&)
 - Where: [Jovyan Zoom](https://zoom.us/j/95228013874?pwd=Ep7HIk8t9JP6VToxt1Wj4P7K5PshC0.1)
-- What: [Meeting notes](https://hackmd.io/Wmz_wjrLRHuUbgWphjwRWw)
+- What:
+  - [Meeting notes](https://github.com/jupyter-server/team-compass/issues?q=is%3Aissue%20%20Meeting%20Notes%20)
+  - [Agenda](https://hackmd.io/Wmz_wjrLRHuUbgWphjwRWw)
 
 See our tentative [roadmap here](https://github.com/jupyter/jupyter_server/issues/127).
 


### PR DESCRIPTION
The old one leads to an issue from 2023; IMO we can link to hackmd directly as it is linked in team compass.