### PR TITLE
add session_id to /channels ws request

### DIFF
--- a/jupyter_server/gateway/connections.py
+++ b/jupyter_server/gateway/connections.py
@@ -45,7 +45,7 @@ class GatewayWebSocketConnection(BaseKernelWebsocketConnection):
             GatewayClient.instance().ws_url or "",
             GatewayClient.instance().kernels_endpoint,
             url_escape(self.kernel_id),
-            "channels",
+            f"channels?session_id={self.session_id}",
         )
         if self.session_id:
             ws_url += f"?session_id={url_escape(self.session_id)}"


### PR DESCRIPTION
Issue to fix:
A bug in `GatewayWebSocketConnection` cause buffered messages dropped when browser reconnections to `/channels` websocket with the same session_id. 

ZMQChannelsWebsocketConnection in Jupyter Kernel Gateway (JKG) will buffer messages after disconnecting per session. If the reconnection is made with the same session id,  `ZMQChannelsWebsocketConnection.connect` method will retrieve the buffered messages and send them to the client. If there session id is not set into `ZMQChannelsWebsocketConnection.session.session`, `session.session` will have a random UUIC.

KernelWebsocketHandler will set `session.session` to self.session, and self.session is populated by the WS request's parameter `session`.

If GatewayWebSocketConnection in JupyterServer makes a WS request to KernelWebsocketHandler in the JKG with a session id, the buffered messages associated with the session id will be replayed to the GatewayWebSocketConnection. However, GatewayWebSocketConnection doesn't put the session id into the request.
In the case when jupyterlab frontend creates a /channel WS connection to KernelWebsocketHandler in JupyterServer, it passes a session_id as the request parameter. When it reconnect to KernelWebsocketHandler due to disconnection, it will pass the same session_id. However this session id is not set by GatewayWebSocketConnection into the WS request to JKG. The session id used in the frontend is different than the one in the JKG. So the buffered messages are not replayed to the frontend, and dropped.
