### PR TITLE
Use pathlib.Path.as_uri to format browser open redirect files

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3080,7 +3080,7 @@ class ServerApp(JupyterApp):
             open_file = self.browser_open_file
 
         if self.use_redirect_file:
-            assembled_url = urljoin("file:", pathname2url(open_file))
+            assembled_url = pathlib.Path(open_file).as_uri()
         else:
             assembled_url = url_path_join(self.connection_url, uri)
 
@@ -3183,7 +3183,7 @@ class ServerApp(JupyterApp):
                         _i18n(
                             "To access the server, open this file in a browser:",
                         ),
-                        "    %s" % urljoin("file:", pathname2url(self.browser_open_file)),
+                        "    %s" % pathlib.Path(self.browser_open_file).as_uri(),
                         _i18n(
                             "Or copy and paste one of these URLs:",
                         ),

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -683,7 +683,7 @@ async def test_browser_open_files(jp_configurable_serverapp, should_exist, caplo
     app = jp_configurable_serverapp(no_browser_open_file=not should_exist)
     await app._post_start()
     assert os.path.exists(app.browser_open_file) == should_exist
-    url = urljoin("file:", pathname2url(app.browser_open_file))
+    url = urljoin("file://", pathname2url(app.browser_open_file))
     url_messages = [rec.message for rec in caplog.records if url in rec.message]
     assert url_messages if should_exist else not url_messages
 


### PR DESCRIPTION
### Summary
Uses `pathlib.Path.as_uri()` to construct standards-compliant local file URLs for the browser redirect file utility.

### Details
The combination of `urljoin("file:", pathname2url(...))` generates non-compliant `file:/home/...` URI strings on Unix platforms. Strict POSIX URL handlers (such as `xdg-open` under desktop environments like LXQt) fail to resolve this format as a local file, breaking automatic browser launch pipelines.

Migrating this formatting layer to `pathlib.Path.as_uri()` ensures robust, platform-aware URI compilation. This guarantees valid triple-slash formats (`file:///...`) for both the background subprocess execution thread and the terminal diagnostic logs.

### Testing

I've ran `pytest` as documented in [CONTRIBUTING.rst#running-tests](https://github.com/jupyter-server/jupyter_server/blob/main/CONTRIBUTING.rst#running-tests).

All tests pass, except for `tests/services/sessions/test_api.py::test_restart_kernel[jp_server_config0]` which on my machine also fails with code on the `main` branch, with `assert 1 == 0`. This seems to be a pre-existing broken test.