### PR TITLE
move argon2-cffi to optional `[password]` dependency for Python 3.13

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,6 +28,8 @@ jobs:
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.13t"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/jupyter_server/auth/security.py
+++ b/jupyter_server/auth/security.py
@@ -62,9 +62,8 @@ def passwd(passphrase=None, algorithm="argon2"):
         try:
             import argon2
         except ModuleNotFoundError:
-            raise ImportError(
-                "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
-            ) from None
+            msg = "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
+            raise ImportError(msg) from None
 
         ph = argon2.PasswordHasher(
             memory_cost=10240,
@@ -113,9 +112,8 @@ def passwd_check(hashed_passphrase, passphrase):
         try:
             import argon2
         except ModuleNotFoundError:
-            raise ImportError(
-                "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
-            ) from None
+            msg = "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
+            raise ImportError(msg) from None
         import argon2
         import argon2.exceptions
 

--- a/jupyter_server/auth/security.py
+++ b/jupyter_server/auth/security.py
@@ -59,7 +59,12 @@ def passwd(passphrase=None, algorithm="argon2"):
             raise ValueError(msg)
 
     if algorithm == "argon2":
-        import argon2
+        try:
+            import argon2
+        except ModuleNotFoundError:
+            raise ImportError(
+                "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
+            ) from None
 
         ph = argon2.PasswordHasher(
             memory_cost=10240,
@@ -105,6 +110,12 @@ def passwd_check(hashed_passphrase, passphrase):
     True
     """
     if hashed_passphrase.startswith("argon2:"):
+        try:
+            import argon2
+        except ModuleNotFoundError:
+            raise ImportError(
+                "argon2 password hashing requires argon2-cffi package. `pip install 'jupyter-server[password]'` for support."
+            ) from None
         import argon2
         import argon2.exceptions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "anyio>=3.1.0",
-    "argon2-cffi>=21.1",
+    # argon2-cffi unavailable for free-threaded Python
+    # make it optional for Python >= 3.13 until PEP 780
+    # lets us limit it to the actually affected builds
+    "argon2-cffi>=21.1; python_version < '3.13'",
     "jinja2>=3.0.3",
     "jupyter_client>=7.4.4",
     "jupyter_core>=4.12,!=5.0.*",
@@ -52,6 +55,9 @@ Source = "https://github.com/jupyter-server/jupyter_server"
 Tracker = "https://github.com/jupyter-server/jupyter_server/issues"
 
 [project.optional-dependencies]
+password = [
+    "argon2-cffi>=21.1",
+]
 test = [
     "ipykernel",
     "pytest-console-scripts",


### PR DESCRIPTION
a temporary measure, to allow installation on free-threaded Python while CFFI is unsupported. Adds a test run against 3.13t.

When [PEP 780](https://peps.python.org/pep-0780/) lands, we can move this to a free-threaded condition, instead of a version one. But it's possible that CFFI will be fixed before that happens.

- big downside: `pip install jupyterlab` becomes incomplete on Python >=3.13, as passwords cannot be set or checked without adding `jupyter-server[password]` dependency. Of course, only password-setting users are affected, not default tokens.
- upside: 3.13t installation is _possible_, where it wasn't before

The standard library _does_ have support for [scrypt](https://docs.python.org/3/library/hashlib.html#hashlib.scrypt) now, so we could at the same time add support for scrypt passwords and use that by default. Then the degradation would be smaller, in that only password checking for already-stored argon2 passwords would be affected, instead of _also_ losing the ability to set new ones.

xref https://github.com/jupyterlab/jupyterlab/issues/16915
