### PR TITLE
Use stdlib override when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements made
 
-- If ServerApp.ip is ipv6 use [::1] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
+- If ServerApp.ip is ipv6 use \[::1\] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
 - Don't hide .so,.dylib files by default [#1457](https://github.com/jupyter-server/jupyter_server/pull/1457) ([@nokados](https://github.com/nokados))
 - Add async start hook to ExtensionApp API [#1417](https://github.com/jupyter-server/jupyter_server/pull/1417) ([@Zsailer](https://github.com/Zsailer))
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib  # noqa: TCH003
+import sys
 import typing as t
 import warnings
 from collections import defaultdict
@@ -25,9 +26,9 @@ from jupyter_core.utils import ensure_async
 from jupyter_events import EventLogger
 from jupyter_events.schema_registry import SchemaRegistryException
 
-try:
+if sys.version_info >= (3, 12):
     from typing import override as overrides
-except ImportError:
+else:
     from overrides import overrides
 from tornado import web
 from tornado.concurrent import Future

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -24,7 +24,11 @@ from jupyter_core.paths import exists
 from jupyter_core.utils import ensure_async
 from jupyter_events import EventLogger
 from jupyter_events.schema_registry import SchemaRegistryException
-from overrides import overrides
+
+try:
+    from typing import override as overrides
+except ImportError:
+    from overrides import overrides
 from tornado import web
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop, PeriodicCallback

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -27,9 +27,9 @@ from jupyter_events import EventLogger
 from jupyter_events.schema_registry import SchemaRegistryException
 
 if sys.version_info >= (3, 12):
-    from typing import override as overrides
+    from typing import override
 else:
-    from overrides import overrides
+    from overrides import overrides as override
 from tornado import web
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -899,28 +899,28 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
         """Emit an event from the kernel manager."""
         self.event_logger.emit(schema_id=schema_id, data=data)
 
-    @overrides
+    @override
     @emit_kernel_action_event(
         success_msg="Kernel {kernel_id} was started.",
     )
     async def start_kernel(self, *args, **kwargs):
         return await super().start_kernel(*args, **kwargs)
 
-    @overrides
+    @override
     @emit_kernel_action_event(
         success_msg="Kernel {kernel_id} was shutdown.",
     )
     async def shutdown_kernel(self, *args, **kwargs):
         return await super().shutdown_kernel(*args, **kwargs)
 
-    @overrides
+    @override
     @emit_kernel_action_event(
         success_msg="Kernel {kernel_id} was restarted.",
     )
     async def restart_kernel(self, *args, **kwargs):
         return await super().restart_kernel(*args, **kwargs)
 
-    @overrides
+    @override
     @emit_kernel_action_event(
         success_msg="Kernel {kernel_id} was interrupted.",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "traitlets>=5.6.0",
     "websocket-client>=1.7",
     "jupyter_events>=0.11.0",
-    "overrides>=5.0"
+    "overrides>=5.0;python_version<'3.12'"
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes https://github.com/jupyter-server/jupyter_server/issues/1531

This PR uses [`typing.override`](https://docs.python.org/3/library/typing.html#typing.override) in favor of the [`overrides`](https://pypi.org/project/overrides/) dependency when possible. As of Python 3.12, the standard library offers `typing.override` to perform a static check on overridden methods. 

### Motivation

  Currently, `overrides` is incompatible with Python 3.14. As a result, any package that attempts to import `overrides` using Python 3.14+ will raise an `AttributeError`. An [issue](https://github.com/mkorpela/overrides/issues/127) has been raised and a [pull request](https://github.com/mkorpela/overrides/pull/133) has been submitted to the GitHub repo for the `overrides` project. But the maintainer has been unresponsive.

To ensure readiness for Python 3.14, this package (and any other package directly depending on `overrides`) should consider using `typing.override` instead.

### Impact

The standard library added `typing.override` as of 3.12. As a result, this change will affect only users of Python 3.12+. Previous versions will continue to rely on `overrides`. Notably, the standard library implementation is slightly different than that of `overrides`. A thorough discussion of those differences is shown in [PEP 698](https://peps.python.org/pep-0698/), and it is also summarized nicely by the maintainer of `overrides` [here](https://github.com/mkorpela/overrides/issues/126#issuecomment-2401327116). The upshot is that `typing.override` does not implement any runtime checking. Instead, it provides information to type checkers.

### An Alternative Approach

We could imagine preferring the `overrides` package when it's available and imports successfully. That implementation might look like this:

```python
try:
    from overrides import overrides
except AttributeError as e:
    if ("module 'typing' has no attribute 'ByteString'" in str(e)):
        # Fallback option (only for Python 3.12+)
        from typing import override as overrides
```

While I originally considered this approach, a dive into why `overrides` was brought in as a dependency turned up this [conversation](https://github.com/jupyter-server/jupyter_server/pull/1252#discussion_r1160811177) between @Zsailer and @kevin-bates. In it, @Zsailer refers to the `overrides` library as a "temporary" dependency. The PR as I've written it here makes a silent switch over to using the standard library approach going forward.