### PR TITLE
Allow user to update identity values

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -227,7 +227,8 @@ class IdentityProvider(LoggingConfigurable):
             field for field in proposal["value"] if field not in valid_updatable_fields
         ]
         if invalid_fields:
-            raise TraitError(f"Invalid fields in updatable_fields: {invalid_fields}")
+            msg = f"Invalid fields in updatable_fields: {invalid_fields}"
+            raise TraitError(msg)
         return proposal["value"]
 
     need_token: bool | Bool[bool, t.Union[bool, int]] = Bool(True)
@@ -300,7 +301,8 @@ class IdentityProvider(LoggingConfigurable):
 
         for field in user_data:
             if field not in self.updatable_fields:
-                raise ValueError(f"Field {field} is not updatable")
+                msg = f"Field {field} is not updatable"
+                raise ValueError(msg)
 
         # Update fields
         for field in self.updatable_fields:

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -20,7 +20,7 @@ from dataclasses import asdict, dataclass
 from http.cookies import Morsel
 
 from tornado import escape, httputil, web
-from traitlets import Bool, Dict, List, TraitError, Type, Unicode, default, validate
+from traitlets import Bool, Dict, Enum, List, TraitError, Type, Unicode, default, validate
 from traitlets.config import LoggingConfigurable
 
 from jupyter_server.transutils import _i18n
@@ -194,7 +194,7 @@ class IdentityProvider(LoggingConfigurable):
 
     # Define the fields that can be updated
     updatable_fields = List(
-        trait=Unicode(),
+        trait=Enum(list(t.get_args(UpdatableField))),
         default_value=["color"],  # Default updatable field
         config=True,
         help=_i18n("List of fields in the User model that can be updated."),
@@ -296,7 +296,7 @@ class IdentityProvider(LoggingConfigurable):
         self, handler: web.RequestHandler, user_data: dict[UpdatableField, str]
     ) -> User:
         """Update user information."""
-        current_user = handler.current_user  # type:ignore[attr-defined]
+        current_user = t.cast(User, handler.current_user)
 
         for field in user_data:
             if field not in self.updatable_fields:

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -4,14 +4,14 @@
 # Distributed under the terms of the Modified BSD License.
 import json
 import os
-from typing import Any
+from typing import Any, cast
 
 from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server._tz import isoformat, utcfromtimestamp
 from jupyter_server.auth.decorator import authorized
-from jupyter_server.auth.identity import IdentityProvider
+from jupyter_server.auth.identity import IdentityProvider, UpdatableField
 
 from ...base.handlers import APIHandler, JupyterHandler
 
@@ -118,7 +118,7 @@ class IdentityHandler(APIHandler):
     @web.authenticated
     async def patch(self):
         """Update user information."""
-        user_data = self.get_json_body()
+        user_data = cast(dict[UpdatableField, str], self.get_json_body())
         if not user_data:
             raise web.HTTPError(400, "Invalid or missing JSON body")
 

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -130,7 +130,7 @@ class IdentityHandler(APIHandler):
         try:
             updated_user = identity_provider.update_user(self, user_data)
             self.write(
-                {"status": "success", "user": identity_provider.identity_model(updated_user)}
+                {"status": "success", "identity": identity_provider.identity_model(updated_user)}
             )
         except ValueError as e:
             raise web.HTTPError(400, str(e)) from e

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -11,7 +11,7 @@ from tornado import web
 
 from jupyter_server._tz import isoformat, utcfromtimestamp
 from jupyter_server.auth.decorator import authorized
-from jupyter_server.auth.identity import IdentityProvider, UpdatableField
+from jupyter_server.auth.identity import IdentityProvider, UpdatableField, User
 
 from ...base.handlers import APIHandler, JupyterHandler
 
@@ -134,6 +134,8 @@ class IdentityHandler(APIHandler):
             )
         except ValueError as e:
             raise web.HTTPError(400, str(e)) from e
+        except NotImplementedError as e:
+            raise web.HTTPError(501, str(e)) from e
 
 
 default_handlers = [

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -11,7 +11,7 @@ from tornado import web
 
 from jupyter_server._tz import isoformat, utcfromtimestamp
 from jupyter_server.auth.decorator import authorized
-from jupyter_server.auth.identity import IdentityProvider, UpdatableField, User
+from jupyter_server.auth.identity import IdentityProvider, UpdatableField
 
 from ...base.handlers import APIHandler, JupyterHandler
 
@@ -107,11 +107,13 @@ class IdentityHandler(APIHandler):
                 if authorized:
                     allowed.append(action)
 
+        # Add permission to user to update their own identity
+        permissions["updatable_fields"] = self.identity_provider.updatable_fields
+
         identity: dict[str, Any] = self.identity_provider.identity_model(user)
         model = {
             "identity": identity,
             "permissions": permissions,
-            "updatable_fields": self.identity_provider.updatable_fields,
         }
         self.write(json.dumps(model))
 


### PR DESCRIPTION
Fixes #1514 

This PR adds a new `PATCH` method to the api handler, to allow users to update their identity values. This handler is associated to a `update_user` method in the `IdentityProvider`, to effectively change the values.

The fields that can be updated is an attribute of the `IdentityProvider` class, and can contain all the attributes of `User` except `username`. By default only the `color` can be updated.

The `PasswordIdentityProvider`, which is the default identity provider, allows updating all the fields (except the username). 